### PR TITLE
Add tenant-aware JWS signing for Event Notification webhook payloads

### DIFF
--- a/docs/event-notification-guide.md
+++ b/docs/event-notification-guide.md
@@ -239,7 +239,7 @@ The decoded JWS claims have the following shape:
 
 ```json
 {
-  "iss": "example.com",
+  "iss": "https://is.example.com:9443/t/example.com/oauth2/token",
   "sub": "example-group",
   "aud": "dpdp-event-notifications",
   "iat": 1787651970,
@@ -266,9 +266,17 @@ secret as the key. Compare `sha256=<computed lowercase hex value>` with the
 `event-signature` header using a constant-time comparison. Do not reserialize
 the outer JSON before verification because whitespace and field order change
 the signature. Then verify the compact JWS with the certificate identified by
-its `kid`/`x5t#S256` protected headers, validate `iss`, `sub`, `aud`, `iat`,
-`jti`, and `txn`, and process the event from the signed `payload` claim. The
-event payload is intentionally not repeated outside the JWS.
+its `kid`/`x5t#S256` protected headers. The `kid` must match an entry from the
+trusted JWKS endpoint for the tenant, and `iss` must exactly match the issuer
+configured by Identity Server for that tenant. Maintain this issuer-to-JWKS
+mapping in trusted receiver configuration; never fetch keys from an arbitrary
+location derived from an unverified JWS. The super tenant normally uses
+`/oauth2/token` and `/oauth2/jwks` without `/t/carbon.super`.
+
+Validate `iss`, `sub`, `aud`, `iat`, `jti`, and `txn`, and process the event
+from the signed `payload` claim. The event payload is intentionally not repeated
+outside the JWS. Receivers that previously accepted a bare tenant domain in
+`iss` must be updated to accept the configured Identity Server issuer.
 
 Return any `2xx` response only after accepting the delivery. Store the
 `Delivery-Id` so that receiving the same delivery again does not repeat the

--- a/docs/event-notification-guide.md
+++ b/docs/event-notification-guide.md
@@ -224,30 +224,51 @@ these headers:
 | Header | Description |
 |---|---|
 | `Delivery-Id` | Stable delivery identifier. Use it to reject duplicate processing. |
-| `Event-Signature` | `sha256=<hex HMAC-SHA256>` computed using the subscription's shared secret. |
+| `event-signature` | `sha256=<hex HMAC-SHA256>` computed using the subscription's shared secret. |
 
-The body is an envelope around the publisher's payload:
+With payload signing enabled (the default), the body contains only the compact
+tenant-signed JWS:
 
 ```json
 {
-  "deliveryId": "<delivery-id>",
-  "eventId": "<event-id>",
-  "subscriptionId": "<subscription-id>",
-  "orgId": "example.com",
-  "topicId": "<topic-id>",
-  "topicName": "consent-status-changed",
+  "signedPayload": "<base64url-header>.<base64url-claims>.<base64url-signature>"
+}
+```
+
+The decoded JWS claims have the following shape:
+
+```json
+{
+  "iss": "example.com",
+  "sub": "example-group",
+  "aud": "dpdp-event-notifications",
+  "iat": 1787651970,
+  "jti": "<delivery-id>",
+  "txn": "<event-id>",
+  "payloadHash": "<HMAC-SHA256 of the embedded payload>",
   "payload": {
-    "consentId": "c7c6b814-ef76-4eb4-9494-8af1b98a9ed1",
-    "status": "REVOKED"
+    "deliveryId": "<delivery-id>",
+    "eventId": "<event-id>",
+    "subscriptionId": "<subscription-id>",
+    "orgId": "example.com",
+    "groupId": "example-group",
+    "topic": "consent-status-changed",
+    "payload": {
+      "consentId": "c7c6b814-ef76-4eb4-9494-8af1b98a9ed1",
+      "status": "REVOKED"
+    }
   }
 }
 ```
 
-Compute HMAC-SHA256 over the exact raw request-body bytes, using the shared
+First compute HMAC-SHA256 over the exact raw request-body bytes, using the shared
 secret as the key. Compare `sha256=<computed lowercase hex value>` with the
-`Event-Signature` header using a constant-time comparison. Do not reserialize
-the JSON before verification because whitespace and field order change the
-signature.
+`event-signature` header using a constant-time comparison. Do not reserialize
+the outer JSON before verification because whitespace and field order change
+the signature. Then verify the compact JWS with the certificate identified by
+its `kid`/`x5t#S256` protected headers, validate `iss`, `sub`, `aud`, `iat`,
+`jti`, and `txn`, and process the event from the signed `payload` claim. The
+event payload is intentionally not repeated outside the JWS.
 
 Return any `2xx` response only after accepting the delivery. Store the
 `Delivery-Id` so that receiving the same delivery again does not repeat the
@@ -323,7 +344,7 @@ curl --request POST "${API_BASE}/events" \
   --header "Content-Type: application/json" \
   --header "group-id: ${TENANT_DOMAIN}" \
   --data '{
-    "topicName": "consent-status-changed",
+    "topic": "consent-status-changed",
     "purposes": ["account-management"],
     "payload": {
       "consentId": "c7c6b814-ef76-4eb4-9494-8af1b98a9ed1",

--- a/dpdp-accelerator/accelerators/dpdp-is/carbon-home/repository/resources/conf/templates/repository/conf/dpdp-accelerator.xml.j2
+++ b/dpdp-accelerator/accelerators/dpdp-is/carbon-home/repository/resources/conf/templates/repository/conf/dpdp-accelerator.xml.j2
@@ -128,6 +128,18 @@
             <AutoCreateEnabled>true</AutoCreateEnabled>
             {% endif %}
         </SystemTopics>
+        <PayloadSigning>
+            {% if dpdp_accelerator.event_notifications.payload_signing.enabled is defined %}
+            <Enabled>{{dpdp_accelerator.event_notifications.payload_signing.enabled}}</Enabled>
+            {% else %}
+            <Enabled>true</Enabled>
+            {% endif %}
+            {% if dpdp_accelerator.event_notifications.payload_signing.audience is defined %}
+            <Audience>{{dpdp_accelerator.event_notifications.payload_signing.audience}}</Audience>
+            {% else %}
+            <Audience>dpdp-event-notifications</Audience>
+            {% endif %}
+        </PayloadSigning>
     </EventNotifications>
     <ConsentHistory>
         {% if dpdp_accelerator.consent_history.enabled is defined %}

--- a/dpdp-accelerator/accelerators/dpdp-is/repository/resources/wso2is-7.3.0-deployment.toml
+++ b/dpdp-accelerator/accelerators/dpdp-is/repository/resources/wso2is-7.3.0-deployment.toml
@@ -243,6 +243,10 @@ client_id = "DPDP_CONSENT_PORTAL"
 # every tenant on create/update. Set false to manage system topics manually instead.
 system_topics_auto_create_enabled = true
 
+[dpdp_accelerator.event_notifications.payload_signing]
+enabled = true
+audience = "dpdp-event-notifications"
+
 # Webhook delivery: callback URL validation, delivery worker sizing, retry/backoff, and
 # subscription-verification behavior.
 [dpdp_accelerator.event_notifications.webhook]

--- a/dpdp-accelerator/components/org.wso2.dpdp.accelerator.common/src/main/java/org/wso2/dpdp/accelerator/common/config/DPDPConfigParser.java
+++ b/dpdp-accelerator/components/org.wso2.dpdp.accelerator.common/src/main/java/org/wso2/dpdp/accelerator/common/config/DPDPConfigParser.java
@@ -255,6 +255,19 @@ public final class DPDPConfigParser {
                 .map(Boolean::parseBoolean).orElse(true);
     }
 
+    public boolean isEventNotificationPayloadSigningEnabled() {
+
+        return getValidatedBoolean(DPDPCommonConstants.EVENT_NOTIFICATIONS_PAYLOAD_SIGNING_ENABLED,
+                DPDPCommonConstants.DEFAULT_EVENT_NOTIFICATIONS_PAYLOAD_SIGNING_ENABLED);
+    }
+
+    public String getEventNotificationPayloadSigningAudience() {
+
+        return getConfigurationAsString(DPDPCommonConstants.EVENT_NOTIFICATIONS_PAYLOAD_SIGNING_AUDIENCE)
+                .filter(value -> !value.trim().isEmpty())
+                .orElse(DPDPCommonConstants.DEFAULT_EVENT_NOTIFICATIONS_PAYLOAD_SIGNING_AUDIENCE);
+    }
+
     public int getEventNotificationThreadPoolSize() {
 
         return getPositiveInt(DPDPCommonConstants.EVENT_NOTIFICATIONS_THREAD_POOL_SIZE,

--- a/dpdp-accelerator/components/org.wso2.dpdp.accelerator.common/src/main/java/org/wso2/dpdp/accelerator/common/config/DPDPConfigurationService.java
+++ b/dpdp-accelerator/components/org.wso2.dpdp.accelerator.common/src/main/java/org/wso2/dpdp/accelerator/common/config/DPDPConfigurationService.java
@@ -67,6 +67,10 @@ public interface DPDPConfigurationService {
 
     boolean isEventNotificationSystemTopicsAutoCreateEnabled();
 
+    boolean isEventNotificationPayloadSigningEnabled();
+
+    String getEventNotificationPayloadSigningAudience();
+
     boolean isConsentHistoryEnabled();
 
     boolean isConsentHistorySnapshotEnabled();

--- a/dpdp-accelerator/components/org.wso2.dpdp.accelerator.common/src/main/java/org/wso2/dpdp/accelerator/common/config/DPDPConfigurationServiceImpl.java
+++ b/dpdp-accelerator/components/org.wso2.dpdp.accelerator.common/src/main/java/org/wso2/dpdp/accelerator/common/config/DPDPConfigurationServiceImpl.java
@@ -191,6 +191,20 @@ public class DPDPConfigurationServiceImpl implements DPDPConfigurationService {
     }
 
     @Override
+    public boolean isEventNotificationPayloadSigningEnabled() {
+
+        return configParser == null ? DPDPCommonConstants.DEFAULT_EVENT_NOTIFICATIONS_PAYLOAD_SIGNING_ENABLED
+                : configParser.isEventNotificationPayloadSigningEnabled();
+    }
+
+    @Override
+    public String getEventNotificationPayloadSigningAudience() {
+
+        return configParser == null ? DPDPCommonConstants.DEFAULT_EVENT_NOTIFICATIONS_PAYLOAD_SIGNING_AUDIENCE
+                : configParser.getEventNotificationPayloadSigningAudience();
+    }
+
+    @Override
     public boolean isConsentHistoryEnabled() {
 
         return configParser == null || configParser.isConsentHistoryEnabled();

--- a/dpdp-accelerator/components/org.wso2.dpdp.accelerator.common/src/main/java/org/wso2/dpdp/accelerator/common/constant/DPDPCommonConstants.java
+++ b/dpdp-accelerator/components/org.wso2.dpdp.accelerator.common/src/main/java/org/wso2/dpdp/accelerator/common/constant/DPDPCommonConstants.java
@@ -69,6 +69,10 @@ public final class DPDPCommonConstants {
             "EventNotifications.WorkerShutdownTimeoutSeconds";
     public static final String EVENT_NOTIFICATIONS_SYSTEM_TOPICS_AUTO_CREATE_ENABLED =
             "EventNotifications.SystemTopics.AutoCreateEnabled";
+    public static final String EVENT_NOTIFICATIONS_PAYLOAD_SIGNING_ENABLED =
+            "EventNotifications.PayloadSigning.Enabled";
+    public static final String EVENT_NOTIFICATIONS_PAYLOAD_SIGNING_AUDIENCE =
+            "EventNotifications.PayloadSigning.Audience";
 
     public static final int DEFAULT_EVENT_NOTIFICATIONS_THREAD_POOL_SIZE = 4;
     public static final long DEFAULT_EVENT_NOTIFICATIONS_BASE_BACKOFF_SECONDS = 5L;
@@ -86,6 +90,9 @@ public final class DPDPCommonConstants {
     public static final int DEFAULT_EVENT_NOTIFICATIONS_PENDING_SUBSCRIPTION_RECOVERY_INTERVAL_SECONDS = 30;
     public static final int DEFAULT_EVENT_NOTIFICATIONS_PENDING_SUBSCRIPTION_RECOVERY_BATCH_SIZE = 20;
     public static final int DEFAULT_EVENT_NOTIFICATIONS_WORKER_SHUTDOWN_TIMEOUT_SECONDS = 5;
+    public static final boolean DEFAULT_EVENT_NOTIFICATIONS_PAYLOAD_SIGNING_ENABLED = true;
+    public static final String DEFAULT_EVENT_NOTIFICATIONS_PAYLOAD_SIGNING_AUDIENCE =
+            "dpdp-event-notifications";
 
     public static final String CONSENT_HISTORY_ENABLED = "ConsentHistory.Enabled";
     public static final String CONSENT_HISTORY_SNAPSHOT_ENABLED = "ConsentHistory.SnapshotEnabled";

--- a/dpdp-accelerator/components/org.wso2.dpdp.accelerator.common/src/test/java/org/wso2/dpdp/accelerator/common/config/DPDPConfigParserTest.java
+++ b/dpdp-accelerator/components/org.wso2.dpdp.accelerator.common/src/test/java/org/wso2/dpdp/accelerator/common/config/DPDPConfigParserTest.java
@@ -79,6 +79,8 @@ public class DPDPConfigParserTest {
                 + "<PendingSubscriptionRecoveryIntervalSeconds>31</PendingSubscriptionRecoveryIntervalSeconds>"
                 + "<PendingSubscriptionRecoveryBatchSize>21</PendingSubscriptionRecoveryBatchSize>"
                 + "<WorkerShutdownTimeoutSeconds>6</WorkerShutdownTimeoutSeconds>"
+                + "<PayloadSigning><Enabled>false</Enabled>"
+                + "<Audience>custom-event-audience</Audience></PayloadSigning>"
                 + "</EventNotifications>"
                 + "</DPDPAccelerator>").getBytes());
         CarbonTestEnvironment.configure(configDir);
@@ -140,6 +142,8 @@ public class DPDPConfigParserTest {
         assertEquals(parser.getEventNotificationPendingSubscriptionRecoveryIntervalSeconds(), 31);
         assertEquals(parser.getEventNotificationPendingSubscriptionRecoveryBatchSize(), 21);
         assertEquals(parser.getEventNotificationWorkerShutdownTimeoutSeconds(), 6);
+        assertTrue(!parser.isEventNotificationPayloadSigningEnabled());
+        assertEquals(parser.getEventNotificationPayloadSigningAudience(), "custom-event-audience");
     }
 
     @Test
@@ -173,6 +177,8 @@ public class DPDPConfigParserTest {
         assertEquals(service.getEventNotificationPendingSubscriptionRecoveryIntervalSeconds(), 31);
         assertEquals(service.getEventNotificationPendingSubscriptionRecoveryBatchSize(), 21);
         assertEquals(service.getEventNotificationWorkerShutdownTimeoutSeconds(), 6);
+        assertTrue(!service.isEventNotificationPayloadSigningEnabled());
+        assertEquals(service.getEventNotificationPayloadSigningAudience(), "custom-event-audience");
     }
 
     @Test
@@ -197,6 +203,8 @@ public class DPDPConfigParserTest {
         assertEquals(service.getEventNotificationPendingSubscriptionRecoveryIntervalSeconds(), 30);
         assertEquals(service.getEventNotificationPendingSubscriptionRecoveryBatchSize(), 20);
         assertEquals(service.getEventNotificationWorkerShutdownTimeoutSeconds(), 5);
+        assertTrue(service.isEventNotificationPayloadSigningEnabled());
+        assertEquals(service.getEventNotificationPayloadSigningAudience(), "dpdp-event-notifications");
     }
 
     @Test
@@ -224,6 +232,8 @@ public class DPDPConfigParserTest {
         values.put("EventNotifications.PendingSubscriptionRecoveryIntervalSeconds", "30");
         values.put("EventNotifications.PendingSubscriptionRecoveryBatchSize", "20");
         values.put("EventNotifications.WorkerShutdownTimeoutSeconds", "5");
+        values.put("EventNotifications.PayloadSigning.Enabled", "false");
+        values.put("EventNotifications.PayloadSigning.Audience", "configured-audience");
         try {
             assertEquals(service.getEventNotificationThreadPoolSize(), 8);
         assertEquals(service.getEventNotificationBaseBackoffSeconds(), 12L);
@@ -240,6 +250,8 @@ public class DPDPConfigParserTest {
         assertEquals(service.getEventNotificationPendingSubscriptionRecoveryIntervalSeconds(), 30);
         assertEquals(service.getEventNotificationPendingSubscriptionRecoveryBatchSize(), 20);
         assertEquals(service.getEventNotificationWorkerShutdownTimeoutSeconds(), 5);
+        assertTrue(!service.isEventNotificationPayloadSigningEnabled());
+        assertEquals(service.getEventNotificationPayloadSigningAudience(), "configured-audience");
 
         values.put("EventNotifications.ThreadPoolSize", "0");
         expectThrows(IllegalStateException.class, service::getEventNotificationThreadPoolSize);
@@ -252,6 +264,8 @@ public class DPDPConfigParserTest {
             values.put("EventNotifications.AllowPrivateNetworkCallbackTargets", "bad");
             expectThrows(IllegalStateException.class,
                     service::isEventNotificationPrivateNetworkCallbackTargetsAllowed);
+            values.put("EventNotifications.PayloadSigning.Enabled", "bad");
+            expectThrows(IllegalStateException.class, service::isEventNotificationPayloadSigningEnabled);
             values.put("EventNotifications.PendingSubscriptionRecoveryIntervalSeconds", "0");
             expectThrows(IllegalStateException.class,
                     service::getEventNotificationPendingSubscriptionRecoveryIntervalSeconds);

--- a/dpdp-accelerator/components/org.wso2.dpdp.accelerator.event.notifications.dao/src/main/java/org/wso2/dpdp/accelerator/event/notifications/dao/impl/DeliveryDAOImpl.java
+++ b/dpdp-accelerator/components/org.wso2.dpdp.accelerator.event.notifications.dao/src/main/java/org/wso2/dpdp/accelerator/event/notifications/dao/impl/DeliveryDAOImpl.java
@@ -160,11 +160,11 @@ public class DeliveryDAOImpl implements DeliveryDAO {
                         list.add(new WebhookDeliveryDispatchContext(
                                 delivery,
                                 rs.getString(EventNotificationDBColumns.ORG_ID),
+                                rs.getString(EventNotificationDBColumns.GROUP_ID),
                                 rs.getString(EventNotificationDBColumns.CALLBACK_URL),
                                 rs.getString(EventNotificationDBColumns.SHARED_SECRET),
                                 rs.getString(EventNotificationDBColumns.PAYLOAD),
                                 rs.getTimestamp(EventNotificationDBColumns.UPDATED_AT),
-                                rs.getString(EventNotificationDBColumns.TOPIC_ID),
                                 rs.getString(EventNotificationDBColumns.TOPIC_NAME)));
                     }
                 }
@@ -200,11 +200,11 @@ public class DeliveryDAOImpl implements DeliveryDAO {
                         list.add(new WebhookDeliveryDispatchContext(
                                 delivery,
                                 rs.getString(EventNotificationDBColumns.ORG_ID),
+                                rs.getString(EventNotificationDBColumns.GROUP_ID),
                                 rs.getString(EventNotificationDBColumns.CALLBACK_URL),
                                 rs.getString(EventNotificationDBColumns.SHARED_SECRET),
                                 rs.getString(EventNotificationDBColumns.PAYLOAD),
                                 rs.getTimestamp(EventNotificationDBColumns.UPDATED_AT),
-                                rs.getString(EventNotificationDBColumns.TOPIC_ID),
                                 rs.getString(EventNotificationDBColumns.TOPIC_NAME)));
                     }
                 }

--- a/dpdp-accelerator/components/org.wso2.dpdp.accelerator.event.notifications.dao/src/main/java/org/wso2/dpdp/accelerator/event/notifications/dao/model/WebhookDeliveryDispatchContext.java
+++ b/dpdp-accelerator/components/org.wso2.dpdp.accelerator.event.notifications.dao/src/main/java/org/wso2/dpdp/accelerator/event/notifications/dao/model/WebhookDeliveryDispatchContext.java
@@ -31,23 +31,23 @@ public class WebhookDeliveryDispatchContext {
 
     private final WebhookDelivery delivery;
     private final String orgId;
+    private final String groupId;
     private final String callbackUrl;
     private final String sharedSecret;
     private final String payload;
     private final Timestamp claimedAt;
-    private final String topicId;
-    private final String topicName;
+    private final String topic;
 
-    public WebhookDeliveryDispatchContext(WebhookDelivery delivery, String orgId, String callbackUrl,
-            String sharedSecret, String payload, Timestamp claimedAt, String topicId, String topicName) {
+    public WebhookDeliveryDispatchContext(WebhookDelivery delivery, String orgId, String groupId, String callbackUrl,
+            String sharedSecret, String payload, Timestamp claimedAt, String topic) {
         this.delivery = delivery;
         this.orgId = orgId;
+        this.groupId = groupId;
         this.callbackUrl = callbackUrl;
         this.sharedSecret = sharedSecret;
         this.payload = payload;
         this.claimedAt = claimedAt;
-        this.topicId = topicId;
-        this.topicName = topicName;
+        this.topic = topic;
     }
 
     public WebhookDelivery getDelivery() {
@@ -56,6 +56,10 @@ public class WebhookDeliveryDispatchContext {
 
     public String getOrgId() {
         return orgId;
+    }
+
+    public String getGroupId() {
+        return groupId;
     }
 
     public String getCallbackUrl() {
@@ -74,11 +78,7 @@ public class WebhookDeliveryDispatchContext {
         return claimedAt;
     }
 
-    public String getTopicId() {
-        return topicId;
-    }
-
-    public String getTopicName() {
-        return topicName;
+    public String getTopic() {
+        return topic;
     }
 }

--- a/dpdp-accelerator/components/org.wso2.dpdp.accelerator.event.notifications.dao/src/main/java/org/wso2/dpdp/accelerator/event/notifications/dao/queries/EventNotificationCommonDBQueries.java
+++ b/dpdp-accelerator/components/org.wso2.dpdp.accelerator.event.notifications.dao/src/main/java/org/wso2/dpdp/accelerator/event/notifications/dao/queries/EventNotificationCommonDBQueries.java
@@ -273,7 +273,7 @@ public class EventNotificationCommonDBQueries {
         return "SELECT EVENT_ID, PURPOSE_NAME FROM EVENT_PURPOSE WHERE EVENT_ID IN (%s)";
     }
 
-    // The dispatch context now pulls topic metadata (TOPIC_ID, TOPIC_NAME) so the
+    // The dispatch context pulls the public topic name so the
     // worker
     // can stamp every webhook payload with the topic that fired without an extra
     // DAO call.
@@ -284,7 +284,7 @@ public class EventNotificationCommonDBQueries {
     // already filters out via isDeliverable(...).
     private static final String DISPATCH_SELECT = "SELECT d.DELIVERY_ID, d.SUBSCRIPTION_ID, d.EVENT_ID, d.STATUS, " +
             "d.ATTEMPT_COUNT, d.NEXT_RETRY_AT, d.CREATED_AT, d.UPDATED_AT, d.DELIVERED_AT, " +
-            "s.ORG_ID, s.CALLBACK_URL, s.SHARED_SECRET, e.PAYLOAD, e.TOPIC_ID AS TOPIC_ID, " +
+            "s.ORG_ID, s.GROUP_ID, s.CALLBACK_URL, s.SHARED_SECRET, e.PAYLOAD, " +
             "t.NAME AS TOPIC_NAME ";
 
     public String getGetPendingWebhookDispatchContextsQuery() {

--- a/dpdp-accelerator/components/org.wso2.dpdp.accelerator.event.notifications.service/pom.xml
+++ b/dpdp-accelerator/components/org.wso2.dpdp.accelerator.event.notifications.service/pom.xml
@@ -51,6 +51,16 @@
             <artifactId>org.wso2.dpdp.accelerator.event.notifications.dao</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.wso2.carbon</groupId>
+            <artifactId>org.wso2.carbon.core</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.identity.framework</groupId>
+            <artifactId>org.wso2.carbon.identity.core</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
             <scope>provided</scope>
@@ -184,6 +194,8 @@
                             org.wso2.dpdp.accelerator.common.util;version="${project.version}",
                             org.wso2.dpdp.accelerator.event.notifications.common.*;version="${project.version}",
                             org.wso2.dpdp.accelerator.event.notifications.dao.*;version="${project.version}",
+                            org.wso2.carbon.identity.core;version="${carbon.identity.core.version}",
+                            org.wso2.carbon.identity.core.util;version="${carbon.identity.core.version}",
                             org.osgi.framework;version="[1.8,2)",
                             *
                         </Import-Package>

--- a/dpdp-accelerator/components/org.wso2.dpdp.accelerator.event.notifications.service/pom.xml
+++ b/dpdp-accelerator/components/org.wso2.dpdp.accelerator.event.notifications.service/pom.xml
@@ -61,6 +61,16 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>org.wso2.carbon.identity.inbound.auth.oauth2</groupId>
+            <artifactId>org.wso2.carbon.identity.oauth</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.orbit.com.nimbusds</groupId>
+            <artifactId>nimbus-jose-jwt</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
             <scope>provided</scope>
@@ -196,6 +206,8 @@
                             org.wso2.dpdp.accelerator.event.notifications.dao.*;version="${project.version}",
                             org.wso2.carbon.identity.core;version="${carbon.identity.core.version}",
                             org.wso2.carbon.identity.core.util;version="${carbon.identity.core.version}",
+                            org.wso2.carbon.identity.oauth2.util;version="${carbon.identity.inbound.auth.oauth.version}",
+                            com.nimbusds.jose;version="[10.0.0,11.0.0)",
                             org.osgi.framework;version="[1.8,2)",
                             *
                         </Import-Package>

--- a/dpdp-accelerator/components/org.wso2.dpdp.accelerator.event.notifications.service/src/main/java/org/wso2/dpdp/accelerator/event/notifications/service/dispatch/EventPayloadSigner.java
+++ b/dpdp-accelerator/components/org.wso2.dpdp.accelerator.event.notifications.service/src/main/java/org/wso2/dpdp/accelerator/event/notifications/service/dispatch/EventPayloadSigner.java
@@ -1,0 +1,25 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.dpdp.accelerator.event.notifications.service.dispatch;
+
+/** Signs a complete outbound event payload with the tenant's Identity Server key. */
+interface EventPayloadSigner {
+
+    String sign(EventPayloadSigningContext context) throws Exception;
+}

--- a/dpdp-accelerator/components/org.wso2.dpdp.accelerator.event.notifications.service/src/main/java/org/wso2/dpdp/accelerator/event/notifications/service/dispatch/EventPayloadSigningContext.java
+++ b/dpdp-accelerator/components/org.wso2.dpdp.accelerator.event.notifications.service/src/main/java/org/wso2/dpdp/accelerator/event/notifications/service/dispatch/EventPayloadSigningContext.java
@@ -1,0 +1,85 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.dpdp.accelerator.event.notifications.service.dispatch;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+/** Immutable input used to create a tenant-signed event JWS. */
+final class EventPayloadSigningContext {
+
+    private final String tenantDomain;
+    private final String issuer;
+    private final String subject;
+    private final String audience;
+    private final String deliveryId;
+    private final String eventId;
+    private final long issuedAt;
+    private final String payloadHash;
+    private final JsonNode payload;
+
+    EventPayloadSigningContext(String tenantDomain, String issuer, String subject, String audience,
+            String deliveryId, String eventId, long issuedAt, String payloadHash, JsonNode payload) {
+
+        this.tenantDomain = tenantDomain;
+        this.issuer = issuer;
+        this.subject = subject;
+        this.audience = audience;
+        this.deliveryId = deliveryId;
+        this.eventId = eventId;
+        this.issuedAt = issuedAt;
+        this.payloadHash = payloadHash;
+        this.payload = payload;
+    }
+
+    String getTenantDomain() {
+        return tenantDomain;
+    }
+
+    String getIssuer() {
+        return issuer;
+    }
+
+    String getSubject() {
+        return subject;
+    }
+
+    String getAudience() {
+        return audience;
+    }
+
+    String getDeliveryId() {
+        return deliveryId;
+    }
+
+    String getEventId() {
+        return eventId;
+    }
+
+    long getIssuedAt() {
+        return issuedAt;
+    }
+
+    String getPayloadHash() {
+        return payloadHash;
+    }
+
+    JsonNode getPayload() {
+        return payload;
+    }
+}

--- a/dpdp-accelerator/components/org.wso2.dpdp.accelerator.event.notifications.service/src/main/java/org/wso2/dpdp/accelerator/event/notifications/service/dispatch/EventPayloadSigningContext.java
+++ b/dpdp-accelerator/components/org.wso2.dpdp.accelerator.event.notifications.service/src/main/java/org/wso2/dpdp/accelerator/event/notifications/service/dispatch/EventPayloadSigningContext.java
@@ -24,7 +24,6 @@ import com.fasterxml.jackson.databind.JsonNode;
 final class EventPayloadSigningContext {
 
     private final String tenantDomain;
-    private final String issuer;
     private final String subject;
     private final String audience;
     private final String deliveryId;
@@ -33,11 +32,10 @@ final class EventPayloadSigningContext {
     private final String payloadHash;
     private final JsonNode payload;
 
-    EventPayloadSigningContext(String tenantDomain, String issuer, String subject, String audience,
+    EventPayloadSigningContext(String tenantDomain, String subject, String audience,
             String deliveryId, String eventId, long issuedAt, String payloadHash, JsonNode payload) {
 
         this.tenantDomain = tenantDomain;
-        this.issuer = issuer;
         this.subject = subject;
         this.audience = audience;
         this.deliveryId = deliveryId;
@@ -49,10 +47,6 @@ final class EventPayloadSigningContext {
 
     String getTenantDomain() {
         return tenantDomain;
-    }
-
-    String getIssuer() {
-        return issuer;
     }
 
     String getSubject() {

--- a/dpdp-accelerator/components/org.wso2.dpdp.accelerator.event.notifications.service/src/main/java/org/wso2/dpdp/accelerator/event/notifications/service/dispatch/IdentityServerPayloadSigner.java
+++ b/dpdp-accelerator/components/org.wso2.dpdp.accelerator.event.notifications.service/src/main/java/org/wso2/dpdp/accelerator/event/notifications/service/dispatch/IdentityServerPayloadSigner.java
@@ -33,19 +33,22 @@ final class IdentityServerPayloadSigner implements EventPayloadSigner {
     private static final String SIGNATURE_ALGORITHM = "SHA256withRSA";
     private static final ObjectMapper MAPPER = new ObjectMapper();
     private final TenantSigningKeyResolver signingKeyResolver;
+    private final TenantIssuerResolver issuerResolver;
 
     IdentityServerPayloadSigner() {
-        this(new IdentityServerTenantSigningKeyResolver());
+        this(new IdentityServerTenantSigningKeyResolver(), new IdentityServerTenantIssuerResolver());
     }
 
-    IdentityServerPayloadSigner(TenantSigningKeyResolver signingKeyResolver) {
+    IdentityServerPayloadSigner(TenantSigningKeyResolver signingKeyResolver, TenantIssuerResolver issuerResolver) {
         this.signingKeyResolver = signingKeyResolver;
+        this.issuerResolver = issuerResolver;
     }
 
     @Override
     public String sign(EventPayloadSigningContext context) throws Exception {
 
         TenantSigningKey signingKey = signingKeyResolver.resolve(context.getTenantDomain());
+        String issuer = issuerResolver.resolve(context.getTenantDomain());
 
         Map<String, Object> header = new LinkedHashMap<>();
         header.put("alg", "RS256");
@@ -54,7 +57,7 @@ final class IdentityServerPayloadSigner implements EventPayloadSigner {
         header.put("x5t#S256", signingKey.getCertificateThumbprint());
 
         Map<String, Object> claims = new LinkedHashMap<>();
-        claims.put("iss", context.getIssuer());
+        claims.put("iss", issuer);
         claims.put("sub", context.getSubject());
         claims.put("aud", context.getAudience());
         claims.put("iat", context.getIssuedAt());

--- a/dpdp-accelerator/components/org.wso2.dpdp.accelerator.event.notifications.service/src/main/java/org/wso2/dpdp/accelerator/event/notifications/service/dispatch/IdentityServerPayloadSigner.java
+++ b/dpdp-accelerator/components/org.wso2.dpdp.accelerator.event.notifications.service/src/main/java/org/wso2/dpdp/accelerator/event/notifications/service/dispatch/IdentityServerPayloadSigner.java
@@ -1,0 +1,85 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.dpdp.accelerator.event.notifications.service.dispatch;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.nio.charset.StandardCharsets;
+import java.security.Signature;
+import java.util.Base64;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/** Creates the compact RS256 JWS used for Identity Server event authentication. */
+final class IdentityServerPayloadSigner implements EventPayloadSigner {
+
+    private static final String SIGNATURE_ALGORITHM = "SHA256withRSA";
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+    private final TenantSigningKeyResolver signingKeyResolver;
+
+    IdentityServerPayloadSigner() {
+        this(new IdentityServerTenantSigningKeyResolver());
+    }
+
+    IdentityServerPayloadSigner(TenantSigningKeyResolver signingKeyResolver) {
+        this.signingKeyResolver = signingKeyResolver;
+    }
+
+    @Override
+    public String sign(EventPayloadSigningContext context) throws Exception {
+
+        TenantSigningKey signingKey = signingKeyResolver.resolve(context.getTenantDomain());
+
+        Map<String, Object> header = new LinkedHashMap<>();
+        header.put("alg", "RS256");
+        header.put("typ", "JWT");
+        header.put("kid", signingKey.getKeyId());
+        header.put("x5t#S256", signingKey.getCertificateThumbprint());
+
+        Map<String, Object> claims = new LinkedHashMap<>();
+        claims.put("iss", context.getIssuer());
+        claims.put("sub", context.getSubject());
+        claims.put("aud", context.getAudience());
+        claims.put("iat", context.getIssuedAt());
+        claims.put("jti", context.getDeliveryId());
+        claims.put("txn", context.getEventId());
+        claims.put("payloadHash", context.getPayloadHash());
+        claims.put("payload", context.getPayload());
+
+        String encodedHeader = encode(toJson(header).getBytes(StandardCharsets.UTF_8));
+        String encodedClaims = encode(toJson(claims).getBytes(StandardCharsets.UTF_8));
+        String signingInput = encodedHeader + "." + encodedClaims;
+
+        Signature signature = Signature.getInstance(SIGNATURE_ALGORITHM);
+        signature.initSign(signingKey.getPrivateKey());
+        signature.update(signingInput.getBytes(StandardCharsets.US_ASCII));
+        return signingInput + "." + encode(signature.sign());
+    }
+
+    private static String toJson(Map<String, Object> claims) throws JsonProcessingException {
+
+        return MAPPER.writeValueAsString(claims);
+    }
+
+    private static String encode(byte[] value) {
+
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(value);
+    }
+}

--- a/dpdp-accelerator/components/org.wso2.dpdp.accelerator.event.notifications.service/src/main/java/org/wso2/dpdp/accelerator/event/notifications/service/dispatch/IdentityServerTenantIssuerResolver.java
+++ b/dpdp-accelerator/components/org.wso2.dpdp.accelerator.event.notifications.service/src/main/java/org/wso2/dpdp/accelerator/event/notifications/service/dispatch/IdentityServerTenantIssuerResolver.java
@@ -1,0 +1,49 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.dpdp.accelerator.event.notifications.service.dispatch;
+
+import org.wso2.carbon.identity.oauth2.util.OAuth2Util;
+
+/** Delegates tenant issuer resolution to Identity Server. */
+final class IdentityServerTenantIssuerResolver implements TenantIssuerResolver {
+
+    private final TenantIssuerResolver issuerLocationResolver;
+
+    IdentityServerTenantIssuerResolver() {
+        this(OAuth2Util::getIssuerLocation);
+    }
+
+    IdentityServerTenantIssuerResolver(TenantIssuerResolver issuerLocationResolver) {
+        this.issuerLocationResolver = issuerLocationResolver;
+    }
+
+    @Override
+    public String resolve(String tenantDomain) throws Exception {
+        if (tenantDomain == null || tenantDomain.trim().isEmpty()) {
+            throw new IllegalArgumentException("Tenant domain is required for event payload issuer resolution.");
+        }
+
+        String normalizedTenantDomain = tenantDomain.trim();
+        String issuer = issuerLocationResolver.resolve(normalizedTenantDomain);
+        if (issuer == null || issuer.trim().isEmpty()) {
+            throw new IllegalStateException("Identity Server tenant issuer is unavailable.");
+        }
+        return issuer;
+    }
+}

--- a/dpdp-accelerator/components/org.wso2.dpdp.accelerator.event.notifications.service/src/main/java/org/wso2/dpdp/accelerator/event/notifications/service/dispatch/IdentityServerTenantKeyIdResolver.java
+++ b/dpdp-accelerator/components/org.wso2.dpdp.accelerator.event.notifications.service/src/main/java/org/wso2/dpdp/accelerator/event/notifications/service/dispatch/IdentityServerTenantKeyIdResolver.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.dpdp.accelerator.event.notifications.service.dispatch;
+
+import com.nimbusds.jose.JWSAlgorithm;
+import org.wso2.carbon.identity.oauth2.util.OAuth2Util;
+
+import java.security.cert.Certificate;
+
+/** Delegates key-ID calculation to Identity Server's configured OAuth provider. */
+final class IdentityServerTenantKeyIdResolver implements TenantKeyIdResolver {
+
+    @Override
+    public String resolve(Certificate certificate, String tenantDomain) throws Exception {
+        return OAuth2Util.getKID(certificate, JWSAlgorithm.RS256, tenantDomain);
+    }
+}

--- a/dpdp-accelerator/components/org.wso2.dpdp.accelerator.event.notifications.service/src/main/java/org/wso2/dpdp/accelerator/event/notifications/service/dispatch/IdentityServerTenantSigningKeyResolver.java
+++ b/dpdp-accelerator/components/org.wso2.dpdp.accelerator.event.notifications.service/src/main/java/org/wso2/dpdp/accelerator/event/notifications/service/dispatch/IdentityServerTenantSigningKeyResolver.java
@@ -21,7 +21,6 @@ package org.wso2.dpdp.accelerator.event.notifications.service.dispatch;
 import org.wso2.carbon.identity.core.IdentityKeyStoreResolver;
 import org.wso2.carbon.identity.core.util.IdentityKeyStoreResolverConstants.InboundProtocol;
 
-import java.nio.charset.StandardCharsets;
 import java.security.Key;
 import java.security.MessageDigest;
 import java.security.PrivateKey;
@@ -32,13 +31,20 @@ import java.util.Base64;
 final class IdentityServerTenantSigningKeyResolver implements TenantSigningKeyResolver {
 
     private final IdentityKeyStoreResolver keyStoreResolver;
+    private final TenantKeyIdResolver keyIdResolver;
 
     IdentityServerTenantSigningKeyResolver() {
-        this(null);
+        this(null, new IdentityServerTenantKeyIdResolver());
     }
 
     IdentityServerTenantSigningKeyResolver(IdentityKeyStoreResolver keyStoreResolver) {
+        this(keyStoreResolver, new IdentityServerTenantKeyIdResolver());
+    }
+
+    IdentityServerTenantSigningKeyResolver(IdentityKeyStoreResolver keyStoreResolver,
+            TenantKeyIdResolver keyIdResolver) {
         this.keyStoreResolver = keyStoreResolver;
+        this.keyIdResolver = keyIdResolver;
     }
 
     @Override
@@ -62,19 +68,10 @@ final class IdentityServerTenantSigningKeyResolver implements TenantSigningKeyRe
 
         byte[] thumbprint = MessageDigest.getInstance("SHA-256").digest(certificate.getEncoded());
         String certificateThumbprint = Base64.getUrlEncoder().withoutPadding().encodeToString(thumbprint);
-        // Identity Server's default OAuth KeyIDProvider uses the URL-safe Base64 encoding
-        // of the lowercase SHA-256 certificate digest followed by the JWS algorithm.
-        String keyId = Base64.getUrlEncoder().withoutPadding()
-                .encodeToString(toLowerHex(thumbprint).getBytes(StandardCharsets.UTF_8)) + "_RS256";
-        return new TenantSigningKey((PrivateKey) key, keyId, certificateThumbprint);
-    }
-
-    private static String toLowerHex(byte[] value) {
-        StringBuilder hex = new StringBuilder(value.length * 2);
-        for (byte current : value) {
-            hex.append(Character.forDigit((current >>> 4) & 0x0F, 16));
-            hex.append(Character.forDigit(current & 0x0F, 16));
+        String keyId = keyIdResolver.resolve(certificate, normalizedTenantDomain);
+        if (keyId == null || keyId.trim().isEmpty()) {
+            throw new IllegalStateException("Identity Server tenant signing key ID is unavailable.");
         }
-        return hex.toString();
+        return new TenantSigningKey((PrivateKey) key, keyId, certificateThumbprint);
     }
 }

--- a/dpdp-accelerator/components/org.wso2.dpdp.accelerator.event.notifications.service/src/main/java/org/wso2/dpdp/accelerator/event/notifications/service/dispatch/IdentityServerTenantSigningKeyResolver.java
+++ b/dpdp-accelerator/components/org.wso2.dpdp.accelerator.event.notifications.service/src/main/java/org/wso2/dpdp/accelerator/event/notifications/service/dispatch/IdentityServerTenantSigningKeyResolver.java
@@ -1,0 +1,80 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.dpdp.accelerator.event.notifications.service.dispatch;
+
+import org.wso2.carbon.identity.core.IdentityKeyStoreResolver;
+import org.wso2.carbon.identity.core.util.IdentityKeyStoreResolverConstants.InboundProtocol;
+
+import java.nio.charset.StandardCharsets;
+import java.security.Key;
+import java.security.MessageDigest;
+import java.security.PrivateKey;
+import java.security.cert.Certificate;
+import java.util.Base64;
+
+/** Uses Identity Server's tenant-aware OAuth keystore resolution and certificate selection. */
+final class IdentityServerTenantSigningKeyResolver implements TenantSigningKeyResolver {
+
+    private final IdentityKeyStoreResolver keyStoreResolver;
+
+    IdentityServerTenantSigningKeyResolver() {
+        this(null);
+    }
+
+    IdentityServerTenantSigningKeyResolver(IdentityKeyStoreResolver keyStoreResolver) {
+        this.keyStoreResolver = keyStoreResolver;
+    }
+
+    @Override
+    public TenantSigningKey resolve(String tenantDomain) throws Exception {
+        if (tenantDomain == null || tenantDomain.trim().isEmpty()) {
+            throw new IllegalArgumentException("Tenant domain is required for event payload signing.");
+        }
+
+        String normalizedTenantDomain = tenantDomain.trim();
+        IdentityKeyStoreResolver resolver = keyStoreResolver != null
+                ? keyStoreResolver : IdentityKeyStoreResolver.getInstance();
+        Key key = resolver.getPrivateKey(normalizedTenantDomain, InboundProtocol.OAUTH);
+        if (!(key instanceof PrivateKey)) {
+            throw new IllegalStateException("Identity Server tenant signing key is not a private key.");
+        }
+
+        Certificate certificate = resolver.getCertificate(normalizedTenantDomain, InboundProtocol.OAUTH);
+        if (certificate == null) {
+            throw new IllegalStateException("Identity Server tenant signing certificate is unavailable.");
+        }
+
+        byte[] thumbprint = MessageDigest.getInstance("SHA-256").digest(certificate.getEncoded());
+        String certificateThumbprint = Base64.getUrlEncoder().withoutPadding().encodeToString(thumbprint);
+        // Identity Server's default OAuth KeyIDProvider uses the URL-safe Base64 encoding
+        // of the lowercase SHA-256 certificate digest followed by the JWS algorithm.
+        String keyId = Base64.getUrlEncoder().withoutPadding()
+                .encodeToString(toLowerHex(thumbprint).getBytes(StandardCharsets.UTF_8)) + "_RS256";
+        return new TenantSigningKey((PrivateKey) key, keyId, certificateThumbprint);
+    }
+
+    private static String toLowerHex(byte[] value) {
+        StringBuilder hex = new StringBuilder(value.length * 2);
+        for (byte current : value) {
+            hex.append(Character.forDigit((current >>> 4) & 0x0F, 16));
+            hex.append(Character.forDigit(current & 0x0F, 16));
+        }
+        return hex.toString();
+    }
+}

--- a/dpdp-accelerator/components/org.wso2.dpdp.accelerator.event.notifications.service/src/main/java/org/wso2/dpdp/accelerator/event/notifications/service/dispatch/TenantIssuerResolver.java
+++ b/dpdp-accelerator/components/org.wso2.dpdp.accelerator.event.notifications.service/src/main/java/org/wso2/dpdp/accelerator/event/notifications/service/dispatch/TenantIssuerResolver.java
@@ -1,0 +1,25 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.dpdp.accelerator.event.notifications.service.dispatch;
+
+/** Resolves the configured Identity Server issuer for a tenant. */
+interface TenantIssuerResolver {
+
+    String resolve(String tenantDomain) throws Exception;
+}

--- a/dpdp-accelerator/components/org.wso2.dpdp.accelerator.event.notifications.service/src/main/java/org/wso2/dpdp/accelerator/event/notifications/service/dispatch/TenantKeyIdResolver.java
+++ b/dpdp-accelerator/components/org.wso2.dpdp.accelerator.event.notifications.service/src/main/java/org/wso2/dpdp/accelerator/event/notifications/service/dispatch/TenantKeyIdResolver.java
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.dpdp.accelerator.event.notifications.service.dispatch;
+
+import java.security.cert.Certificate;
+
+/** Resolves the configured Identity Server key identifier for a tenant certificate. */
+interface TenantKeyIdResolver {
+
+    String resolve(Certificate certificate, String tenantDomain) throws Exception;
+}

--- a/dpdp-accelerator/components/org.wso2.dpdp.accelerator.event.notifications.service/src/main/java/org/wso2/dpdp/accelerator/event/notifications/service/dispatch/TenantSigningKey.java
+++ b/dpdp-accelerator/components/org.wso2.dpdp.accelerator.event.notifications.service/src/main/java/org/wso2/dpdp/accelerator/event/notifications/service/dispatch/TenantSigningKey.java
@@ -1,0 +1,47 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.dpdp.accelerator.event.notifications.service.dispatch;
+
+import java.security.PrivateKey;
+
+/** Tenant-specific private key and the identifier of its matching certificate. */
+final class TenantSigningKey {
+
+    private final PrivateKey privateKey;
+    private final String keyId;
+    private final String certificateThumbprint;
+
+    TenantSigningKey(PrivateKey privateKey, String keyId, String certificateThumbprint) {
+        this.privateKey = privateKey;
+        this.keyId = keyId;
+        this.certificateThumbprint = certificateThumbprint;
+    }
+
+    PrivateKey getPrivateKey() {
+        return privateKey;
+    }
+
+    String getKeyId() {
+        return keyId;
+    }
+
+    String getCertificateThumbprint() {
+        return certificateThumbprint;
+    }
+}

--- a/dpdp-accelerator/components/org.wso2.dpdp.accelerator.event.notifications.service/src/main/java/org/wso2/dpdp/accelerator/event/notifications/service/dispatch/TenantSigningKeyResolver.java
+++ b/dpdp-accelerator/components/org.wso2.dpdp.accelerator.event.notifications.service/src/main/java/org/wso2/dpdp/accelerator/event/notifications/service/dispatch/TenantSigningKeyResolver.java
@@ -1,0 +1,25 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.dpdp.accelerator.event.notifications.service.dispatch;
+
+/** Resolves the Identity Server signing material owned by a tenant. */
+interface TenantSigningKeyResolver {
+
+    TenantSigningKey resolve(String tenantDomain) throws Exception;
+}

--- a/dpdp-accelerator/components/org.wso2.dpdp.accelerator.event.notifications.service/src/main/java/org/wso2/dpdp/accelerator/event/notifications/service/dispatch/WebhookDeliveryTask.java
+++ b/dpdp-accelerator/components/org.wso2.dpdp.accelerator.event.notifications.service/src/main/java/org/wso2/dpdp/accelerator/event/notifications/service/dispatch/WebhookDeliveryTask.java
@@ -48,7 +48,7 @@ import org.apache.commons.logging.LogFactory;
  * <p>For each invocation the task:</p>
  * <ol>
  *   <li>POSTs the payload to the subscriber's callback URL with an HMAC-SHA256 signature in
- *       the {@code Event-Signature} header.</li>
+ *       the {@code event-signature} header.</li>
  *   <li>Writes exactly one {@code WEBHOOK_DELIVERY_AUDIT} row regardless of outcome.</li>
  *   <li>On a 2xx success, marks the delivery {@code delivered} with the current timestamp.</li>
  *   <li>On a non-2xx response or an exception, increments {@code ATTEMPT_COUNT}, computes the
@@ -68,7 +68,7 @@ public class WebhookDeliveryTask implements Runnable {
 
     // Constants kept here (not in EventNotificationCommonConstants) so they stay scoped to
     // outbound HTTP delivery and don't leak into the common module.
-    private static final String EVENT_SIGNATURE_HEADER = "Event-Signature";
+    private static final String EVENT_SIGNATURE_HEADER = "event-signature";
     private static final String DELIVERY_ID_HEADER = "Delivery-Id";
     private static final String CONTENT_TYPE_HEADER = "Content-Type";
     private static final String CONTENT_TYPE_JSON = "application/json";
@@ -85,35 +85,47 @@ public class WebhookDeliveryTask implements Runnable {
 
     private final WebhookDelivery delivery;
     private final String orgId;
+    private final String groupId;
     private final String payload;
     private final String callbackUrl;
     private final String sharedSecret;
-    private final String topicId;
-    private final String topicName;
+    private final String topic;
     private final DeliveryDAO deliveryDAO;
     private final HttpClient httpClient;
     private final DPDPConfigurationService configurationService;
+    private final EventPayloadSigner payloadSigner;
 
-    public WebhookDeliveryTask(WebhookDelivery delivery, String orgId, String payload, String callbackUrl,
-            String sharedSecret, String topicId, String topicName, DeliveryDAO deliveryDAO,
+    public WebhookDeliveryTask(WebhookDelivery delivery, String orgId, String groupId, String payload, String callbackUrl,
+            String sharedSecret, String topic, DeliveryDAO deliveryDAO,
             HttpClient httpClient) {
-        this(delivery, orgId, payload, callbackUrl, sharedSecret, topicId, topicName, deliveryDAO,
-                httpClient, new org.wso2.dpdp.accelerator.common.config.DPDPConfigurationServiceImpl(false));
+        this(delivery, orgId, groupId, payload, callbackUrl, sharedSecret, topic, deliveryDAO,
+                httpClient, new org.wso2.dpdp.accelerator.common.config.DPDPConfigurationServiceImpl(false),
+                new IdentityServerPayloadSigner());
     }
 
-    public WebhookDeliveryTask(WebhookDelivery delivery, String orgId, String payload, String callbackUrl,
-            String sharedSecret, String topicId, String topicName, DeliveryDAO deliveryDAO,
+    public WebhookDeliveryTask(WebhookDelivery delivery, String orgId, String groupId, String payload,
+            String callbackUrl,
+            String sharedSecret, String topic, DeliveryDAO deliveryDAO,
             HttpClient httpClient, DPDPConfigurationService configurationService) {
+        this(delivery, orgId, groupId, payload, callbackUrl, sharedSecret, topic, deliveryDAO,
+                httpClient, configurationService, new IdentityServerPayloadSigner());
+    }
+
+    WebhookDeliveryTask(WebhookDelivery delivery, String orgId, String groupId, String payload, String callbackUrl,
+            String sharedSecret, String topic, DeliveryDAO deliveryDAO,
+            HttpClient httpClient, DPDPConfigurationService configurationService,
+            EventPayloadSigner payloadSigner) {
         this.delivery = delivery;
         this.orgId = orgId;
+        this.groupId = groupId;
         this.payload = payload;
         this.callbackUrl = callbackUrl;
         this.sharedSecret = sharedSecret;
-        this.topicId = topicId;
-        this.topicName = topicName;
+        this.topic = topic;
         this.deliveryDAO = deliveryDAO;
         this.httpClient = httpClient;
         this.configurationService = configurationService;
+        this.payloadSigner = payloadSigner;
     }
 
     @Override
@@ -147,29 +159,44 @@ public class WebhookDeliveryTask implements Runnable {
     }
 
     /**
-     * Builds the envelope, signs it, and returns the HTTP status code as a string.
+     * Builds the event payload, signs it, and returns the HTTP status code as a string.
      * Interrupts and IO errors propagate to the caller.
      *
-     * <p>The body is a JSON envelope that wraps the original event payload under
-     * {@code payload}, with the accelerator-managed routing fields
-     * ({@code deliveryId}, {@code eventId}, {@code subscriptionId}, {@code orgId},
-     * {@code topicId}, {@code topicName}) as siblings. The HMAC-SHA256 in
-     * {@code Event-Signature} is computed over the serialized envelope — not the raw
-     * payload — so receivers must verify against the entire request body. Receivers can
-     * also dedupe on the {@code Delivery-Id} header without recomputing the HMAC.</p>
+     * <p>When certificate signing is enabled, the body contains only {@code signedPayload}.
+     * The compact JWS embeds the complete event envelope and its HMAC-SHA256 hash, avoiding
+     * a second unsigned copy of the event data. The {@code event-signature} header remains
+     * an HMAC over the exact HTTP body for subscription-level authentication.</p>
      */
     private String dispatch() throws Exception {
         if (sharedSecret == null || sharedSecret.trim().isEmpty()) {
             throw new MissingSharedSecretException();
         }
-        String envelope = buildEnvelope();
+        String body = buildEnvelope();
+        if (configurationService.isEventNotificationPayloadSigningEnabled()) {
+            com.fasterxml.jackson.databind.JsonNode eventPayload = ENVELOPE_MAPPER.readTree(body);
+            String serializedPayload = ENVELOPE_MAPPER.writeValueAsString(eventPayload);
+            String payloadHash = HmacSigner.sign(sharedSecret, serializedPayload);
+            EventPayloadSigningContext signingContext = new EventPayloadSigningContext(
+                    orgId,
+                    orgId,
+                    groupId,
+                    configurationService.getEventNotificationPayloadSigningAudience(),
+                    delivery.getDeliveryId(),
+                    delivery.getEventId(),
+                    System.currentTimeMillis() / 1000L,
+                    payloadHash,
+                    eventPayload);
+            Map<String, Object> signedBody = new LinkedHashMap<>();
+            signedBody.put("signedPayload", payloadSigner.sign(signingContext));
+            body = ENVELOPE_MAPPER.writeValueAsString(signedBody);
+        }
         HttpRequest.Builder builder = HttpRequest.newBuilder()
                 .uri(URI.create(callbackUrl))
                 .timeout(HTTP_TIMEOUT)
                 .header(CONTENT_TYPE_HEADER, CONTENT_TYPE_JSON)
                 .header(DELIVERY_ID_HEADER, delivery.getDeliveryId())
-                .POST(HttpRequest.BodyPublishers.ofString(envelope));
-        String signature = HmacSigner.sign(sharedSecret, envelope);
+                .POST(HttpRequest.BodyPublishers.ofString(body));
+        String signature = HmacSigner.sign(sharedSecret, body);
         builder.header(EVENT_SIGNATURE_HEADER, "sha256=" + signature);
         HttpResponse<Void> response = httpClient.send(builder.build(), HttpResponse.BodyHandlers.discarding());
         return String.valueOf(response.statusCode());
@@ -183,8 +210,8 @@ public class WebhookDeliveryTask implements Runnable {
      *
      * <p>LinkedHashMap preserves field order so the serialized envelope is stable across
      * runs (helpful for snapshot tests and for receivers diffing the body byte-for-byte).
-     * If the raw payload is null or not parseable JSON, the {@code payload} field falls
-     * causes the delivery to be marked permanently failed.</p>
+     * If the raw payload is null or not parseable JSON, the delivery is marked permanently
+     * failed.</p>
      */
     private String buildEnvelope() throws Exception {
         Map<String, Object> envelope = new LinkedHashMap<>();
@@ -192,8 +219,8 @@ public class WebhookDeliveryTask implements Runnable {
         envelope.put("eventId", delivery.getEventId());
         envelope.put("subscriptionId", delivery.getSubscriptionId());
         envelope.put("orgId", orgId);
-        envelope.put("topicId", topicId);
-        envelope.put("topicName", topicName);
+        envelope.put("groupId", groupId);
+        envelope.put("topic", topic);
 
         Object payloadNode;
         if (payload == null) {
@@ -263,7 +290,7 @@ public class WebhookDeliveryTask implements Runnable {
             boolean recorded = deliveryDAO.recordSuccessfulAttempt(audit, updated);
             if (recorded) {
                 LOG.info("Webhook delivered [delivery=" + LogSanitizer.sanitize(delivery.getDeliveryId()) + ", event="
-                        + LogSanitizer.sanitize(delivery.getEventId()) + ", topic=" + LogSanitizer.sanitize(topicName) + ", attempt="
+                        + LogSanitizer.sanitize(delivery.getEventId()) + ", topic=" + LogSanitizer.sanitize(topic) + ", attempt="
                         + updated.getAttemptCount() + ", status=" + httpStatus + "].");
             } else {
                 LOG.debug("recordSuccessfulAttempt returned false for delivery ["

--- a/dpdp-accelerator/components/org.wso2.dpdp.accelerator.event.notifications.service/src/main/java/org/wso2/dpdp/accelerator/event/notifications/service/dispatch/WebhookDeliveryTask.java
+++ b/dpdp-accelerator/components/org.wso2.dpdp.accelerator.event.notifications.service/src/main/java/org/wso2/dpdp/accelerator/event/notifications/service/dispatch/WebhookDeliveryTask.java
@@ -178,7 +178,6 @@ public class WebhookDeliveryTask implements Runnable {
             String payloadHash = HmacSigner.sign(sharedSecret, serializedPayload);
             EventPayloadSigningContext signingContext = new EventPayloadSigningContext(
                     orgId,
-                    orgId,
                     groupId,
                     configurationService.getEventNotificationPayloadSigningAudience(),
                     delivery.getDeliveryId(),

--- a/dpdp-accelerator/components/org.wso2.dpdp.accelerator.event.notifications.service/src/main/java/org/wso2/dpdp/accelerator/event/notifications/service/dispatch/WebhookDeliveryWorker.java
+++ b/dpdp-accelerator/components/org.wso2.dpdp.accelerator.event.notifications.service/src/main/java/org/wso2/dpdp/accelerator/event/notifications/service/dispatch/WebhookDeliveryWorker.java
@@ -197,11 +197,11 @@ public class WebhookDeliveryWorker implements Runnable {
         new WebhookDeliveryTask(
                 delivery,
                 ctx.getOrgId(),
+                ctx.getGroupId(),
                 ctx.getPayload(),
                 ctx.getCallbackUrl(),
                 ctx.getSharedSecret(),
-                ctx.getTopicId(),
-                ctx.getTopicName(),
+                ctx.getTopic(),
                 deliveryDAO,
                 httpClient,
                 getConfiguration()).run();

--- a/dpdp-accelerator/components/org.wso2.dpdp.accelerator.event.notifications.service/src/main/java/org/wso2/dpdp/accelerator/event/notifications/service/dto/EventCreateDTO.java
+++ b/dpdp-accelerator/components/org.wso2.dpdp.accelerator.event.notifications.service/src/main/java/org/wso2/dpdp/accelerator/event/notifications/service/dto/EventCreateDTO.java
@@ -30,25 +30,25 @@ import java.util.Map;
  */
 public class EventCreateDTO {
 
-    private String topicName;
+    private String topic;
     private List<String> purposes;
     private Map<String, Object> payload;
 
     public EventCreateDTO() {
     }
 
-    public EventCreateDTO(String topicName, List<String> purposes, Map<String, Object> payload) {
-        this.topicName = topicName;
+    public EventCreateDTO(String topic, List<String> purposes, Map<String, Object> payload) {
+        this.topic = topic;
         this.purposes = purposes;
         this.payload = payload;
     }
 
-    public String getTopicName() {
-        return topicName;
+    public String getTopic() {
+        return topic;
     }
 
-    public void setTopicName(String topicName) {
-        this.topicName = topicName;
+    public void setTopic(String topic) {
+        this.topic = topic;
     }
 
     public List<String> getPurposes() {

--- a/dpdp-accelerator/components/org.wso2.dpdp.accelerator.event.notifications.service/src/test/java/org/wso2/dpdp/accelerator/event/notifications/service/dispatch/IdentityServerPayloadSignerTest.java
+++ b/dpdp-accelerator/components/org.wso2.dpdp.accelerator.event.notifications.service/src/test/java/org/wso2/dpdp/accelerator/event/notifications/service/dispatch/IdentityServerPayloadSignerTest.java
@@ -34,6 +34,7 @@ import java.util.Map;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.expectThrows;
 
 /** Tests the tenant boundary and compact RS256 contract of the event payload signer. */
 public class IdentityServerPayloadSignerTest {
@@ -58,7 +59,10 @@ public class IdentityServerPayloadSignerTest {
                 tenantAKeyPair.getPrivate(), "tenant-a-kid", "tenant-a-thumbprint"));
         keys.put(TENANT_B, new TenantSigningKey(
                 tenantBKeyPair.getPrivate(), "tenant-b-kid", "tenant-b-thumbprint"));
-        signer = new IdentityServerPayloadSigner(keys::get);
+        Map<String, String> issuers = new HashMap<>();
+        issuers.put(TENANT_A, "https://is.example/t/tenant-a.example/oauth2/token");
+        issuers.put(TENANT_B, "https://is.example/t/tenant-b.example/oauth2/token");
+        signer = new IdentityServerPayloadSigner(keys::get, issuers::get);
     }
 
     @Test
@@ -78,7 +82,7 @@ public class IdentityServerPayloadSignerTest {
         assertEquals(header.get("x5t#S256").asText(), "tenant-a-thumbprint");
 
         JsonNode claims = decodeJson(parts[1]);
-        assertEquals(claims.get("iss").asText(), TENANT_A);
+        assertEquals(claims.get("iss").asText(), "https://is.example/t/tenant-a.example/oauth2/token");
         assertEquals(claims.get("sub").asText(), "group-1");
         assertEquals(claims.get("aud").asText(), "dpdp-event-notifications");
         assertEquals(claims.get("jti").asText(), "delivery-1");
@@ -101,14 +105,42 @@ public class IdentityServerPayloadSignerTest {
 
         assertEquals(decodeJson(tenantAJws.split("\\.")[0]).get("kid").asText(), "tenant-a-kid");
         assertEquals(decodeJson(tenantBJws.split("\\.")[0]).get("kid").asText(), "tenant-b-kid");
+        assertEquals(decodeJson(tenantAJws.split("\\.")[1]).get("iss").asText(),
+                "https://is.example/t/tenant-a.example/oauth2/token");
+        assertEquals(decodeJson(tenantBJws.split("\\.")[1]).get("iss").asText(),
+                "https://is.example/t/tenant-b.example/oauth2/token");
         assertTrue(verify(tenantBJws, tenantBKeyPair));
         assertFalse(verify(tenantBJws, tenantAKeyPair));
+    }
+
+    @Test
+    public void testPropagatesSigningKeyResolutionFailure() throws Exception {
+        IdentityServerPayloadSigner failingSigner = new IdentityServerPayloadSigner(
+                tenantDomain -> {
+                    throw new IllegalStateException("key unavailable");
+                }, tenantDomain -> "https://is.example/oauth2/token");
+
+        expectThrows(IllegalStateException.class, () -> failingSigner.sign(context(
+                TENANT_A, "group-a", "delivery-a", "event-a", "hash-a", MAPPER.readTree("{}"))));
+    }
+
+    @Test
+    public void testPropagatesIssuerResolutionFailure() throws Exception {
+        IdentityServerPayloadSigner failingSigner = new IdentityServerPayloadSigner(
+                tenantDomain -> new TenantSigningKey(
+                        tenantAKeyPair.getPrivate(), "tenant-a-kid", "tenant-a-thumbprint"),
+                tenantDomain -> {
+                    throw new IllegalStateException("issuer unavailable");
+                });
+
+        expectThrows(IllegalStateException.class, () -> failingSigner.sign(context(
+                TENANT_A, "group-a", "delivery-a", "event-a", "hash-a", MAPPER.readTree("{}"))));
     }
 
     private static EventPayloadSigningContext context(String tenant, String subject, String deliveryId,
             String eventId, String payloadHash, JsonNode payload) {
 
-        return new EventPayloadSigningContext(tenant, tenant, subject, "dpdp-event-notifications",
+        return new EventPayloadSigningContext(tenant, subject, "dpdp-event-notifications",
                 deliveryId, eventId, 1_787_651_970L, payloadHash, payload);
     }
 

--- a/dpdp-accelerator/components/org.wso2.dpdp.accelerator.event.notifications.service/src/test/java/org/wso2/dpdp/accelerator/event/notifications/service/dispatch/IdentityServerPayloadSignerTest.java
+++ b/dpdp-accelerator/components/org.wso2.dpdp.accelerator.event.notifications.service/src/test/java/org/wso2/dpdp/accelerator/event/notifications/service/dispatch/IdentityServerPayloadSignerTest.java
@@ -1,0 +1,126 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.dpdp.accelerator.event.notifications.service.dispatch;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.Signature;
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+/** Tests the tenant boundary and compact RS256 contract of the event payload signer. */
+public class IdentityServerPayloadSignerTest {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+    private static final String TENANT_A = "tenant-a.example";
+    private static final String TENANT_B = "tenant-b.example";
+
+    private KeyPair tenantAKeyPair;
+    private KeyPair tenantBKeyPair;
+    private IdentityServerPayloadSigner signer;
+
+    @BeforeClass
+    public void setUp() throws Exception {
+        KeyPairGenerator generator = KeyPairGenerator.getInstance("RSA");
+        generator.initialize(2048);
+        tenantAKeyPair = generator.generateKeyPair();
+        tenantBKeyPair = generator.generateKeyPair();
+
+        Map<String, TenantSigningKey> keys = new HashMap<>();
+        keys.put(TENANT_A, new TenantSigningKey(
+                tenantAKeyPair.getPrivate(), "tenant-a-kid", "tenant-a-thumbprint"));
+        keys.put(TENANT_B, new TenantSigningKey(
+                tenantBKeyPair.getPrivate(), "tenant-b-kid", "tenant-b-thumbprint"));
+        signer = new IdentityServerPayloadSigner(keys::get);
+    }
+
+    @Test
+    public void testSignsWithTenantSpecificKeyAndMetadata() throws Exception {
+        JsonNode eventPayload = MAPPER.readTree("{\"deliveryId\":\"delivery-1\",\"topic\":\"consent.revoke\","
+                + "\"payload\":{\"status\":\"REVOKED\"}}");
+        String jws = signer.sign(context(TENANT_A, "group-1", "delivery-1", "event-1",
+                "payload-hash", eventPayload));
+
+        String[] parts = jws.split("\\.");
+        assertEquals(parts.length, 3);
+
+        JsonNode header = decodeJson(parts[0]);
+        assertEquals(header.get("alg").asText(), "RS256");
+        assertEquals(header.get("typ").asText(), "JWT");
+        assertEquals(header.get("kid").asText(), "tenant-a-kid");
+        assertEquals(header.get("x5t#S256").asText(), "tenant-a-thumbprint");
+
+        JsonNode claims = decodeJson(parts[1]);
+        assertEquals(claims.get("iss").asText(), TENANT_A);
+        assertEquals(claims.get("sub").asText(), "group-1");
+        assertEquals(claims.get("aud").asText(), "dpdp-event-notifications");
+        assertEquals(claims.get("jti").asText(), "delivery-1");
+        assertEquals(claims.get("txn").asText(), "event-1");
+        assertEquals(claims.get("payloadHash").asText(), "payload-hash");
+        assertEquals(claims.get("payload"), eventPayload);
+
+        assertTrue(verify(jws, tenantAKeyPair));
+        assertFalse(verify(jws, tenantBKeyPair),
+                "A tenant signature must not verify with another tenant's public key.");
+    }
+
+    @Test
+    public void testDifferentTenantsProduceDifferentKeyIdentifiers() throws Exception {
+        JsonNode payload = MAPPER.readTree("{\"payload\":{\"key\":\"value\"}}");
+        String tenantAJws = signer.sign(context(TENANT_A, "group-a", "delivery-a", "event-a",
+                "hash-a", payload));
+        String tenantBJws = signer.sign(context(TENANT_B, "group-b", "delivery-b", "event-b",
+                "hash-b", payload));
+
+        assertEquals(decodeJson(tenantAJws.split("\\.")[0]).get("kid").asText(), "tenant-a-kid");
+        assertEquals(decodeJson(tenantBJws.split("\\.")[0]).get("kid").asText(), "tenant-b-kid");
+        assertTrue(verify(tenantBJws, tenantBKeyPair));
+        assertFalse(verify(tenantBJws, tenantAKeyPair));
+    }
+
+    private static EventPayloadSigningContext context(String tenant, String subject, String deliveryId,
+            String eventId, String payloadHash, JsonNode payload) {
+
+        return new EventPayloadSigningContext(tenant, tenant, subject, "dpdp-event-notifications",
+                deliveryId, eventId, 1_787_651_970L, payloadHash, payload);
+    }
+
+    private static JsonNode decodeJson(String encoded) throws Exception {
+        return MAPPER.readTree(Base64.getUrlDecoder().decode(encoded));
+    }
+
+    private static boolean verify(String jws, KeyPair keyPair) throws Exception {
+        String[] parts = jws.split("\\.");
+        Signature verifier = Signature.getInstance("SHA256withRSA");
+        verifier.initVerify(keyPair.getPublic());
+        verifier.update((parts[0] + "." + parts[1]).getBytes(StandardCharsets.US_ASCII));
+        return verifier.verify(Base64.getUrlDecoder().decode(parts[2]));
+    }
+}

--- a/dpdp-accelerator/components/org.wso2.dpdp.accelerator.event.notifications.service/src/test/java/org/wso2/dpdp/accelerator/event/notifications/service/dispatch/IdentityServerTenantIssuerResolverTest.java
+++ b/dpdp-accelerator/components/org.wso2.dpdp.accelerator.event.notifications.service/src/test/java/org/wso2/dpdp/accelerator/event/notifications/service/dispatch/IdentityServerTenantIssuerResolverTest.java
@@ -1,0 +1,62 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.dpdp.accelerator.event.notifications.service.dispatch;
+
+import org.testng.annotations.Test;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.expectThrows;
+
+/** Tests tenant normalization and validation around Identity Server issuer resolution. */
+public class IdentityServerTenantIssuerResolverTest {
+
+    @Test
+    public void testDelegatesNormalizedTenantDomain() throws Exception {
+        AtomicReference<String> resolvedTenant = new AtomicReference<>();
+        IdentityServerTenantIssuerResolver resolver = new IdentityServerTenantIssuerResolver(tenantDomain -> {
+            resolvedTenant.set(tenantDomain);
+            return "https://is.example/t/tenant.example/oauth2/token";
+        });
+
+        String issuer = resolver.resolve(" tenant.example ");
+
+        assertEquals(resolvedTenant.get(), "tenant.example");
+        assertEquals(issuer, "https://is.example/t/tenant.example/oauth2/token");
+    }
+
+    @Test
+    public void testRejectsMissingTenantDomain() {
+        IdentityServerTenantIssuerResolver resolver = new IdentityServerTenantIssuerResolver(tenantDomain -> "unused");
+
+        expectThrows(IllegalArgumentException.class, () -> resolver.resolve(" "));
+    }
+
+    @Test
+    public void testRejectsBlankOrNullIssuer() {
+        IdentityServerTenantIssuerResolver blankResolver =
+                new IdentityServerTenantIssuerResolver(tenantDomain -> " ");
+        IdentityServerTenantIssuerResolver nullResolver =
+                new IdentityServerTenantIssuerResolver(tenantDomain -> null);
+
+        expectThrows(IllegalStateException.class, () -> blankResolver.resolve("tenant.example"));
+        expectThrows(IllegalStateException.class, () -> nullResolver.resolve("tenant.example"));
+    }
+}

--- a/dpdp-accelerator/components/org.wso2.dpdp.accelerator.event.notifications.service/src/test/java/org/wso2/dpdp/accelerator/event/notifications/service/dispatch/IdentityServerTenantSigningKeyResolverTest.java
+++ b/dpdp-accelerator/components/org.wso2.dpdp.accelerator.event.notifications.service/src/test/java/org/wso2/dpdp/accelerator/event/notifications/service/dispatch/IdentityServerTenantSigningKeyResolverTest.java
@@ -1,0 +1,81 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.dpdp.accelerator.event.notifications.service.dispatch;
+
+import org.testng.annotations.Test;
+import org.wso2.carbon.identity.core.IdentityKeyStoreResolver;
+import org.wso2.carbon.identity.core.util.IdentityKeyStoreResolverConstants.InboundProtocol;
+
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.MessageDigest;
+import java.security.cert.Certificate;
+import java.util.Base64;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertSame;
+import static org.testng.Assert.expectThrows;
+
+/** Tests Identity Server tenant key selection without loading a Carbon runtime. */
+public class IdentityServerTenantSigningKeyResolverTest {
+
+    @Test
+    public void testResolvesOAuthTenantKeyAndCertificateThumbprint() throws Exception {
+        IdentityKeyStoreResolver identityResolver = mock(IdentityKeyStoreResolver.class);
+        Certificate certificate = mock(Certificate.class);
+        KeyPairGenerator generator = KeyPairGenerator.getInstance("RSA");
+        generator.initialize(2048);
+        KeyPair keyPair = generator.generateKeyPair();
+        byte[] encodedCertificate = "tenant-certificate".getBytes(java.nio.charset.StandardCharsets.UTF_8);
+
+        when(identityResolver.getPrivateKey("tenant.example", InboundProtocol.OAUTH))
+                .thenReturn(keyPair.getPrivate());
+        when(identityResolver.getCertificate("tenant.example", InboundProtocol.OAUTH))
+                .thenReturn(certificate);
+        when(certificate.getEncoded()).thenReturn(encodedCertificate);
+
+        TenantSigningKey signingKey =
+                new IdentityServerTenantSigningKeyResolver(identityResolver).resolve(" tenant.example ");
+
+        assertSame(signingKey.getPrivateKey(), keyPair.getPrivate());
+        byte[] certificateDigest = MessageDigest.getInstance("SHA-256").digest(encodedCertificate);
+        StringBuilder hex = new StringBuilder(certificateDigest.length * 2);
+        for (byte current : certificateDigest) {
+            hex.append(String.format("%02x", current));
+        }
+        assertEquals(signingKey.getKeyId(), Base64.getUrlEncoder().withoutPadding()
+                .encodeToString(hex.toString().getBytes(java.nio.charset.StandardCharsets.UTF_8)) + "_RS256");
+        assertEquals(signingKey.getCertificateThumbprint(),
+                Base64.getUrlEncoder().withoutPadding().encodeToString(certificateDigest));
+        verify(identityResolver).getPrivateKey("tenant.example", InboundProtocol.OAUTH);
+        verify(identityResolver).getCertificate("tenant.example", InboundProtocol.OAUTH);
+    }
+
+    @Test
+    public void testRejectsMissingTenantDomain() {
+        IdentityKeyStoreResolver identityResolver = mock(IdentityKeyStoreResolver.class);
+        IdentityServerTenantSigningKeyResolver resolver =
+                new IdentityServerTenantSigningKeyResolver(identityResolver);
+
+        expectThrows(IllegalArgumentException.class, () -> resolver.resolve(" "));
+    }
+}

--- a/dpdp-accelerator/components/org.wso2.dpdp.accelerator.event.notifications.service/src/test/java/org/wso2/dpdp/accelerator/event/notifications/service/dispatch/IdentityServerTenantSigningKeyResolverTest.java
+++ b/dpdp-accelerator/components/org.wso2.dpdp.accelerator.event.notifications.service/src/test/java/org/wso2/dpdp/accelerator/event/notifications/service/dispatch/IdentityServerTenantSigningKeyResolverTest.java
@@ -29,6 +29,7 @@ import java.security.cert.Certificate;
 import java.util.Base64;
 
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
@@ -41,6 +42,7 @@ public class IdentityServerTenantSigningKeyResolverTest {
     @Test
     public void testResolvesOAuthTenantKeyAndCertificateThumbprint() throws Exception {
         IdentityKeyStoreResolver identityResolver = mock(IdentityKeyStoreResolver.class);
+        TenantKeyIdResolver keyIdResolver = mock(TenantKeyIdResolver.class);
         Certificate certificate = mock(Certificate.class);
         KeyPairGenerator generator = KeyPairGenerator.getInstance("RSA");
         generator.initialize(2048);
@@ -52,22 +54,19 @@ public class IdentityServerTenantSigningKeyResolverTest {
         when(identityResolver.getCertificate("tenant.example", InboundProtocol.OAUTH))
                 .thenReturn(certificate);
         when(certificate.getEncoded()).thenReturn(encodedCertificate);
+        when(keyIdResolver.resolve(certificate, "tenant.example")).thenReturn("configured-provider-kid");
 
-        TenantSigningKey signingKey =
-                new IdentityServerTenantSigningKeyResolver(identityResolver).resolve(" tenant.example ");
+        TenantSigningKey signingKey = new IdentityServerTenantSigningKeyResolver(identityResolver, keyIdResolver)
+                .resolve(" tenant.example ");
 
         assertSame(signingKey.getPrivateKey(), keyPair.getPrivate());
         byte[] certificateDigest = MessageDigest.getInstance("SHA-256").digest(encodedCertificate);
-        StringBuilder hex = new StringBuilder(certificateDigest.length * 2);
-        for (byte current : certificateDigest) {
-            hex.append(String.format("%02x", current));
-        }
-        assertEquals(signingKey.getKeyId(), Base64.getUrlEncoder().withoutPadding()
-                .encodeToString(hex.toString().getBytes(java.nio.charset.StandardCharsets.UTF_8)) + "_RS256");
+        assertEquals(signingKey.getKeyId(), "configured-provider-kid");
         assertEquals(signingKey.getCertificateThumbprint(),
                 Base64.getUrlEncoder().withoutPadding().encodeToString(certificateDigest));
         verify(identityResolver).getPrivateKey("tenant.example", InboundProtocol.OAUTH);
         verify(identityResolver).getCertificate("tenant.example", InboundProtocol.OAUTH);
+        verify(keyIdResolver).resolve(certificate, "tenant.example");
     }
 
     @Test
@@ -77,5 +76,61 @@ public class IdentityServerTenantSigningKeyResolverTest {
                 new IdentityServerTenantSigningKeyResolver(identityResolver);
 
         expectThrows(IllegalArgumentException.class, () -> resolver.resolve(" "));
+    }
+
+    @Test
+    public void testRejectsNonPrivateSigningKey() throws Exception {
+        IdentityKeyStoreResolver identityResolver = mock(IdentityKeyStoreResolver.class);
+        TenantKeyIdResolver keyIdResolver = mock(TenantKeyIdResolver.class);
+        when(identityResolver.getPrivateKey("tenant.example", InboundProtocol.OAUTH))
+                .thenReturn(mock(java.security.Key.class));
+
+        IdentityServerTenantSigningKeyResolver resolver =
+                new IdentityServerTenantSigningKeyResolver(identityResolver, keyIdResolver);
+
+        expectThrows(IllegalStateException.class, () -> resolver.resolve("tenant.example"));
+        verify(identityResolver, never()).getCertificate("tenant.example", InboundProtocol.OAUTH);
+    }
+
+    @Test
+    public void testRejectsMissingCertificate() throws Exception {
+        IdentityKeyStoreResolver identityResolver = mock(IdentityKeyStoreResolver.class);
+        TenantKeyIdResolver keyIdResolver = mock(TenantKeyIdResolver.class);
+        KeyPairGenerator generator = KeyPairGenerator.getInstance("RSA");
+        generator.initialize(2048);
+        when(identityResolver.getPrivateKey("tenant.example", InboundProtocol.OAUTH))
+                .thenReturn(generator.generateKeyPair().getPrivate());
+        when(identityResolver.getCertificate("tenant.example", InboundProtocol.OAUTH)).thenReturn(null);
+
+        IdentityServerTenantSigningKeyResolver resolver =
+                new IdentityServerTenantSigningKeyResolver(identityResolver, keyIdResolver);
+
+        expectThrows(IllegalStateException.class, () -> resolver.resolve("tenant.example"));
+        verify(keyIdResolver, never()).resolve(org.mockito.ArgumentMatchers.any(),
+                org.mockito.ArgumentMatchers.anyString());
+    }
+
+    @Test
+    public void testRejectsBlankOrNullProviderKeyId() throws Exception {
+        assertInvalidProviderKeyId(" ");
+        assertInvalidProviderKeyId(null);
+    }
+
+    private static void assertInvalidProviderKeyId(String keyId) throws Exception {
+        IdentityKeyStoreResolver identityResolver = mock(IdentityKeyStoreResolver.class);
+        TenantKeyIdResolver keyIdResolver = mock(TenantKeyIdResolver.class);
+        Certificate certificate = mock(Certificate.class);
+        KeyPairGenerator generator = KeyPairGenerator.getInstance("RSA");
+        generator.initialize(2048);
+        when(identityResolver.getPrivateKey("tenant.example", InboundProtocol.OAUTH))
+                .thenReturn(generator.generateKeyPair().getPrivate());
+        when(identityResolver.getCertificate("tenant.example", InboundProtocol.OAUTH)).thenReturn(certificate);
+        when(certificate.getEncoded()).thenReturn(new byte[]{1, 2, 3});
+        when(keyIdResolver.resolve(certificate, "tenant.example")).thenReturn(keyId);
+
+        IdentityServerTenantSigningKeyResolver resolver =
+                new IdentityServerTenantSigningKeyResolver(identityResolver, keyIdResolver);
+
+        expectThrows(IllegalStateException.class, () -> resolver.resolve("tenant.example"));
     }
 }

--- a/dpdp-accelerator/components/org.wso2.dpdp.accelerator.event.notifications.service/src/test/java/org/wso2/dpdp/accelerator/event/notifications/service/dispatch/WebhookDeliveryTaskTest.java
+++ b/dpdp-accelerator/components/org.wso2.dpdp.accelerator.event.notifications.service/src/test/java/org/wso2/dpdp/accelerator/event/notifications/service/dispatch/WebhookDeliveryTaskTest.java
@@ -39,8 +39,8 @@ import java.sql.Timestamp;
 import java.util.UUID;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -384,7 +384,6 @@ public class WebhookDeliveryTaskTest {
         verify(payloadSigner).sign(contextCaptor.capture());
         EventPayloadSigningContext context = contextCaptor.getValue();
         assertEquals(context.getTenantDomain(), ORG_ID);
-        assertEquals(context.getIssuer(), ORG_ID);
         assertEquals(context.getSubject(), GROUP_ID);
         assertEquals(context.getAudience(), "dpdp-event-notifications");
         assertEquals(context.getDeliveryId(), DELIVERY_ID);
@@ -400,6 +399,22 @@ public class WebhookDeliveryTaskTest {
 
         String expectedBodySignature = "sha256=" + HmacSigner.sign(SHARED_SECRET, bodyOf(request));
         assertEquals(request.headers().firstValue("Event-Signature").orElse(null), expectedBodySignature);
+    }
+
+    @Test
+    public void testPayloadSigningFailurePreventsHttpRequestAndSchedulesRetry() throws Exception {
+        WebhookDelivery delivery = delivery(0);
+        when(configurationService.isEventNotificationPayloadSigningEnabled()).thenReturn(true);
+        when(configurationService.getEventNotificationPayloadSigningAudience())
+                .thenReturn("dpdp-event-notifications");
+        when(payloadSigner.sign(any(EventPayloadSigningContext.class)))
+                .thenThrow(new IllegalStateException("issuer unavailable"));
+        when(deliveryDAO.recordRetryableFailure(any(), anyString(), anyInt(), any())).thenReturn(true);
+
+        task(delivery, "{\"hello\":\"world\"}").run();
+
+        verify(httpClient, never()).send(any(), any());
+        verify(deliveryDAO).recordRetryableFailure(any(), eq(DELIVERY_ID), eq(1), any());
     }
 
     @Test

--- a/dpdp-accelerator/components/org.wso2.dpdp.accelerator.event.notifications.service/src/test/java/org/wso2/dpdp/accelerator/event/notifications/service/dispatch/WebhookDeliveryTaskTest.java
+++ b/dpdp-accelerator/components/org.wso2.dpdp.accelerator.event.notifications.service/src/test/java/org/wso2/dpdp/accelerator/event/notifications/service/dispatch/WebhookDeliveryTaskTest.java
@@ -40,6 +40,7 @@ import java.util.UUID;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -61,9 +62,9 @@ public class WebhookDeliveryTaskTest {
     private static final String SUBSCRIPTION_ID = "sub-1";
     private static final String EVENT_ID = "event-1";
     private static final String ORG_ID = "org-1";
+    private static final String GROUP_ID = "group-1";
     private static final String CALLBACK_URL = "https://callback.example.com/hook";
     private static final String SHARED_SECRET = "secret";
-    private static final String TOPIC_ID = "topic-1";
     private static final String TOPIC_NAME = "accounts";
 
     @Mock
@@ -74,6 +75,9 @@ public class WebhookDeliveryTaskTest {
 
     @Mock
     private DPDPConfigurationService configurationService;
+
+    @Mock
+    private EventPayloadSigner payloadSigner;
 
     @BeforeMethod
     public void setUp() {
@@ -107,14 +111,15 @@ public class WebhookDeliveryTaskTest {
         return new WebhookDeliveryTask(
                 delivery,
                 ORG_ID,
+                GROUP_ID,
                 payload,
                 CALLBACK_URL,
                 sharedSecret,
-                TOPIC_ID,
                 TOPIC_NAME,
                 deliveryDAO,
                 httpClient,
-                configurationService);
+                configurationService,
+                payloadSigner);
     }
 
     @SuppressWarnings("unchecked")
@@ -325,8 +330,9 @@ public class WebhookDeliveryTaskTest {
         assertEquals(envelope.get("eventId").asText(), EVENT_ID);
         assertEquals(envelope.get("subscriptionId").asText(), SUBSCRIPTION_ID);
         assertEquals(envelope.get("orgId").asText(), ORG_ID);
-        assertEquals(envelope.get("topicId").asText(), TOPIC_ID);
-        assertEquals(envelope.get("topicName").asText(), TOPIC_NAME);
+        assertNull(envelope.get("topicId"));
+        assertEquals(envelope.get("topic").asText(), TOPIC_NAME);
+        assertNull(envelope.get("topicName"));
     }
 
     @Test
@@ -352,6 +358,48 @@ public class WebhookDeliveryTaskTest {
         String expected = HmacSigner.sign(SHARED_SECRET, body);
         assertEquals(signatureHeader, "sha256=" + expected,
                 "signature must be HMAC over the envelope body");
+    }
+
+    @Test
+    public void testCertificateSignedPayloadEmbedsCompleteEventWithoutUnsignedCopy() throws Exception {
+        WebhookDelivery delivery = delivery(0);
+        stubHttpResponse(200);
+        when(deliveryDAO.recordSuccessfulAttempt(any(), any())).thenReturn(true);
+        when(configurationService.isEventNotificationPayloadSigningEnabled()).thenReturn(true);
+        when(configurationService.getEventNotificationPayloadSigningAudience())
+                .thenReturn("dpdp-event-notifications");
+        when(payloadSigner.sign(any(EventPayloadSigningContext.class))).thenReturn("header.claims.signature");
+
+        task(delivery, "{\"hello\":\"world\"}").run();
+
+        HttpRequest request = captureRequest();
+        JsonNode body = new ObjectMapper().readTree(bodyOf(request));
+        assertEquals(body.size(), 1);
+        assertEquals(body.get("signedPayload").asText(), "header.claims.signature");
+        assertNull(body.get("payload"), "the event must not be duplicated outside the JWS");
+        assertNull(body.get("payloadHash"), "the hash is an integrity claim inside the JWS");
+
+        ArgumentCaptor<EventPayloadSigningContext> contextCaptor =
+                ArgumentCaptor.forClass(EventPayloadSigningContext.class);
+        verify(payloadSigner).sign(contextCaptor.capture());
+        EventPayloadSigningContext context = contextCaptor.getValue();
+        assertEquals(context.getTenantDomain(), ORG_ID);
+        assertEquals(context.getIssuer(), ORG_ID);
+        assertEquals(context.getSubject(), GROUP_ID);
+        assertEquals(context.getAudience(), "dpdp-event-notifications");
+        assertEquals(context.getDeliveryId(), DELIVERY_ID);
+        assertEquals(context.getEventId(), EVENT_ID);
+        assertEquals(context.getPayload().get("deliveryId").asText(), DELIVERY_ID);
+        assertEquals(context.getPayload().get("subscriptionId").asText(), SUBSCRIPTION_ID);
+        assertEquals(context.getPayload().get("orgId").asText(), ORG_ID);
+        assertEquals(context.getPayload().get("groupId").asText(), GROUP_ID);
+        assertEquals(context.getPayload().get("topic").asText(), TOPIC_NAME);
+        assertEquals(context.getPayload().get("payload").get("hello").asText(), "world");
+        assertEquals(context.getPayloadHash(), HmacSigner.sign(SHARED_SECRET,
+                new ObjectMapper().writeValueAsString(context.getPayload())));
+
+        String expectedBodySignature = "sha256=" + HmacSigner.sign(SHARED_SECRET, bodyOf(request));
+        assertEquals(request.headers().firstValue("Event-Signature").orElse(null), expectedBodySignature);
     }
 
     @Test

--- a/dpdp-accelerator/components/org.wso2.dpdp.accelerator.event.notifications.service/src/test/java/org/wso2/dpdp/accelerator/event/notifications/service/dispatch/WebhookDeliveryWorkerTest.java
+++ b/dpdp-accelerator/components/org.wso2.dpdp.accelerator.event.notifications.service/src/test/java/org/wso2/dpdp/accelerator/event/notifications/service/dispatch/WebhookDeliveryWorkerTest.java
@@ -109,11 +109,11 @@ public class WebhookDeliveryWorkerTest {
     }
 
     private WebhookDeliveryDispatchContext context(String deliveryId, int attemptCount) {
-        return context(deliveryId, attemptCount, "topic-1", "accounts");
+        return context(deliveryId, attemptCount, "accounts");
     }
 
     private WebhookDeliveryDispatchContext context(String deliveryId, int attemptCount,
-            String topicId, String topicName) {
+            String topic) {
         WebhookDelivery delivery = new WebhookDelivery(
                 deliveryId,
                 "sub-1",
@@ -127,12 +127,12 @@ public class WebhookDeliveryWorkerTest {
         return new WebhookDeliveryDispatchContext(
                 delivery,
                 "org-1",
+                "group-1",
                 "https://callback.example.com/hook",
                 "secret",
                 "{\"hello\":\"world\"}",
                 delivery.getUpdatedAt(),
-                topicId,
-                topicName);
+                topic);
     }
 
     @Test
@@ -192,7 +192,7 @@ public class WebhookDeliveryWorkerTest {
         WebhookDelivery delivery = new WebhookDelivery(
                 "d1", "sub-1", "event-1", "pending", 0, null, new Timestamp(0), new Timestamp(0), null);
         WebhookDeliveryDispatchContext broken = new WebhookDeliveryDispatchContext(
-                delivery, "org-1", null, "secret", "{}", new Timestamp(0), "topic-1", "accounts");
+                delivery, "org-1", "group-1", null, "secret", "{}", new Timestamp(0), "accounts");
 
         when(deliveryDAO.getPendingWebhookDispatchContexts(anyInt()))
                 .thenReturn(java.util.Collections.singletonList(broken));
@@ -258,10 +258,9 @@ public class WebhookDeliveryWorkerTest {
         WebhookDeliveryDispatchContext dispatchContext = context("update-failure", 0);
         when(deliveryDAO.getPendingWebhookDispatchContexts(anyInt()))
                 .thenReturn(Collections.singletonList(new WebhookDeliveryDispatchContext(
-                        dispatchContext.getDelivery(), dispatchContext.getOrgId(),
+                        dispatchContext.getDelivery(), dispatchContext.getOrgId(), dispatchContext.getGroupId(),
                         null, dispatchContext.getSharedSecret(), dispatchContext.getPayload(),
-                        dispatchContext.getDelivery().getUpdatedAt(), dispatchContext.getTopicId(),
-                        dispatchContext.getTopicName())));
+                        dispatchContext.getDelivery().getUpdatedAt(), dispatchContext.getTopic())));
         when(deliveryDAO.claimWebhookDelivery(eq("update-failure"))).thenReturn(true);
         doThrow(new RuntimeException("status update failed"))
                 .when(deliveryDAO).updateWebhookDeliveryStatus(any());
@@ -279,8 +278,8 @@ public class WebhookDeliveryWorkerTest {
         WebhookDelivery delivery = new WebhookDelivery(
                 "d1", "sub-1", "event-1", "pending", 0, null, new Timestamp(0), new Timestamp(0), null);
         WebhookDeliveryDispatchContext broken = new WebhookDeliveryDispatchContext(
-                delivery, "org-1", "https://callback.example.com/hook", "secret", null,
-                new Timestamp(0), "topic-1", "accounts");
+                delivery, "org-1", "group-1", "https://callback.example.com/hook", "secret", null,
+                new Timestamp(0), "accounts");
 
         when(deliveryDAO.getPendingWebhookDispatchContexts(anyInt()))
                 .thenReturn(java.util.Collections.singletonList(broken));
@@ -299,7 +298,7 @@ public class WebhookDeliveryWorkerTest {
         WebhookDelivery delivery = new WebhookDelivery(
                 "d1", "sub-1", "event-1", "pending", 0, null, new Timestamp(0), new Timestamp(0), null);
         WebhookDeliveryDispatchContext broken = new WebhookDeliveryDispatchContext(
-                delivery, "org-1", null, "secret", "{}", new Timestamp(0), "topic-1", "accounts");
+                delivery, "org-1", "group-1", null, "secret", "{}", new Timestamp(0), "accounts");
 
         when(deliveryDAO.getPendingWebhookDispatchContexts(anyInt()))
                 .thenReturn(java.util.Collections.singletonList(broken));
@@ -320,8 +319,8 @@ public class WebhookDeliveryWorkerTest {
     public void testMissingSharedSecretMarksDeliveryUnrecoverableWithoutDispatch() {
         WebhookDeliveryDispatchContext valid = context("missing-secret", 0);
         WebhookDeliveryDispatchContext unsigned = new WebhookDeliveryDispatchContext(
-                valid.getDelivery(), valid.getOrgId(), valid.getCallbackUrl(), " ", valid.getPayload(),
-                valid.getDelivery().getUpdatedAt(), valid.getTopicId(), valid.getTopicName());
+                valid.getDelivery(), valid.getOrgId(), valid.getGroupId(), valid.getCallbackUrl(), " ", valid.getPayload(),
+                valid.getDelivery().getUpdatedAt(), valid.getTopic());
         when(deliveryDAO.getPendingWebhookDispatchContexts(anyInt()))
                 .thenReturn(Collections.singletonList(unsigned));
         when(deliveryDAO.claimWebhookDelivery("missing-secret")).thenReturn(true);

--- a/dpdp-accelerator/components/org.wso2.dpdp.accelerator.event.notifications.service/src/test/java/org/wso2/dpdp/accelerator/event/notifications/service/dto/ServiceDTOTest.java
+++ b/dpdp-accelerator/components/org.wso2.dpdp.accelerator.event.notifications.service/src/test/java/org/wso2/dpdp/accelerator/event/notifications/service/dto/ServiceDTOTest.java
@@ -37,14 +37,14 @@ public class ServiceDTOTest {
         List<String> purposes = Collections.singletonList("analytics");
         Map<String, Object> payload = Collections.singletonMap("key", "value");
         EventCreateDTO dto = new EventCreateDTO();
-        dto.setTopicName("topic");
+        dto.setTopic("topic");
         dto.setPurposes(purposes);
         dto.setPayload(payload);
-        assertEquals(dto.getTopicName(), "topic");
+        assertEquals(dto.getTopic(), "topic");
         assertEquals(dto.getPurposes(), purposes);
         assertEquals(dto.getPayload(), payload);
         EventCreateDTO constructed = new EventCreateDTO("constructed", purposes, payload);
-        assertEquals(constructed.getTopicName(), "constructed");
+        assertEquals(constructed.getTopic(), "constructed");
     }
 
     @Test

--- a/dpdp-accelerator/internal-webapps/org.wso2.dpdp.accelerator.event.notifications.endpoint/src/main/java/org/wso2/dpdp/accelerator/event/notifications/endpoint/handler/EventHandler.java
+++ b/dpdp-accelerator/internal-webapps/org.wso2.dpdp.accelerator.event.notifications.endpoint/src/main/java/org/wso2/dpdp/accelerator/event/notifications/endpoint/handler/EventHandler.java
@@ -53,7 +53,7 @@ public class EventHandler {
     }
 
     public EventDTO publishEvent(String orgId, String groupId, EventCreateDTO request) {
-        String topicName = request != null ? request.getTopicName() : null;
+        String topicName = request != null ? request.getTopic() : null;
         List<String> purposes = request != null ? request.getPurposes() : null;
         Map<String, Object> payload = request != null ? request.getPayload() : null;
         return eventPublishService.publishEvent(orgId, groupId, topicName, purposes, payload);

--- a/dpdp-accelerator/react-apps/consent-portal/frontend/src/__tests__/EventsApi.test.ts
+++ b/dpdp-accelerator/react-apps/consent-portal/frontend/src/__tests__/EventsApi.test.ts
@@ -98,7 +98,7 @@ describe('eventsApi', () => {
     respondWith({ eventId: 'evt-1', topicId: 'topic-1' })
 
     const payload = {
-      topicName: 'consent.revoke',
+      topic: 'consent.revoke',
       groupId: 'group-1',
       purposes: ['MARKETING'],
       payload: { consentId: 'c1', status: 'REVOKED' },

--- a/dpdp-accelerator/react-apps/consent-portal/frontend/src/types/event.ts
+++ b/dpdp-accelerator/react-apps/consent-portal/frontend/src/types/event.ts
@@ -54,7 +54,7 @@ export interface EventListResponse {
 }
 
 export interface EventInput {
-  topicName: string
+  topic: string
   groupId?: string
   purposes?: string[]
   payload: Record<string, unknown>

--- a/pom.xml
+++ b/pom.xml
@@ -359,6 +359,12 @@
                 <scope>provided</scope>
             </dependency>
             <dependency>
+                <groupId>org.wso2.orbit.com.nimbusds</groupId>
+                <artifactId>nimbus-jose-jwt</artifactId>
+                <version>${nimbus.jose.jwt.version}</version>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
                 <groupId>org.wso2.carbon.identity.organization.management.core</groupId>
                 <artifactId>org.wso2.carbon.identity.organization.management.service</artifactId>
                 <version>${carbon.identity.organization.mgt.service.version}</version>
@@ -499,6 +505,7 @@
         <carbon.identity.role.mgt.core.version>7.10.156</carbon.identity.role.mgt.core.version>
         <carbon.identity.api.resource.mgt.version>7.10.156</carbon.identity.api.resource.mgt.version>
         <carbon.identity.inbound.auth.oauth.version>7.4.99</carbon.identity.inbound.auth.oauth.version>
+        <nimbus.jose.jwt.version>10.3.0.wso2v1</nimbus.jose.jwt.version>
         <carbon.identity.organization.mgt.service.version>1.5.2</carbon.identity.organization.mgt.service.version>
         <!-- 2.9.0 is missing org.wso2.carbon.consent.mgt.core.listener (ConsentManagementListener,
              AbstractConsentManagementListener) and PrivilegedConsentManager - added in 2.9.1.


### PR DESCRIPTION
 # Add tenant-aware JWS signing for Event Notification webhook payloads

## Purpose

This PR adds tenant-aware certificate signing for Event Notification webhook deliveries.

Previously, webhook deliveries sent a plain JSON event envelope protected only by an HMAC-based `event-signature` header. With this change, the complete event envelope is embedded in a compact RS256 JWS signed using the corresponding tenant's Identity Server signing key.

The existing subscription-level HMAC validation is retained as an additional verification layer.

## What changed

### 1. Tenant-aware JWS signing

Added an Event Notification signing abstraction that:

- Resolves signing material through Identity Server's tenant-aware OAuth keystore.
- Uses the tenant-specific private key.
- Produces compact RS256 JWS tokens.
- Adds the matching certificate identifiers as protected headers:
  - `kid`
  - `x5t#S256`
- Keeps key-resolution and signing logic isolated from the webhook worker.

The signing implementation follows this flow:

```
Webhook delivery
    ↓
Build event envelope
    ↓
Resolve tenant OAuth signing key and certificate
    ↓
Create JWS claims
    ↓
Sign using RS256
    ↓
Wrap compact JWS in the webhook request body
    ↓
Calculate event-signature HMAC over the exact request body
    ↓
POST to subscriber callback
```

### 2. Signed webhook body

When payload signing is enabled, the webhook body now contains only the compact JWS:

```json
{
  "signedPayload": "<base64url-header>.<base64url-claims>.<base64url-signature>"
}
```

The original event payload is not duplicated outside the JWS.

### 3. JWS protected headers

The compact JWS uses the following protected headers:

```json
{
  "alg": "RS256",
  "typ": "JWT",
  "kid": "<identity-server-key-id>",
  "x5t#S256": "<certificate-sha256-thumbprint>"
}
```

The `kid` follows the default Identity Server OAuth key identifier convention. The `x5t#S256` value is calculated from the selected tenant certificate.

### 4. JWS claims

The decoded JWS claims have the following structure:

```json
{
  "iss": "example.com",
  "sub": "example-group",
  "aud": "dpdp-event-notifications",
  "iat": 1787651970,
  "jti": "4941a812-7190-4683-9c7d-58a63de7d91d",
  "txn": "f6aa43ba-0c39-4b74-b513-396791737b4f",
  "payloadHash": "<HMAC-SHA256 of embedded event envelope>",
  "payload": {
    "deliveryId": "4941a812-7190-4683-9c7d-58a63de7d91d",
    "eventId": "f6aa43ba-0c39-4b74-b513-396791737b4f",
    "subscriptionId": "58648811-3569-45f4-ba0d-40c40f3c645f",
    "orgId": "example.com",
    "groupId": "example-group",
    "topic": "consent.revoke",
    "payload": {
      "consentId": "consent-abc123",
      "status": "REVOKED",
      "occurredAt": 1752624000000
    }
  }
}
```

#### Claim usage

| Claim | Purpose |
|-------|---------|
| iss | Tenant responsible for issuing the event |
| sub | Subscriber/group associated with the delivery |
| aud | Configured Event Notification audience |
| iat | JWS creation time in epoch seconds |
| jti | Stable delivery ID used for deduplication |
| txn | Event ID associated with the delivery |
| payloadHash | HMAC integrity value for the embedded event envelope |
| payload | Complete signed event and routing information |

When signing is explicitly disabled, the worker retains the existing plain JSON envelope protected by the HMAC `event-signature` header.

## Receiver verification flow

Webhook receivers should process signed deliveries in this order:

1. Read the raw HTTP request body without reserializing it.
2. Calculate HMAC-SHA256 over the exact body using the subscription shared secret.
3. Compare it with the `event-signature` header using a constant-time comparison.
4. Extract `signedPayload` from the outer JSON object.
5. Decode the protected JWS header.
6. Resolve the tenant certificate using `kid` or `x5t#S256`.
7. Verify the RS256 signature.
8. Validate `iss`, `sub`, `aud`, `iat`, `jti`, and `txn`.
9. Ensure the signed `orgId` and `groupId` match the expected subscription context.
10. Use `jti`/`Delivery-Id` to reject duplicate processing.
11. Process the event from the signed `payload` claim.
12. Return a `2xx` response only after accepting the event.

## Main implementation areas

- Tenant signing-key resolution
- RS256 compact JWS generation
- Typed payload-signing context
- Webhook request generation
- Event Notification configuration parser and service
- Webhook dispatch DAO projection
- Consent Portal event-publishing contract
- Event Notification documentation
- Unit tests for tenant isolation and signing behavior

## Testing

The following scenarios are covered:

- Resolving OAuth signing material for the requested tenant.
- Rejecting an empty tenant domain.
- Producing a valid three-part compact JWS.
- Verifying RS256 signatures using the expected tenant public key.
- Ensuring another tenant's key cannot verify the signature.
- Verifying `kid` and `x5t#S256`.
- Verifying the expected JWS claims.
- Ensuring the complete event envelope is embedded in the JWS.
- Ensuring the clear payload is not repeated outside the JWS.
- Verifying the outer `event-signature` against the exact request body.
- Verifying the strict `topic` request and webhook contract.
- Verifying webhook worker dispatch after the DAO projection changes.

### Test result

```
Tests run: 184
Failures: 0
Errors: 0
Skipped: 0
```

## Compatibility considerations

This changes the default webhook body when payload signing is enabled.

### Old body

```json
{
  "deliveryId": "...",
  "eventId": "...",
  "topicName": "...",
  "payload": {}
}
```

### New body

```json
{
  "signedPayload": "<compact-jws>"
}
```

Webhook receivers must therefore be updated to decode and verify `signedPayload`.

Signing can temporarily be disabled during receiver migration:

```toml
[dpdp_accelerator.event_notifications.payload_signing]
enabled = false
```