### PR TITLE
CI: allow unsafe checkout for the E2E job's fork PR head commit (main)

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -120,9 +120,17 @@ jobs:
       # silently test the wrong code - explicitly pin to the PR's own head commit. A
       # plain workflow_dispatch run has no pull_request context, so it falls back to
       # whatever ref triggered it (actions/checkout's own default).
+      #
+      # allow-unsafe-pr-checkout is required because that head commit can belong to a
+      # fork - actions/checkout otherwise refuses to fetch fork code into a
+      # pull_request_target run (the "pwn request" guard). Safe here specifically
+      # because this job only runs after a maintainer has reviewed the diff and
+      # applied the Action/trigger-e2e label (see the trigger comment above and
+      # `reset-e2e-label-on-push` below) - same pattern FS Accelerator's maven.yml uses.
       - uses: actions/checkout@v5
         with:
           ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || '' }}
+          allow-unsafe-pr-checkout: ${{ github.event_name == 'pull_request_target' }}
           persist-credentials: false
 
       - uses: actions/setup-java@v5


### PR DESCRIPTION
## Summary
- Same fix as #47, applied to `main` to keep it in sync (main and dev are currently kept identical for this workflow file).
- `actions/checkout@v5` refuses to fetch a fork PR's head commit inside a `pull_request_target` run by default (the "pwn request" guard) - confirmed live on PR #43, where the `e2e` job failed at checkout with: `Refusing to check out fork pull request code from a 'pull_request_target' workflow ... set 'allow-unsafe-pr-checkout: true'`.
- Adds `allow-unsafe-pr-checkout: ${{ github.event_name == 'pull_request_target' }}` to the `e2e` job's checkout step - same pattern FS Accelerator's `maven.yml` already uses.

## Test plan
- [ ] Merge alongside #47 so main/dev stay identical for this file