### PR TITLE
Fix consent history gaps and improve the UI for latest IS consent API changes

### DIFF
--- a/dpdp-accelerator/accelerators/dpdp-is/bin/merge.sh
+++ b/dpdp-accelerator/accelerators/dpdp-is/bin/merge.sh
@@ -38,15 +38,21 @@ if [ ! -d "${WSO2_IS_HOME}/repository/components" ]; then
 fi
 
 WEBAPPS_PATH="${WSO2_IS_HOME}/repository/deployment/server/webapps"
-PORTAL_PATH="${WEBAPPS_PATH}/consent-portal"
 
-if [ -d "${PORTAL_PATH}" ]; then
-  # A stale exploded webapp from an older accelerator version would be
-  # redeployed alongside the fresh WAR otherwise.
-  echo "Removing the previously deployed consent portal"
-  rm -rf "${PORTAL_PATH}"
-fi
-rm -f "${WEBAPPS_PATH}/consent-portal.war"
+# A stale exploded webapp from an older accelerator version would otherwise sit
+# alongside the fresh one - `cp -r` below only adds/overwrites, it never removes
+# a destination file the new build no longer has (a renamed WEB-INF/lib jar, a
+# deleted class). Driven off the accelerator's own webapps so a future webapp
+# is covered automatically instead of needing another hardcoded block.
+for webapp in "${ACCELERATOR_HOME}"/carbon-home/repository/deployment/server/webapps/*/; do
+  name="$(basename "${webapp}")"
+  target="${WEBAPPS_PATH}/${name}"
+  if [ -d "${target}" ]; then
+    echo "Removing the previously deployed ${name}"
+    rm -rf "${target}"
+  fi
+  rm -f "${WEBAPPS_PATH}/${name}.war"
+done
 
 # Same as above for the complaint-mgt and event notification endpoints: a WAR finalName
 # change (context path rename) would otherwise leave the old context deployed alongside

--- a/dpdp-accelerator/accelerators/dpdp-is/bin/merge.sh
+++ b/dpdp-accelerator/accelerators/dpdp-is/bin/merge.sh
@@ -54,14 +54,6 @@ for webapp in "${ACCELERATOR_HOME}"/carbon-home/repository/deployment/server/web
   rm -f "${WEBAPPS_PATH}/${name}.war"
 done
 
-# Same as above for the complaint-mgt and event notification endpoints: a WAR finalName
-# change (context path rename) would otherwise leave the old context deployed alongside
-# the new one, both claiming overlapping paths under the same API root.
-echo "Removing the previously deployed complaint-mgt endpoint"
-find "${WEBAPPS_PATH}" -maxdepth 1 -name "api#dpdp#complaints*" -exec rm -rf {} +
-echo "Removing the previously deployed event notification endpoint"
-find "${WEBAPPS_PATH}" -maxdepth 1 -name "api#dpdp#event-notifications*" -exec rm -rf {} +
-
 # Likewise for dropins: a stale jar from an older accelerator version (renamed class,
 # version bump) would otherwise sit alongside the new one and load as a duplicate bundle.
 echo "Removing old DPDP accelerator artifacts from the product"

--- a/dpdp-accelerator/accelerators/dpdp-is/repository/resources/wso2is-7.3.0-deployment.toml
+++ b/dpdp-accelerator/accelerators/dpdp-is/repository/resources/wso2is-7.3.0-deployment.toml
@@ -384,7 +384,7 @@ allowed_callback_ports = "-1,80,443,8443"
 # Set true only for controlled/on-prem deployments where a webhook receiver legitimately lives
 # on a private/internal network (RFC1918, link-local, IPv6 unique-local). Loopback, wildcard,
 # and multicast targets are always rejected regardless of this setting.
-allow_private_network_callback_targets = true
+allow_private_network_callback_targets = false
 delivery_worker_batch_size = 50
 delivery_worker_poll_seconds = 5
 stuck_inflight_threshold_seconds = 10

--- a/dpdp-accelerator/accelerators/dpdp-is/repository/resources/wso2is-7.3.0-deployment.toml
+++ b/dpdp-accelerator/accelerators/dpdp-is/repository/resources/wso2is-7.3.0-deployment.toml
@@ -2,7 +2,6 @@
 hostname = "IS_HOSTNAME"
 node_ip = "127.0.0.1"
 base_path = "https://$ref{server.hostname}:${carbon.management.port}"
-offset = 3
 
 [super_admin]
 username = "IS_ADMIN_USERNAME"
@@ -413,5 +412,5 @@ snapshot_enabled = true
 # requirements" section of docs/configuration-guide.md before relying on this in production.
 [dpdp_accelerator.consent_expiry]
 enabled = true
-cron_value = "0 0/2 * ? * * *"
+cron_value = "0 0 0 * * ?"
 batch_size = 100

--- a/dpdp-accelerator/accelerators/dpdp-is/repository/resources/wso2is-7.3.0-deployment.toml
+++ b/dpdp-accelerator/accelerators/dpdp-is/repository/resources/wso2is-7.3.0-deployment.toml
@@ -2,6 +2,7 @@
 hostname = "IS_HOSTNAME"
 node_ip = "127.0.0.1"
 base_path = "https://$ref{server.hostname}:${carbon.management.port}"
+offset = 3
 
 [super_admin]
 username = "IS_ADMIN_USERNAME"
@@ -384,7 +385,7 @@ allowed_callback_ports = "-1,80,443,8443"
 # Set true only for controlled/on-prem deployments where a webhook receiver legitimately lives
 # on a private/internal network (RFC1918, link-local, IPv6 unique-local). Loopback, wildcard,
 # and multicast targets are always rejected regardless of this setting.
-allow_private_network_callback_targets = false
+allow_private_network_callback_targets = true
 delivery_worker_batch_size = 50
 delivery_worker_poll_seconds = 5
 stuck_inflight_threshold_seconds = 10
@@ -412,5 +413,5 @@ snapshot_enabled = true
 # requirements" section of docs/configuration-guide.md before relying on this in production.
 [dpdp_accelerator.consent_expiry]
 enabled = true
-cron_value = "0 0 0 * * ?"
+cron_value = "0 0/2 * ? * * *"
 batch_size = 100

--- a/dpdp-accelerator/components/org.wso2.dpdp.accelerator.identity.extensions/src/main/java/org/wso2/dpdp/accelerator/identity/extensions/consent/DPDPConsentHistoryListener.java
+++ b/dpdp-accelerator/components/org.wso2.dpdp.accelerator.identity.extensions/src/main/java/org/wso2/dpdp/accelerator/identity/extensions/consent/DPDPConsentHistoryListener.java
@@ -102,19 +102,29 @@ public class DPDPConsentHistoryListener extends AbstractConsentManagementListene
     @Override
     public void postUpdateConsent(ReceiptUpdateInput updateInput, String tenantDomain) {
 
-        // ReceiptUpdateInput carries no state field - update never changes the consent's
-        // lifecycle status, so previous and current are the same captured pre-mutation value.
+        // Unlike revoke/delete, an update's outcome status isn't fixed in advance - pushing the
+        // expiry into the past or future can flip the resolved state (see
+        // DPDPConsentExpiryReconciler), so the current status is re-read live here, same as
+        // postAuthorizeConsent already does, instead of assuming it matches the pre-mutation value.
+        String consentId = updateInput.getConsentReceiptId();
         String previousStatus = takePreviousStatus();
-        recordStatusAudit(updateInput.getConsentReceiptId(), tenantDomain, previousStatus, previousStatus,
-                ActionType.UPDATE);
-        captureSnapshot(updateInput.getConsentReceiptId(), tenantDomain, ActionType.UPDATE);
+        try {
+            PrivilegedConsentManager consentManager = DPDPIdentityExtensionDataHolder.getInstance()
+                    .getPrivilegedConsentManager();
+            Receipt receipt = consentManager.getReceiptWithExtendedSchema(consentId);
+            String currentStatus = receipt.getState();
+            recordStatusAudit(consentId, tenantDomain, previousStatus, currentStatus, ActionType.UPDATE);
+            captureSnapshotFromReceipt(tenantDomain, consentId, ActionType.UPDATE, consentManager, receipt);
+        } catch (Exception e) {
+            LOG.error("Error reading the post-update state for consent: " + sanitize(consentId), e);
+        }
 
         // isClearExpiry() and getExpiryTime() are the two distinct signals an update can carry -
         // neither set means this update didn't touch expiry at all, so the tracker is left alone.
         if (updateInput.isClearExpiry()) {
-            untrackExpiry(updateInput.getConsentReceiptId(), tenantDomain);
+            untrackExpiry(consentId, tenantDomain);
         } else if (updateInput.getExpiryTime() != null) {
-            trackExpiry(updateInput.getConsentReceiptId(), tenantDomain, updateInput.getExpiryTime());
+            trackExpiry(consentId, tenantDomain, updateInput.getExpiryTime());
         }
     }
 
@@ -171,7 +181,7 @@ public class DPDPConsentHistoryListener extends AbstractConsentManagementListene
             String currentStatus = receipt.getState();
             ActionType actionType = mapAuthorizeActionType(authStatus);
             recordStatusAudit(consentId, tenantDomain, previousStatus, currentStatus, actionType);
-            captureAuthorizeSnapshot(tenantDomain, consentId, actionType, consentManager, receipt);
+            captureSnapshotFromReceipt(tenantDomain, consentId, actionType, consentManager, receipt);
 
             // REJECTED/REVOKED can never resolve to EXPIRED (see DPDPConsentExpiryReconciler) -
             // only ACTIVE/PENDING are worth tracking. Re-checked on every call, so a consent that
@@ -239,12 +249,12 @@ public class DPDPConsentHistoryListener extends AbstractConsentManagementListene
     }
 
     /**
-     * {@code postAuthorizeConsent} already has the receipt in hand from resolving the current
-     * status - reused here instead of a second, redundant fetch. Caught separately from that
-     * caller's own try block so a snapshot failure can't also skip the expiry tracking that
-     * follows it.
+     * Shared by {@code postAuthorizeConsent} and {@code postUpdateConsent} - both already have the
+     * receipt in hand from resolving the current status, so it's reused here instead of a second,
+     * redundant fetch. Caught separately from the caller's own try block so a snapshot failure
+     * can't also skip the expiry tracking that follows it there.
      */
-    private void captureAuthorizeSnapshot(String tenantDomain, String consentId, ActionType actionType,
+    private void captureSnapshotFromReceipt(String tenantDomain, String consentId, ActionType actionType,
             PrivilegedConsentManager consentManager, Receipt receipt) {
 
         try {

--- a/dpdp-accelerator/internal-webapps/org.wso2.dpdp.accelerator.consent.mgt.extensions.endpoint/src/main/java/org/wso2/dpdp/accelerator/consent/mgt/extensions/endpoint/api/ConsentHistorySelfApi.java
+++ b/dpdp-accelerator/internal-webapps/org.wso2.dpdp.accelerator.consent.mgt.extensions.endpoint/src/main/java/org/wso2/dpdp/accelerator/consent/mgt/extensions/endpoint/api/ConsentHistorySelfApi.java
@@ -23,6 +23,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.consent.mgt.core.PrivilegedConsentManager;
 import org.wso2.carbon.consent.mgt.core.exception.ConsentManagementException;
+import org.wso2.carbon.consent.mgt.core.model.ConsentAuthorization;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
 import org.wso2.dpdp.accelerator.consent.extensions.dao.exceptions.ConsentHistoryDataRetrievalException;
 import org.wso2.dpdp.accelerator.consent.extensions.dao.models.ConsentHistoryRecord;
@@ -34,6 +35,8 @@ import org.wso2.dpdp.accelerator.consent.mgt.extensions.endpoint.exception.Conse
 import org.wso2.dpdp.accelerator.consent.mgt.extensions.endpoint.util.ConsentHistoryEndpointUtil;
 import org.wso2.dpdp.accelerator.consent.extensions.service.ConsentHistoryService;
 import org.wso2.dpdp.accelerator.consent.extensions.service.models.PagedResult;
+
+import java.util.List;
 
 import javax.ws.rs.DefaultValue;
 import javax.ws.rs.GET;
@@ -63,7 +66,7 @@ public class ConsentHistorySelfApi {
 
         ConsentHistoryEndpointUtil.validatePagination(limit, offset);
         String tenantDomain = PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantDomain();
-        requireCallerOwnsConsent(consentId);
+        requireCallerInvolvedInConsent(consentId);
         try {
             PagedResult<ConsentStatusAuditRecord> result = getConsentHistoryService()
                     .getStatusAuditHistory(tenantDomain, consentId, limit, offset);
@@ -86,7 +89,7 @@ public class ConsentHistorySelfApi {
 
         ConsentHistoryEndpointUtil.validatePagination(limit, offset);
         String tenantDomain = PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantDomain();
-        requireCallerOwnsConsent(consentId);
+        requireCallerInvolvedInConsent(consentId);
         try {
             PagedResult<ConsentHistoryRecord> result = getConsentHistoryService()
                     .getConsentHistory(tenantDomain, consentId, limit, offset);
@@ -101,13 +104,19 @@ public class ConsentHistorySelfApi {
         }
     }
 
-    private void requireCallerOwnsConsent(String consentId) {
+    /**
+     * A delegated consent (e.g. a guardian authorizing on behalf of a dependent) legitimately
+     * concerns more than one person - both the subject and whoever is listed on it as an
+     * authorizer need to be able to read its history, not just the subject.
+     */
+    private void requireCallerInvolvedInConsent(String consentId) {
 
         String callerUsername = PrivilegedCarbonContext.getThreadLocalCarbonContext().getUsername();
         try {
-            String piiPrincipalId = getPrivilegedConsentManager().getReceiptWithExtendedSchema(consentId)
-                    .getPiiPrincipalId();
-            ConsentHistoryEndpointUtil.requireOwner(callerUsername, piiPrincipalId);
+            PrivilegedConsentManager consentManager = getPrivilegedConsentManager();
+            String piiPrincipalId = consentManager.getReceiptWithExtendedSchema(consentId).getPiiPrincipalId();
+            List<ConsentAuthorization> authorizations = consentManager.getConsentAuthorizations(consentId);
+            ConsentHistoryEndpointUtil.requireInvolved(callerUsername, piiPrincipalId, authorizations);
         } catch (ConsentManagementException e) {
             LOG.debug("Could not resolve consent " + sanitize(consentId) + " for the ownership check.", e);
             throw new ConsentHistoryEndpointException(Response.Status.NOT_FOUND.getStatusCode(),

--- a/dpdp-accelerator/internal-webapps/org.wso2.dpdp.accelerator.consent.mgt.extensions.endpoint/src/main/java/org/wso2/dpdp/accelerator/consent/mgt/extensions/endpoint/util/ConsentHistoryEndpointUtil.java
+++ b/dpdp-accelerator/internal-webapps/org.wso2.dpdp.accelerator.consent.mgt.extensions.endpoint/src/main/java/org/wso2/dpdp/accelerator/consent/mgt/extensions/endpoint/util/ConsentHistoryEndpointUtil.java
@@ -20,6 +20,7 @@ package org.wso2.dpdp.accelerator.consent.mgt.extensions.endpoint.util;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.wso2.carbon.consent.mgt.core.model.ConsentAuthorization;
 import org.wso2.dpdp.accelerator.consent.extensions.dao.models.ConsentHistoryRecord;
 import org.wso2.dpdp.accelerator.consent.extensions.dao.models.ConsentStatusAuditRecord;
 import org.wso2.dpdp.accelerator.consent.mgt.extensions.endpoint.dto.ActionType;
@@ -84,6 +85,40 @@ public final class ConsentHistoryEndpointUtil {
             throw new ConsentHistoryEndpointException(Response.Status.FORBIDDEN.getStatusCode(),
                     ConsentHistoryErrorCodes.FORBIDDEN_NOT_OWNER,
                     "The authenticated user is not the owner of this consent.");
+        }
+    }
+
+    /**
+     * True when the caller is the consent's own subject, or is listed as one of its authorizers -
+     * a delegated consent (e.g. a guardian authorizing on behalf of a dependent) legitimately
+     * concerns both. Mirrors the frontend's {@code isCurrentUserInvolved}. {@code authorizations}
+     * never carries an entry for the subject itself, so the {@link #isOwner} check still has to
+     * run separately even once authorizers are considered.
+     */
+    public static boolean isInvolved(String callerUsername, String piiPrincipalId,
+            List<ConsentAuthorization> authorizations) {
+
+        if (isOwner(callerUsername, piiPrincipalId)) {
+            return true;
+        }
+        if (callerUsername == null || authorizations == null) {
+            return false;
+        }
+        for (ConsentAuthorization authorization : authorizations) {
+            if (callerUsername.equals(authorization.getUserId())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public static void requireInvolved(String callerUsername, String piiPrincipalId,
+            List<ConsentAuthorization> authorizations) {
+
+        if (!isInvolved(callerUsername, piiPrincipalId, authorizations)) {
+            throw new ConsentHistoryEndpointException(Response.Status.FORBIDDEN.getStatusCode(),
+                    ConsentHistoryErrorCodes.FORBIDDEN_NOT_OWNER,
+                    "The authenticated user is neither the subject nor an authorizer of this consent.");
         }
     }
 

--- a/dpdp-accelerator/internal-webapps/org.wso2.dpdp.accelerator.consent.mgt.extensions.endpoint/src/main/resources/consent-history.yaml
+++ b/dpdp-accelerator/internal-webapps/org.wso2.dpdp.accelerator.consent.mgt.extensions.endpoint/src/main/resources/consent-history.yaml
@@ -16,10 +16,11 @@ tags:
       anything in this webapp.
   - name: self
     description: >-
-      Requires the named consent:<resource>:view:self scope; ownership of the specific consent is
-      additionally checked in code by comparing the caller's username against the consent's PII
-      principal ID - the scope only gates whether the caller can reach the route at all, never
-      which row they're allowed to see.
+      Requires the named consent:<resource>:view:self scope; involvement in the specific consent
+      is additionally checked in code - the caller must either be the consent's PII principal, or
+      be listed as one of its authorizers (e.g. a guardian authorizing on behalf of a dependent).
+      The scope only gates whether the caller can reach the route at all, never which row they're
+      allowed to see.
 paths:
   /consents/{consentId}/status-history:
     get:

--- a/dpdp-accelerator/internal-webapps/org.wso2.dpdp.accelerator.consent.mgt.extensions.endpoint/src/test/java/org/wso2/dpdp/accelerator/consent/mgt/extensions/endpoint/util/ConsentHistoryEndpointUtilTest.java
+++ b/dpdp-accelerator/internal-webapps/org.wso2.dpdp.accelerator.consent.mgt.extensions.endpoint/src/test/java/org/wso2/dpdp/accelerator/consent/mgt/extensions/endpoint/util/ConsentHistoryEndpointUtilTest.java
@@ -21,6 +21,7 @@ package org.wso2.dpdp.accelerator.consent.mgt.extensions.endpoint.util;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.testng.annotations.Test;
+import org.wso2.carbon.consent.mgt.core.model.ConsentAuthorization;
 import org.wso2.dpdp.accelerator.consent.extensions.dao.models.ConsentHistoryRecord;
 import org.wso2.dpdp.accelerator.consent.extensions.dao.models.ConsentStatusAuditRecord;
 import org.wso2.dpdp.accelerator.consent.mgt.extensions.endpoint.dto.ConsentHistoryResponseDTO;
@@ -29,6 +30,7 @@ import org.wso2.dpdp.accelerator.consent.mgt.extensions.endpoint.exception.Conse
 import org.wso2.dpdp.accelerator.consent.extensions.service.models.PagedResult;
 
 import java.util.Collections;
+import java.util.List;
 
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
@@ -85,6 +87,54 @@ public class ConsentHistoryEndpointUtilTest {
 
         expectThrows(ConsentHistoryEndpointException.class,
                 () -> ConsentHistoryEndpointUtil.requireOwner("jdoe@carbon.super", "other@carbon.super"));
+    }
+
+    @Test
+    public void isInvolvedTreatsTheSubjectAsInvolved() {
+
+        assertTrue(ConsentHistoryEndpointUtil.isInvolved("jdoe@carbon.super", "jdoe@carbon.super",
+                Collections.emptyList()));
+    }
+
+    @Test
+    public void isInvolvedTreatsAListedAuthorizerAsInvolved() {
+
+        List<ConsentAuthorization> authorizations = Collections
+                .singletonList(new ConsentAuthorization("consent-1234", "guardian@carbon.super",
+                        ConsentAuthorization.AuthorizationStatus.APPROVED, 1L, "PARENT"));
+
+        assertTrue(ConsentHistoryEndpointUtil.isInvolved("guardian@carbon.super", "child@carbon.super",
+                authorizations));
+    }
+
+    @Test
+    public void isInvolvedRejectsAnUninvolvedCaller() {
+
+        List<ConsentAuthorization> authorizations = Collections
+                .singletonList(new ConsentAuthorization("consent-1234", "guardian@carbon.super",
+                        ConsentAuthorization.AuthorizationStatus.APPROVED, 1L, "PARENT"));
+
+        assertFalse(ConsentHistoryEndpointUtil.isInvolved("stranger@carbon.super", "child@carbon.super",
+                authorizations));
+        assertFalse(ConsentHistoryEndpointUtil.isInvolved("stranger@carbon.super", "child@carbon.super", null));
+        assertFalse(ConsentHistoryEndpointUtil.isInvolved(null, "child@carbon.super", authorizations));
+    }
+
+    @Test
+    public void requireInvolvedThrowsForAnUninvolvedCaller() {
+
+        expectThrows(ConsentHistoryEndpointException.class, () -> ConsentHistoryEndpointUtil
+                .requireInvolved("stranger@carbon.super", "child@carbon.super", Collections.emptyList()));
+    }
+
+    @Test
+    public void requireInvolvedPassesForAListedAuthorizer() {
+
+        List<ConsentAuthorization> authorizations = Collections
+                .singletonList(new ConsentAuthorization("consent-1234", "guardian@carbon.super",
+                        ConsentAuthorization.AuthorizationStatus.APPROVED, 1L, "PARENT"));
+
+        ConsentHistoryEndpointUtil.requireInvolved("guardian@carbon.super", "child@carbon.super", authorizations);
     }
 
     @Test

--- a/dpdp-accelerator/react-apps/consent-portal/frontend/public/i18n/as/common.json
+++ b/dpdp-accelerator/react-apps/consent-portal/frontend/public/i18n/as/common.json
@@ -93,7 +93,14 @@
       "serviceId": "সেৱা",
       "removeConsentIdForState": "ৰাজ্যিক ফিল্টাৰ ব্যৱহাৰ কৰিবলৈ সন্মতি আইডি ফিল্টাৰটো আঁতৰাওক।",
       "propertyFilterLabel": "সন্মতিৰ সম্পত্তি",
-      "removeConsentIdForSubject": "ইউজাৰ আইডি ফিল্টাৰ ব্যৱহাৰ কৰিবলৈ কনছেণ্ট আইডি ফিল্টাৰটো আঁতৰাওক।"
+      "removeConsentIdForSubject": "ইউজাৰ আইডি ফিল্টাৰ ব্যৱহাৰ কৰিবলৈ কনছেণ্ট আইডি ফিল্টাৰটো আঁতৰাওক।",
+      "relation": "Relation",
+      "relationHelperText": "Set a User to filter by relation",
+      "relationOptions": {
+        "any": "Any",
+        "subject": "Subject",
+        "authorizer": "Authorizer"
+      }
     }
   },
   "consentRegistry": {
@@ -246,7 +253,13 @@
       "clear": "সকলো মচি পেলাওক",
       "clearAriaLabel": "সকলো ফিল্টাৰ মচি পেলাওক",
       "serviceSearchPlaceholder": "সেৱা অনুসৰি সন্ধান কৰক",
-      "state": "ৰাজ্য"
+      "state": "ৰাজ্য",
+      "relation": "Relation",
+      "relationOptions": {
+        "any": "All",
+        "subject": "My Own",
+        "authorizer": "Managed by Me"
+      }
     },
     "messages": {
       "loading": "সন্মতিসমূহ ল'ড হৈ আছে...",

--- a/dpdp-accelerator/react-apps/consent-portal/frontend/public/i18n/bn/common.json
+++ b/dpdp-accelerator/react-apps/consent-portal/frontend/public/i18n/bn/common.json
@@ -93,7 +93,14 @@
       "serviceId": "পরিষেবা",
       "removeConsentIdForState": "স্টেট ফিল্টার ব্যবহার করার জন্য সম্মতি আইডি ফিল্টারটি সরান।",
       "propertyFilterLabel": "সম্মতি সম্পত্তি",
-      "removeConsentIdForSubject": "ইউজার আইডি ফিল্টার ব্যবহার করার জন্য কনসেন্ট আইডি ফিল্টারটি সরান।"
+      "removeConsentIdForSubject": "ইউজার আইডি ফিল্টার ব্যবহার করার জন্য কনসেন্ট আইডি ফিল্টারটি সরান।",
+      "relation": "Relation",
+      "relationHelperText": "Set a User to filter by relation",
+      "relationOptions": {
+        "any": "Any",
+        "subject": "Subject",
+        "authorizer": "Authorizer"
+      }
     }
   },
   "consentRegistry": {
@@ -246,7 +253,13 @@
       "clear": "সব মুছুন",
       "clearAriaLabel": "সমস্ত ফিল্টার মুছুন",
       "serviceSearchPlaceholder": "পরিষেবা অনুসারে অনুসন্ধান করুন",
-      "state": "রাজ্য"
+      "state": "রাজ্য",
+      "relation": "Relation",
+      "relationOptions": {
+        "any": "All",
+        "subject": "My Own",
+        "authorizer": "Managed by Me"
+      }
     },
     "messages": {
       "loading": "সম্মতিসমূহ লোড হচ্ছে...",

--- a/dpdp-accelerator/react-apps/consent-portal/frontend/public/i18n/brx/common.json
+++ b/dpdp-accelerator/react-apps/consent-portal/frontend/public/i18n/brx/common.json
@@ -93,7 +93,14 @@
       "serviceId": "सिबिथाइ",
       "removeConsentIdForState": "रायजोनि फिल्टारखौ बाहायनो थाखाय गनायथि आइ.डि. फिल्टारखौ बोखार।",
       "propertyFilterLabel": "गनायथि सम्फथि",
-      "removeConsentIdForSubject": "इउजार आइ.डि. फिल्टारखौ बाहायनो थाखाय कन्सेन्ट आइ.डि. फिल्टारखौ बोखार।"
+      "removeConsentIdForSubject": "इउजार आइ.डि. फिल्टारखौ बाहायनो थाखाय कन्सेन्ट आइ.डि. फिल्टारखौ बोखार।",
+      "relation": "Relation",
+      "relationHelperText": "Set a User to filter by relation",
+      "relationOptions": {
+        "any": "Any",
+        "subject": "Subject",
+        "authorizer": "Authorizer"
+      }
     }
   },
   "consentRegistry": {
@@ -246,7 +253,13 @@
       "clear": "गासै बोखार",
       "clearAriaLabel": "गासै फिल्टरफोरखौ बोखार",
       "serviceSearchPlaceholder": "सिबिथायजों नागिर",
-      "state": "रायजो"
+      "state": "रायजो",
+      "relation": "Relation",
+      "relationOptions": {
+        "any": "All",
+        "subject": "My Own",
+        "authorizer": "Managed by Me"
+      }
     },
     "messages": {
       "loading": "गनायथिफोरखौ लोड खालामफुगासिनो...",

--- a/dpdp-accelerator/react-apps/consent-portal/frontend/public/i18n/doi/common.json
+++ b/dpdp-accelerator/react-apps/consent-portal/frontend/public/i18n/doi/common.json
@@ -93,7 +93,14 @@
       "serviceId": "सेवा",
       "removeConsentIdForState": "स्टेट फिल्टर दा इस्तेमाल करने आस्तै सहमति आईडी फिल्टर हटाइयै रक्खो।",
       "propertyFilterLabel": "सहमति संपत्ति",
-      "removeConsentIdForSubject": "यूजर आईडी फिल्टर दा इस्तेमाल करने आस्तै सहमति आईडी फिल्टर हटाई देओ।"
+      "removeConsentIdForSubject": "यूजर आईडी फिल्टर दा इस्तेमाल करने आस्तै सहमति आईडी फिल्टर हटाई देओ।",
+      "relation": "Relation",
+      "relationHelperText": "Set a User to filter by relation",
+      "relationOptions": {
+        "any": "Any",
+        "subject": "Subject",
+        "authorizer": "Authorizer"
+      }
     }
   },
   "consentRegistry": {
@@ -246,7 +253,13 @@
       "clear": "सब साफ करो",
       "clearAriaLabel": "सारे फिल्टर साफ करो",
       "serviceSearchPlaceholder": "सेवा राहें तुप्पो",
-      "state": "राज्य"
+      "state": "राज्य",
+      "relation": "Relation",
+      "relationOptions": {
+        "any": "All",
+        "subject": "My Own",
+        "authorizer": "Managed by Me"
+      }
     },
     "messages": {
       "loading": "सहमतियां लोड होआ करदियां न...",

--- a/dpdp-accelerator/react-apps/consent-portal/frontend/public/i18n/en/common.json
+++ b/dpdp-accelerator/react-apps/consent-portal/frontend/public/i18n/en/common.json
@@ -93,7 +93,14 @@
       "serviceId": "Service",
       "removeConsentIdForState": "Remove the Consent ID filter to use the state filter.",
       "propertyFilterLabel": "Consent property",
-      "removeConsentIdForSubject": "Remove the Consent ID filter to use the User ID filter."
+      "removeConsentIdForSubject": "Remove the Consent ID filter to use the User ID filter.",
+      "relation": "Relation",
+      "relationHelperText": "Set a User to filter by relation",
+      "relationOptions": {
+        "any": "Any",
+        "subject": "Subject",
+        "authorizer": "Authorizer"
+      }
     }
   },
   "consentRegistry": {
@@ -246,7 +253,13 @@
       "clear": "Clear all",
       "clearAriaLabel": "Clear all filters",
       "serviceSearchPlaceholder": "Search by service",
-      "state": "State"
+      "state": "State",
+      "relation": "Relation",
+      "relationOptions": {
+        "any": "All",
+        "subject": "My Own",
+        "authorizer": "Managed by Me"
+      }
     },
     "messages": {
       "loading": "Loading consents...",

--- a/dpdp-accelerator/react-apps/consent-portal/frontend/public/i18n/gu/common.json
+++ b/dpdp-accelerator/react-apps/consent-portal/frontend/public/i18n/gu/common.json
@@ -93,7 +93,14 @@
       "serviceId": "સેવા",
       "removeConsentIdForState": "રાજ્ય ફિલ્ટરનો ઉપયોગ કરવા માટે સંમતિ ID ફિલ્ટર દૂર કરો.",
       "propertyFilterLabel": "સંમતિ મિલકત",
-      "removeConsentIdForSubject": "યુઝર આઈડી ફિલ્ટરનો ઉપયોગ કરવા માટે સંમતિ આઈડી ફિલ્ટર દૂર કરો."
+      "removeConsentIdForSubject": "યુઝર આઈડી ફિલ્ટરનો ઉપયોગ કરવા માટે સંમતિ આઈડી ફિલ્ટર દૂર કરો.",
+      "relation": "Relation",
+      "relationHelperText": "Set a User to filter by relation",
+      "relationOptions": {
+        "any": "Any",
+        "subject": "Subject",
+        "authorizer": "Authorizer"
+      }
     }
   },
   "consentRegistry": {
@@ -246,7 +253,13 @@
       "clear": "તમામ સાફ કરો",
       "clearAriaLabel": "બધા ફિલ્ટર્સ સાફ કરો",
       "serviceSearchPlaceholder": "સેવા દ્વારા શોધો",
-      "state": "રાજ્ય"
+      "state": "રાજ્ય",
+      "relation": "Relation",
+      "relationOptions": {
+        "any": "All",
+        "subject": "My Own",
+        "authorizer": "Managed by Me"
+      }
     },
     "messages": {
       "loading": "સંમતિઓ લોડ થઈ રહી છે...",

--- a/dpdp-accelerator/react-apps/consent-portal/frontend/public/i18n/hi/common.json
+++ b/dpdp-accelerator/react-apps/consent-portal/frontend/public/i18n/hi/common.json
@@ -93,7 +93,14 @@
       "serviceId": "सेवा",
       "removeConsentIdForState": "स्टेट फ़िल्टर का उपयोग करने के लिए सहमति आईडी फ़िल्टर हटाएँ।",
       "propertyFilterLabel": "सहमति संपत्ति",
-      "removeConsentIdForSubject": "यूज़र आईडी फ़िल्टर का उपयोग करने के लिए सहमति आईडी फ़िल्टर हटाएँ।"
+      "removeConsentIdForSubject": "यूज़र आईडी फ़िल्टर का उपयोग करने के लिए सहमति आईडी फ़िल्टर हटाएँ।",
+      "relation": "Relation",
+      "relationHelperText": "Set a User to filter by relation",
+      "relationOptions": {
+        "any": "Any",
+        "subject": "Subject",
+        "authorizer": "Authorizer"
+      }
     }
   },
   "consentRegistry": {
@@ -246,7 +253,13 @@
       "clear": "सभी हटाएं",
       "clearAriaLabel": "सभी फ़िल्टर हटाएं",
       "serviceSearchPlaceholder": "सेवा के अनुसार खोजें",
-      "state": "राज्य"
+      "state": "राज्य",
+      "relation": "Relation",
+      "relationOptions": {
+        "any": "All",
+        "subject": "My Own",
+        "authorizer": "Managed by Me"
+      }
     },
     "messages": {
       "loading": "सहमतियां लोड हो रही हैं...",

--- a/dpdp-accelerator/react-apps/consent-portal/frontend/public/i18n/kn/common.json
+++ b/dpdp-accelerator/react-apps/consent-portal/frontend/public/i18n/kn/common.json
@@ -93,7 +93,14 @@
       "serviceId": "ಸೇವೆ",
       "removeConsentIdForState": "ರಾಜ್ಯ ಫಿಲ್ಟರ್ ಅನ್ನು ಬಳಸಲು ಸಮ್ಮತಿ ID ಫಿಲ್ಟರ್ ಅನ್ನು ತೆಗೆದುಹಾಕಿ.",
       "propertyFilterLabel": "ಸಮ್ಮತಿ ಆಸ್ತಿ",
-      "removeConsentIdForSubject": "ಬಳಕೆದಾರರ ಐಡಿ ಫಿಲ್ಟರ್ ಅನ್ನು ಬಳಸಲು ಸಮ್ಮತಿ ಐಡಿ ಫಿಲ್ಟರ್ ಅನ್ನು ತೆಗೆದುಹಾಕಿ."
+      "removeConsentIdForSubject": "ಬಳಕೆದಾರರ ಐಡಿ ಫಿಲ್ಟರ್ ಅನ್ನು ಬಳಸಲು ಸಮ್ಮತಿ ಐಡಿ ಫಿಲ್ಟರ್ ಅನ್ನು ತೆಗೆದುಹಾಕಿ.",
+      "relation": "Relation",
+      "relationHelperText": "Set a User to filter by relation",
+      "relationOptions": {
+        "any": "Any",
+        "subject": "Subject",
+        "authorizer": "Authorizer"
+      }
     }
   },
   "consentRegistry": {
@@ -246,7 +253,13 @@
       "clear": "ಎಲ್ಲವನ್ನೂ ತೆರವುಗೊಳಿಸಿ",
       "clearAriaLabel": "ಎಲ್ಲಾ ಫಿಲ್ಟರ್‌ಗಳನ್ನು ತೆರವುಗೊಳಿಸಿ",
       "serviceSearchPlaceholder": "ಸೇವೆಯಿಂದ ಹುಡುಕಿ",
-      "state": "ರಾಜ್ಯ"
+      "state": "ರಾಜ್ಯ",
+      "relation": "Relation",
+      "relationOptions": {
+        "any": "All",
+        "subject": "My Own",
+        "authorizer": "Managed by Me"
+      }
     },
     "messages": {
       "loading": "ಸಮ್ಮತಿಗಳನ್ನು ಲೋಡ್ ಮಾಡಲಾಗುತ್ತಿದೆ...",

--- a/dpdp-accelerator/react-apps/consent-portal/frontend/public/i18n/kok/common.json
+++ b/dpdp-accelerator/react-apps/consent-portal/frontend/public/i18n/kok/common.json
@@ -93,7 +93,14 @@
       "serviceId": "सेवा",
       "removeConsentIdForState": "राज्य फिल्टर वापरपा खातीर संमती आयडी फिल्टर काडून उडयात.",
       "propertyFilterLabel": "संमती मालमत्ता",
-      "removeConsentIdForSubject": "युजर आयडी फिल्टर वापरपा खातीर संमती आयडी फिल्टर काडून उडयात."
+      "removeConsentIdForSubject": "युजर आयडी फिल्टर वापरपा खातीर संमती आयडी फिल्टर काडून उडयात.",
+      "relation": "Relation",
+      "relationHelperText": "Set a User to filter by relation",
+      "relationOptions": {
+        "any": "Any",
+        "subject": "Subject",
+        "authorizer": "Authorizer"
+      }
     }
   },
   "consentRegistry": {
@@ -246,7 +253,13 @@
       "clear": "सगळे पुसून उडयात",
       "clearAriaLabel": "सगळे फिल्टर पुसून उडयात",
       "serviceSearchPlaceholder": "सेवे प्रमाण सोदचें",
-      "state": "राज्य"
+      "state": "राज्य",
+      "relation": "Relation",
+      "relationOptions": {
+        "any": "All",
+        "subject": "My Own",
+        "authorizer": "Managed by Me"
+      }
     },
     "messages": {
       "loading": "संमती लोड जाता...",

--- a/dpdp-accelerator/react-apps/consent-portal/frontend/public/i18n/ks/common.json
+++ b/dpdp-accelerator/react-apps/consent-portal/frontend/public/i18n/ks/common.json
@@ -93,7 +93,14 @@
       "serviceId": "خدمت",
       "removeConsentIdForState": "رِیاستی فلٹر استعمال کرنہٕ خٲطرٕ کٔڑِو رضامندی ہُنٛد آیی ڈی فلٹر۔",
       "propertyFilterLabel": "رضامندی ہٕنٛز جٲیِداد",
-      "removeConsentIdForSubject": "یوزر آیی ڈی فلٹر استعمال کرنہٕ خٲطرٕ کٔڑِو کنسنٹ آیی ڈی فلٹر۔"
+      "removeConsentIdForSubject": "یوزر آیی ڈی فلٹر استعمال کرنہٕ خٲطرٕ کٔڑِو کنسنٹ آیی ڈی فلٹر۔",
+      "relation": "Relation",
+      "relationHelperText": "Set a User to filter by relation",
+      "relationOptions": {
+        "any": "Any",
+        "subject": "Subject",
+        "authorizer": "Authorizer"
+      }
     }
   },
   "consentRegistry": {
@@ -246,7 +253,13 @@
       "clear": "ساری صاف کِریو",
       "clearAriaLabel": "ساری فِلتَر صاف کِریو",
       "serviceSearchPlaceholder": "سروسہِ سٕتہِ ژھٲرِو",
-      "state": "رِیاسَتھ"
+      "state": "رِیاسَتھ",
+      "relation": "Relation",
+      "relationOptions": {
+        "any": "All",
+        "subject": "My Own",
+        "authorizer": "Managed by Me"
+      }
     },
     "messages": {
       "loading": "رضامندیہِ لوڈ گَچھان...",

--- a/dpdp-accelerator/react-apps/consent-portal/frontend/public/i18n/mai/common.json
+++ b/dpdp-accelerator/react-apps/consent-portal/frontend/public/i18n/mai/common.json
@@ -93,7 +93,14 @@
       "serviceId": "सेवा",
       "removeConsentIdForState": "राज्य फिल्टरक उपयोग करबाक लेल सहमति आईडी फिल्टर हटा दिअ।",
       "propertyFilterLabel": "सहमति संपत्ति",
-      "removeConsentIdForSubject": "यूजर आईडी फिल्टरक उपयोग करबाक लेल सहमति आईडी फिल्टर हटा दिअ।"
+      "removeConsentIdForSubject": "यूजर आईडी फिल्टरक उपयोग करबाक लेल सहमति आईडी फिल्टर हटा दिअ।",
+      "relation": "Relation",
+      "relationHelperText": "Set a User to filter by relation",
+      "relationOptions": {
+        "any": "Any",
+        "subject": "Subject",
+        "authorizer": "Authorizer"
+      }
     }
   },
   "consentRegistry": {
@@ -246,7 +253,13 @@
       "clear": "सभ साफ़ करू",
       "clearAriaLabel": "सभ फ़िल्टर साफ़ करू",
       "serviceSearchPlaceholder": "सेवा द्वारा खोजू",
-      "state": "राज्य"
+      "state": "राज्य",
+      "relation": "Relation",
+      "relationOptions": {
+        "any": "All",
+        "subject": "My Own",
+        "authorizer": "Managed by Me"
+      }
     },
     "messages": {
       "loading": "सहमति सभ लोड भऽ रहल अछि...",

--- a/dpdp-accelerator/react-apps/consent-portal/frontend/public/i18n/ml/common.json
+++ b/dpdp-accelerator/react-apps/consent-portal/frontend/public/i18n/ml/common.json
@@ -93,7 +93,14 @@
       "serviceId": "സേവനം",
       "removeConsentIdForState": "സംസ്ഥാന ഫിൽട്ടർ ഉപയോഗിക്കുന്നതിന് സമ്മത ഐഡി ഫിൽട്ടർ നീക്കം ചെയ്യുക.",
       "propertyFilterLabel": "സമ്മത സ്വത്ത്",
-      "removeConsentIdForSubject": "ഉപയോക്തൃ ഐഡി ഫിൽട്ടർ ഉപയോഗിക്കുന്നതിന് സമ്മത ഐഡി ഫിൽട്ടർ നീക്കം ചെയ്യുക."
+      "removeConsentIdForSubject": "ഉപയോക്തൃ ഐഡി ഫിൽട്ടർ ഉപയോഗിക്കുന്നതിന് സമ്മത ഐഡി ഫിൽട്ടർ നീക്കം ചെയ്യുക.",
+      "relation": "Relation",
+      "relationHelperText": "Set a User to filter by relation",
+      "relationOptions": {
+        "any": "Any",
+        "subject": "Subject",
+        "authorizer": "Authorizer"
+      }
     }
   },
   "consentRegistry": {
@@ -246,7 +253,13 @@
       "clear": "എല്ലാം മായ്‌ക്കുക",
       "clearAriaLabel": "എല്ലാ ഫിൽട്ടറുകളും മായ്‌ക്കുക",
       "serviceSearchPlaceholder": "സേവനം അനുസരിച്ച് തിരയുക",
-      "state": "സംസ്ഥാനം"
+      "state": "സംസ്ഥാനം",
+      "relation": "Relation",
+      "relationOptions": {
+        "any": "All",
+        "subject": "My Own",
+        "authorizer": "Managed by Me"
+      }
     },
     "messages": {
       "loading": "സമ്മതങ്ങൾ ലോഡുചെയ്യുന്നു...",

--- a/dpdp-accelerator/react-apps/consent-portal/frontend/public/i18n/mni/common.json
+++ b/dpdp-accelerator/react-apps/consent-portal/frontend/public/i18n/mni/common.json
@@ -93,7 +93,14 @@
       "serviceId": "Service",
       "removeConsentIdForState": "Remove the Consent ID filter to use the state filter.",
       "propertyFilterLabel": "Consent property",
-      "removeConsentIdForSubject": "Remove the Consent ID filter to use the User ID filter."
+      "removeConsentIdForSubject": "Remove the Consent ID filter to use the User ID filter.",
+      "relation": "Relation",
+      "relationHelperText": "Set a User to filter by relation",
+      "relationOptions": {
+        "any": "Any",
+        "subject": "Subject",
+        "authorizer": "Authorizer"
+      }
     }
   },
   "consentRegistry": {
@@ -246,7 +253,13 @@
       "clear": "পুম্নমক সেংদোকপা",
       "clearAriaLabel": "ফিল্টর পুম্নমক সেংদোকপা",
       "serviceSearchPlaceholder": "Search by service",
-      "state": "State"
+      "state": "State",
+      "relation": "Relation",
+      "relationOptions": {
+        "any": "All",
+        "subject": "My Own",
+        "authorizer": "Managed by Me"
+      }
     },
     "messages": {
       "loading": "য়ানবা লোড তৌরি...",

--- a/dpdp-accelerator/react-apps/consent-portal/frontend/public/i18n/mr/common.json
+++ b/dpdp-accelerator/react-apps/consent-portal/frontend/public/i18n/mr/common.json
@@ -93,7 +93,14 @@
       "serviceId": "सेवा",
       "removeConsentIdForState": "राज्य फिल्टर वापरण्यासाठी संमती आयडी फिल्टर काढा.",
       "propertyFilterLabel": "संमती मालमत्ता",
-      "removeConsentIdForSubject": "युजर आयडी फिल्टर वापरण्यासाठी संमती आयडी फिल्टर काढून टाका."
+      "removeConsentIdForSubject": "युजर आयडी फिल्टर वापरण्यासाठी संमती आयडी फिल्टर काढून टाका.",
+      "relation": "Relation",
+      "relationHelperText": "Set a User to filter by relation",
+      "relationOptions": {
+        "any": "Any",
+        "subject": "Subject",
+        "authorizer": "Authorizer"
+      }
     }
   },
   "consentRegistry": {
@@ -246,7 +253,13 @@
       "clear": "सर्व साफ करा",
       "clearAriaLabel": "सर्व फिल्टर साफ करा",
       "serviceSearchPlaceholder": "सेवेनुसार शोधा",
-      "state": "राज्य"
+      "state": "राज्य",
+      "relation": "Relation",
+      "relationOptions": {
+        "any": "All",
+        "subject": "My Own",
+        "authorizer": "Managed by Me"
+      }
     },
     "messages": {
       "loading": "संमती लोड होत आहेत...",

--- a/dpdp-accelerator/react-apps/consent-portal/frontend/public/i18n/ne/common.json
+++ b/dpdp-accelerator/react-apps/consent-portal/frontend/public/i18n/ne/common.json
@@ -93,7 +93,14 @@
       "serviceId": "सेवा",
       "removeConsentIdForState": "राज्य फिल्टर प्रयोग गर्न सहमति आईडी फिल्टर हटाउनुहोस्।",
       "propertyFilterLabel": "सहमति सम्पत्ति",
-      "removeConsentIdForSubject": "प्रयोगकर्ता आइडी फिल्टर प्रयोग गर्न सहमति आइडी फिल्टर हटाउनुहोस्।"
+      "removeConsentIdForSubject": "प्रयोगकर्ता आइडी फिल्टर प्रयोग गर्न सहमति आइडी फिल्टर हटाउनुहोस्।",
+      "relation": "Relation",
+      "relationHelperText": "Set a User to filter by relation",
+      "relationOptions": {
+        "any": "Any",
+        "subject": "Subject",
+        "authorizer": "Authorizer"
+      }
     }
   },
   "consentRegistry": {
@@ -246,7 +253,13 @@
       "clear": "सबै हटाउनुहोस्",
       "clearAriaLabel": "सबै फिल्टरहरू हटाउनुहोस्",
       "serviceSearchPlaceholder": "सेवाद्वारा खोज्नुहोस्",
-      "state": "राज्य"
+      "state": "राज्य",
+      "relation": "Relation",
+      "relationOptions": {
+        "any": "All",
+        "subject": "My Own",
+        "authorizer": "Managed by Me"
+      }
     },
     "messages": {
       "loading": "सहमतिहरू लोड हुँदैछन्...",

--- a/dpdp-accelerator/react-apps/consent-portal/frontend/public/i18n/or/common.json
+++ b/dpdp-accelerator/react-apps/consent-portal/frontend/public/i18n/or/common.json
@@ -93,7 +93,14 @@
       "serviceId": "ସେବା",
       "removeConsentIdForState": "ରାଜ୍ୟ ଫିଲ୍ଟର୍ ବ୍ୟବହାର କରିବାକୁ ସମ୍ମତି ID ଫିଲ୍ଟର୍ ଅପସାରଣ କରନ୍ତୁ |",
       "propertyFilterLabel": "ସମ୍ମତି ସମ୍ପତ୍ତି",
-      "removeConsentIdForSubject": "ଉପଭୋକ୍ତା ID ଫିଲ୍ଟର୍ ବ୍ୟବହାର କରିବା ପାଇଁ ସମ୍ମତି ID ଫିଲ୍ଟର୍ ହଟାନ୍ତୁ।"
+      "removeConsentIdForSubject": "ଉପଭୋକ୍ତା ID ଫିଲ୍ଟର୍ ବ୍ୟବହାର କରିବା ପାଇଁ ସମ୍ମତି ID ଫିଲ୍ଟର୍ ହଟାନ୍ତୁ।",
+      "relation": "Relation",
+      "relationHelperText": "Set a User to filter by relation",
+      "relationOptions": {
+        "any": "Any",
+        "subject": "Subject",
+        "authorizer": "Authorizer"
+      }
     }
   },
   "consentRegistry": {
@@ -246,7 +253,13 @@
       "clear": "ସବୁ ସଫା କରନ୍ତୁ",
       "clearAriaLabel": "ସମସ୍ତ ଫିଲ୍ଟର୍ ସଫା କରନ୍ତୁ",
       "serviceSearchPlaceholder": "ସେବା ଅନୁସାରେ ଖୋଜନ୍ତୁ |",
-      "state": "ରାଜ୍ୟ"
+      "state": "ରାଜ୍ୟ",
+      "relation": "Relation",
+      "relationOptions": {
+        "any": "All",
+        "subject": "My Own",
+        "authorizer": "Managed by Me"
+      }
     },
     "messages": {
       "loading": "ସମ୍ମତିଗୁଡ଼ିକ ଲୋଡ୍ ହେଉଛି...",

--- a/dpdp-accelerator/react-apps/consent-portal/frontend/public/i18n/pa/common.json
+++ b/dpdp-accelerator/react-apps/consent-portal/frontend/public/i18n/pa/common.json
@@ -93,7 +93,14 @@
       "serviceId": "ਸੇਵਾ",
       "removeConsentIdForState": "ਸਟੇਟ ਫਿਲਟਰ ਵਰਤਣ ਲਈ ਸਹਿਮਤੀ ਆਈਡੀ ਫਿਲਟਰ ਹਟਾਓ।",
       "propertyFilterLabel": "ਸਹਿਮਤੀ ਜਾਇਦਾਦ",
-      "removeConsentIdForSubject": "ਯੂਜ਼ਰ ਆਈਡੀ ਫਿਲਟਰ ਵਰਤਣ ਲਈ ਸਹਿਮਤੀ ਆਈਡੀ ਫਿਲਟਰ ਹਟਾਓ।"
+      "removeConsentIdForSubject": "ਯੂਜ਼ਰ ਆਈਡੀ ਫਿਲਟਰ ਵਰਤਣ ਲਈ ਸਹਿਮਤੀ ਆਈਡੀ ਫਿਲਟਰ ਹਟਾਓ।",
+      "relation": "Relation",
+      "relationHelperText": "Set a User to filter by relation",
+      "relationOptions": {
+        "any": "Any",
+        "subject": "Subject",
+        "authorizer": "Authorizer"
+      }
     }
   },
   "consentRegistry": {
@@ -246,7 +253,13 @@
       "clear": "ਸਭ ਸਾਫ਼ ਕਰੋ",
       "clearAriaLabel": "ਸਾਰੇ ਫਿਲਟਰ ਸਾਫ਼ ਕਰੋ",
       "serviceSearchPlaceholder": "ਸੇਵਾ ਦੁਆਰਾ ਖੋਜ ਕਰੋ",
-      "state": "ਰਾਜ"
+      "state": "ਰਾਜ",
+      "relation": "Relation",
+      "relationOptions": {
+        "any": "All",
+        "subject": "My Own",
+        "authorizer": "Managed by Me"
+      }
     },
     "messages": {
       "loading": "ਸਹਿਮਤੀਆਂ ਲੋਡ ਹੋ ਰਹੀਆਂ ਹਨ...",

--- a/dpdp-accelerator/react-apps/consent-portal/frontend/public/i18n/sa/common.json
+++ b/dpdp-accelerator/react-apps/consent-portal/frontend/public/i18n/sa/common.json
@@ -93,7 +93,14 @@
       "serviceId": "सेवा",
       "removeConsentIdForState": "राज्य-शोधकस्य उपयोगार्थं संमति-अभिज्ञान-शोधकम् निष्कासय।",
       "propertyFilterLabel": "अनुमोदनसम्पत्तिः",
-      "removeConsentIdForSubject": "उपयोक्तृ-अभिज्ञान-अन्तराधिकारम् उपयोक्तुं संमति-अभिज्ञान-अन्तराधिकारम् निष्कासयतु।"
+      "removeConsentIdForSubject": "उपयोक्तृ-अभिज्ञान-अन्तराधिकारम् उपयोक्तुं संमति-अभिज्ञान-अन्तराधिकारम् निष्कासयतु।",
+      "relation": "Relation",
+      "relationHelperText": "Set a User to filter by relation",
+      "relationOptions": {
+        "any": "Any",
+        "subject": "Subject",
+        "authorizer": "Authorizer"
+      }
     }
   },
   "consentRegistry": {
@@ -246,7 +253,13 @@
       "clear": "सर्वं मार्जयन्तु",
       "clearAriaLabel": "सर्वान् शोधकान् मार्जयन्तु",
       "serviceSearchPlaceholder": "सेवायाः अन्वेषणम्",
-      "state": "राज्यम्"
+      "state": "राज्यम्",
+      "relation": "Relation",
+      "relationOptions": {
+        "any": "All",
+        "subject": "My Own",
+        "authorizer": "Managed by Me"
+      }
     },
     "messages": {
       "loading": "सहमतयः भार्यन्ते...",

--- a/dpdp-accelerator/react-apps/consent-portal/frontend/public/i18n/sat/common.json
+++ b/dpdp-accelerator/react-apps/consent-portal/frontend/public/i18n/sat/common.json
@@ -93,7 +93,14 @@
       "serviceId": "ᱥᱮᱵᱟ",
       "removeConsentIdForState": "ᱨᱟᱥᱴᱨᱤᱭᱚ ᱯᱷᱤᱞᱴᱟᱨ ᱵᱮᱵᱷᱟᱨ ᱞᱟᱹᱜᱤᱫ ᱥᱟᱹᱠᱭᱟᱹᱛ ᱟᱭ ᱰᱤ ᱯᱷᱤᱞᱴᱟᱨ ᱚᱪᱚᱜ ᱢᱮ ᱾",
       "propertyFilterLabel": "ᱥᱟᱹᱠᱭᱟᱹᱛ ᱥᱚᱢᱯᱚᱛᱛᱤ",
-      "removeConsentIdForSubject": "ᱵᱮᱵᱷᱟᱨᱤᱭᱟᱹ ᱟᱭᱰᱤ ᱯᱷᱤᱞᱴᱟᱨ ᱵᱮᱵᱷᱟᱨ ᱞᱟᱹᱜᱤᱫ ᱥᱟᱹᱠᱭᱟᱹᱛ ᱟᱭᱰᱤ ᱯᱷᱤᱞᱴᱟᱨ ᱚᱪᱚᱜ ᱢᱮ ᱾"
+      "removeConsentIdForSubject": "ᱵᱮᱵᱷᱟᱨᱤᱭᱟᱹ ᱟᱭᱰᱤ ᱯᱷᱤᱞᱴᱟᱨ ᱵᱮᱵᱷᱟᱨ ᱞᱟᱹᱜᱤᱫ ᱥᱟᱹᱠᱭᱟᱹᱛ ᱟᱭᱰᱤ ᱯᱷᱤᱞᱴᱟᱨ ᱚᱪᱚᱜ ᱢᱮ ᱾",
+      "relation": "Relation",
+      "relationHelperText": "Set a User to filter by relation",
+      "relationOptions": {
+        "any": "Any",
+        "subject": "Subject",
+        "authorizer": "Authorizer"
+      }
     }
   },
   "consentRegistry": {
@@ -246,7 +253,13 @@
       "clear": "ᱡᱚᱛᱚ ᱥᱟᱯᱷᱟᱭ ᱢᱮ",
       "clearAriaLabel": "ᱡᱚᱛᱚ ᱯᱷᱤᱞᱴᱚᱨ ᱥᱟᱯᱷᱟᱭ ᱢᱮ",
       "serviceSearchPlaceholder": "ᱥᱮᱵᱟ ᱞᱮᱠᱟᱛᱮ ᱯᱟᱸᱡᱟᱭ ᱢᱮ ᱾",
-      "state": "ᱯᱚᱱᱚᱛ"
+      "state": "ᱯᱚᱱᱚᱛ",
+      "relation": "Relation",
+      "relationOptions": {
+        "any": "All",
+        "subject": "My Own",
+        "authorizer": "Managed by Me"
+      }
     },
     "messages": {
       "loading": "ᱥᱟᱹᱢᱟᱹᱛᱤ ᱠᱚ ᱞᱳᱰ ᱦᱩᱭᱩᱜ ᱠᱟᱱᱟ...",

--- a/dpdp-accelerator/react-apps/consent-portal/frontend/public/i18n/sd/common.json
+++ b/dpdp-accelerator/react-apps/consent-portal/frontend/public/i18n/sd/common.json
@@ -93,7 +93,14 @@
       "serviceId": "Service",
       "removeConsentIdForState": "Remove the Consent ID filter to use the state filter.",
       "propertyFilterLabel": "Consent property",
-      "removeConsentIdForSubject": "Remove the Consent ID filter to use the User ID filter."
+      "removeConsentIdForSubject": "Remove the Consent ID filter to use the User ID filter.",
+      "relation": "Relation",
+      "relationHelperText": "Set a User to filter by relation",
+      "relationOptions": {
+        "any": "Any",
+        "subject": "Subject",
+        "authorizer": "Authorizer"
+      }
     }
   },
   "consentRegistry": {
@@ -246,7 +253,13 @@
       "clear": "سڀ صاف ڪريو",
       "clearAriaLabel": "سڀ فلٽر صاف ڪريو",
       "serviceSearchPlaceholder": "Search by service",
-      "state": "State"
+      "state": "State",
+      "relation": "Relation",
+      "relationOptions": {
+        "any": "All",
+        "subject": "My Own",
+        "authorizer": "Managed by Me"
+      }
     },
     "messages": {
       "loading": "رضامنديون لوڊ ٿي رهيون آهن...",

--- a/dpdp-accelerator/react-apps/consent-portal/frontend/public/i18n/ta/common.json
+++ b/dpdp-accelerator/react-apps/consent-portal/frontend/public/i18n/ta/common.json
@@ -93,7 +93,14 @@
       "serviceId": "சேவை",
       "removeConsentIdForState": "மாநில வடிகட்டியைப் பயன்படுத்த சம்மத அடையாள வடிகட்டியை அகற்றவும்.",
       "propertyFilterLabel": "சம்மத சொத்து",
-      "removeConsentIdForSubject": "பயனர் ஐடி வடிகட்டியைப் பயன்படுத்த, சம்மத ஐடி வடிகட்டியை அகற்றவும்."
+      "removeConsentIdForSubject": "பயனர் ஐடி வடிகட்டியைப் பயன்படுத்த, சம்மத ஐடி வடிகட்டியை அகற்றவும்.",
+      "relation": "Relation",
+      "relationHelperText": "Set a User to filter by relation",
+      "relationOptions": {
+        "any": "Any",
+        "subject": "Subject",
+        "authorizer": "Authorizer"
+      }
     }
   },
   "consentRegistry": {
@@ -246,7 +253,13 @@
       "clear": "துடை",
       "clearAriaLabel": "அனைத்து வடிகட்டிகளையும் துடை",
       "serviceSearchPlaceholder": "சேவை மூலம் தேடுங்கள்",
-      "state": "மாநிலம்"
+      "state": "மாநிலம்",
+      "relation": "Relation",
+      "relationOptions": {
+        "any": "All",
+        "subject": "My Own",
+        "authorizer": "Managed by Me"
+      }
     },
     "messages": {
       "loading": "சம்மதங்கள் ஏற்றப்படுகின்றன...",

--- a/dpdp-accelerator/react-apps/consent-portal/frontend/public/i18n/te/common.json
+++ b/dpdp-accelerator/react-apps/consent-portal/frontend/public/i18n/te/common.json
@@ -93,7 +93,14 @@
       "serviceId": "సేవ",
       "removeConsentIdForState": "రాష్ట్ర ఫిల్టర్‌ను ఉపయోగించడానికి సమ్మతి ID ఫిల్టర్‌ను తీసివేయండి.",
       "propertyFilterLabel": "సమ్మతి ఆస్తి",
-      "removeConsentIdForSubject": "యూజర్ ఐడి ఫిల్టర్‌ను ఉపయోగించడానికి కన్సెంట్ ఐడి ఫిల్టర్‌ను తీసివేయండి."
+      "removeConsentIdForSubject": "యూజర్ ఐడి ఫిల్టర్‌ను ఉపయోగించడానికి కన్సెంట్ ఐడి ఫిల్టర్‌ను తీసివేయండి.",
+      "relation": "Relation",
+      "relationHelperText": "Set a User to filter by relation",
+      "relationOptions": {
+        "any": "Any",
+        "subject": "Subject",
+        "authorizer": "Authorizer"
+      }
     }
   },
   "consentRegistry": {
@@ -246,7 +253,13 @@
       "clear": "అన్నీ క్లియర్ చేయి",
       "clearAriaLabel": "అన్ని ఫిల్టర్‌లను క్లియర్ చేయి",
       "serviceSearchPlaceholder": "సేవల ద్వారా వెతకండి",
-      "state": "రాష్ట్రం"
+      "state": "రాష్ట్రం",
+      "relation": "Relation",
+      "relationOptions": {
+        "any": "All",
+        "subject": "My Own",
+        "authorizer": "Managed by Me"
+      }
     },
     "messages": {
       "loading": "సమ్మతులు లోడ్ అవుతున్నాయి...",

--- a/dpdp-accelerator/react-apps/consent-portal/frontend/public/i18n/ur/common.json
+++ b/dpdp-accelerator/react-apps/consent-portal/frontend/public/i18n/ur/common.json
@@ -93,7 +93,14 @@
       "serviceId": "خدمت",
       "removeConsentIdForState": "ریاستی فلٹر استعمال کرنے کے لیے رضامندی شناختی فلٹر ہٹا دیں۔",
       "propertyFilterLabel": "رضامندی کی جائیداد",
-      "removeConsentIdForSubject": "یوزر آئی ڈی فلٹر استعمال کرنے کے لیے کنسنٹ آئی ڈی فلٹر ہٹا دیں۔"
+      "removeConsentIdForSubject": "یوزر آئی ڈی فلٹر استعمال کرنے کے لیے کنسنٹ آئی ڈی فلٹر ہٹا دیں۔",
+      "relation": "Relation",
+      "relationHelperText": "Set a User to filter by relation",
+      "relationOptions": {
+        "any": "Any",
+        "subject": "Subject",
+        "authorizer": "Authorizer"
+      }
     }
   },
   "consentRegistry": {
@@ -246,7 +253,13 @@
       "clear": "سب صاف کریں",
       "clearAriaLabel": "تمام فلٹرز صاف کریں",
       "serviceSearchPlaceholder": "سروس کے ذریعے تلاش کریں۔",
-      "state": "ریاست"
+      "state": "ریاست",
+      "relation": "Relation",
+      "relationOptions": {
+        "any": "All",
+        "subject": "My Own",
+        "authorizer": "Managed by Me"
+      }
     },
     "messages": {
       "loading": "رضامندیاں لوڈ ہو رہی ہیں...",

--- a/dpdp-accelerator/react-apps/consent-portal/frontend/src/__tests__/AdminConsentFilters.test.tsx
+++ b/dpdp-accelerator/react-apps/consent-portal/frontend/src/__tests__/AdminConsentFilters.test.tsx
@@ -50,27 +50,41 @@ describe('administrative consent filters', () => {
       normalizeAdminConsentFilters({
         state: 'ACTIVE',
         consentId: '  consent-1 ',
-        subjectId: ' admin ',
+        userId: ' admin ',
+        relation: 'AUTHORIZER',
         serviceId: ' dpdp-portal ',
         purposeId: ' purpose-1 ',
         propertyKey: ' dataCategory ',
         propertyValue: ' personal ',
+        createdAfter: ' 2026-01-01 ',
+        createdBefore: ' 2026-01-31 ',
       }),
     ).toEqual({
       state: 'ACTIVE',
       consentId: 'consent-1',
-      subjectId: 'admin',
+      userId: 'admin',
+      relation: 'AUTHORIZER',
       serviceId: 'dpdp-portal',
       purposeId: 'purpose-1',
       propertyKey: 'dataCategory',
       propertyValue: 'personal',
+      createdAfter: '2026-01-01',
+      createdBefore: '2026-01-31',
     })
   })
 
   it('reads native consent states from the URL and ignores unknown ones', () => {
     expect(getAdminConsentFilters(new URLSearchParams('state=PENDING')).state).toBe('PENDING')
     expect(getAdminConsentFilters(new URLSearchParams('state=CREATED')).state).toBe('All')
-    expect(getAdminConsentFilters(new URLSearchParams('subjectId=admin')).subjectId).toBe('admin')
+    expect(getAdminConsentFilters(new URLSearchParams('userId=admin')).userId).toBe('admin')
+  })
+
+  it('falls back to ANY for a missing or unknown relation', () => {
+    expect(getAdminConsentFilters(new URLSearchParams('')).relation).toBe('ANY')
+    expect(getAdminConsentFilters(new URLSearchParams('relation=BOGUS')).relation).toBe('ANY')
+    expect(getAdminConsentFilters(new URLSearchParams('relation=AUTHORIZER')).relation).toBe(
+      'AUTHORIZER',
+    )
   })
 
   it('searches by User directly from the main row', () => {
@@ -79,24 +93,51 @@ describe('administrative consent filters', () => {
 
     expect(screen.getByPlaceholderText('Search by consent ID')).toBeInTheDocument()
 
-    const subjectId = screen.getByRole('textbox', { name: 'User' })
-    expect(subjectId).toBeEnabled()
+    const userId = screen.getByRole('textbox', { name: 'User' })
+    expect(userId).toBeEnabled()
 
-    fireEvent.change(subjectId, { target: { value: ' admin ' } })
-    fireEvent.keyDown(subjectId, { key: 'Enter' })
+    fireEvent.change(userId, { target: { value: ' admin ' } })
+    fireEvent.keyDown(userId, { key: 'Enter' })
 
     expect(onFilterChange).toHaveBeenCalledWith({
       state: 'All',
       consentId: '',
-      subjectId: 'admin',
+      userId: 'admin',
+      relation: 'ANY',
       serviceId: '',
       purposeId: '',
       propertyKey: '',
       propertyValue: '',
+      createdAfter: '',
+      createdBefore: '',
     })
   })
 
-  it('offers service, purpose and a consent-property filter in advanced filters', () => {
+  it('disables the relation select until a User is set, then applies it immediately', () => {
+    const onFilterChange = vi.fn()
+    renderFilters(EMPTY_ADMIN_CONSENT_FILTERS, onFilterChange)
+
+    expect(screen.getByRole('combobox', { name: 'Relation' })).toHaveAttribute(
+      'aria-disabled',
+      'true',
+    )
+    cleanup()
+
+    renderFilters({ ...EMPTY_ADMIN_CONSENT_FILTERS, userId: 'admin' }, onFilterChange)
+    const relationSelect = screen.getByRole('combobox', { name: 'Relation' })
+    expect(relationSelect).not.toHaveAttribute('aria-disabled', 'true')
+
+    fireEvent.mouseDown(relationSelect)
+    fireEvent.click(screen.getByRole('option', { name: 'Authorizer' }))
+
+    expect(onFilterChange).toHaveBeenCalledWith({
+      ...EMPTY_ADMIN_CONSENT_FILTERS,
+      userId: 'admin',
+      relation: 'AUTHORIZER',
+    })
+  })
+
+  it('offers service, purpose, a consent-property filter and a created-date range in advanced filters', () => {
     const onFilterChange = vi.fn()
     renderFilters(EMPTY_ADMIN_CONSENT_FILTERS, onFilterChange)
 
@@ -123,11 +164,14 @@ describe('administrative consent filters', () => {
     expect(onFilterChange).toHaveBeenCalledWith({
       state: 'All',
       consentId: '',
-      subjectId: '',
+      userId: '',
+      relation: 'ANY',
       serviceId: 'dpdp-portal',
       purposeId: 'purpose-1',
       propertyKey: 'dataCategory',
       propertyValue: 'personal',
+      createdAfter: '',
+      createdBefore: '',
     })
   })
 
@@ -149,10 +193,10 @@ describe('administrative consent filters', () => {
     renderFilters({ ...EMPTY_ADMIN_CONSENT_FILTERS, consentId: 'consent-123' })
 
     const advancedFiltersButton = screen.getByRole('button', { name: 'Advanced filters' })
-    const subjectId = screen.getByRole('textbox', { name: 'User' })
+    const userId = screen.getByRole('textbox', { name: 'User' })
     const stateSelect = screen.getByRole('combobox', { name: 'State' })
     expect(advancedFiltersButton).toBeDisabled()
-    expect(subjectId).toBeDisabled()
+    expect(userId).toBeDisabled()
     expect(stateSelect).toHaveAttribute('aria-disabled', 'true')
 
     fireEvent.mouseOver(advancedFiltersButton.parentElement as HTMLElement)
@@ -160,7 +204,7 @@ describe('administrative consent filters', () => {
       await screen.findByText('Remove the Consent ID filter to use advanced filters.'),
     ).toBeInTheDocument()
 
-    fireEvent.mouseOver(subjectId.closest('[aria-label]') as HTMLElement)
+    fireEvent.mouseOver(userId.closest('[aria-label]') as HTMLElement)
     expect(
       await screen.findByText('Remove the Consent ID filter to use the User ID filter.'),
     ).toBeInTheDocument()

--- a/dpdp-accelerator/react-apps/consent-portal/frontend/src/__tests__/AdminConsentFilters.test.tsx
+++ b/dpdp-accelerator/react-apps/consent-portal/frontend/src/__tests__/AdminConsentFilters.test.tsx
@@ -113,26 +113,21 @@ describe('administrative consent filters', () => {
     })
   })
 
-  it('disables the relation select until a User is set, then applies it immediately', () => {
+  it('keeps the relation select usable even before a User is set', () => {
     const onFilterChange = vi.fn()
     renderFilters(EMPTY_ADMIN_CONSENT_FILTERS, onFilterChange)
 
-    expect(screen.getByRole('combobox', { name: 'Relation' })).toHaveAttribute(
-      'aria-disabled',
-      'true',
-    )
-    cleanup()
-
-    renderFilters({ ...EMPTY_ADMIN_CONSENT_FILTERS, userId: 'admin' }, onFilterChange)
     const relationSelect = screen.getByRole('combobox', { name: 'Relation' })
     expect(relationSelect).not.toHaveAttribute('aria-disabled', 'true')
 
     fireEvent.mouseDown(relationSelect)
     fireEvent.click(screen.getByRole('option', { name: 'Authorizer' }))
 
+    // Applied immediately, same as the other single-select filters - the API
+    // layer itself drops `relation` whenever `userId` is empty, so selecting
+    // one ahead of the User field is harmless.
     expect(onFilterChange).toHaveBeenCalledWith({
       ...EMPTY_ADMIN_CONSENT_FILTERS,
-      userId: 'admin',
       relation: 'AUTHORIZER',
     })
   })
@@ -195,9 +190,11 @@ describe('administrative consent filters', () => {
     const advancedFiltersButton = screen.getByRole('button', { name: 'Advanced filters' })
     const userId = screen.getByRole('textbox', { name: 'User' })
     const stateSelect = screen.getByRole('combobox', { name: 'State' })
+    const relationSelect = screen.getByRole('combobox', { name: 'Relation' })
     expect(advancedFiltersButton).toBeDisabled()
     expect(userId).toBeDisabled()
     expect(stateSelect).toHaveAttribute('aria-disabled', 'true')
+    expect(relationSelect).toHaveAttribute('aria-disabled', 'true')
 
     fireEvent.mouseOver(advancedFiltersButton.parentElement as HTMLElement)
     expect(

--- a/dpdp-accelerator/react-apps/consent-portal/frontend/src/__tests__/AdminConsentRegistryPage.test.tsx
+++ b/dpdp-accelerator/react-apps/consent-portal/frontend/src/__tests__/AdminConsentRegistryPage.test.tsx
@@ -104,9 +104,12 @@ describe('AdminConsentRegistryPage', () => {
       limit: 10,
       after: undefined,
       before: undefined,
-      subjectId: undefined,
+      userId: undefined,
+      relation: 'ANY',
       serviceId: undefined,
       state: undefined,
+      purposeId: undefined,
+      filter: undefined,
     })
   })
 

--- a/dpdp-accelerator/react-apps/consent-portal/frontend/src/__tests__/AdminConsentsApi.test.ts
+++ b/dpdp-accelerator/react-apps/consent-portal/frontend/src/__tests__/AdminConsentsApi.test.ts
@@ -58,7 +58,8 @@ describe('administrative consent API', () => {
     await fetchAdminConsents({
       limit: 25,
       after: 'Mg==',
-      subjectId: 'admin',
+      userId: 'admin',
+      relation: 'AUTHORIZER',
       serviceId: 'dpdp-portal',
       state: 'ACTIVE',
     })
@@ -68,11 +69,24 @@ describe('administrative consent API', () => {
     expect(Object.fromEntries(url.searchParams)).toEqual({
       limit: '25',
       after: 'Mg==',
-      subjectId: 'admin',
+      userId: 'admin',
+      relation: 'AUTHORIZER',
       serviceId: 'dpdp-portal',
       state: 'ACTIVE',
+      attributes: 'purposes,authorizations',
     })
     expect(sentRequest().method).toBe('GET')
+  })
+
+  it('never sends relation without a userId, even if one is passed', async () => {
+    respondWith({ totalResults: 0, links: [], Consents: [] })
+
+    await fetchAdminConsents({ limit: 10, relation: 'ANY' })
+
+    expect(Object.fromEntries(new URL(sentRequest().url).searchParams)).toEqual({
+      limit: '10',
+      attributes: 'purposes,authorizations',
+    })
   })
 
   it('sends a before cursor when paging backwards and omits unset filters', async () => {
@@ -83,6 +97,7 @@ describe('administrative consent API', () => {
     expect(Object.fromEntries(new URL(sentRequest().url).searchParams)).toEqual({
       limit: '10',
       before: 'MQ==',
+      attributes: 'purposes,authorizations',
     })
   })
 
@@ -99,6 +114,7 @@ describe('administrative consent API', () => {
       limit: '10',
       purposeId: 'purpose-1',
       filter: 'properties.dataCategory eq "personal"',
+      attributes: 'purposes,authorizations',
     })
   })
 
@@ -111,28 +127,24 @@ describe('administrative consent API', () => {
     expect(buildConsentPropertyFilter('', 'personal')).toBeUndefined()
   })
 
-  it('expands each row with a detail lookup, keeping the summary when one fails', async () => {
-    // The Identity Server's list rows carry no purposes; the table shows them.
+  it('returns list rows as-is, relying on attributes to inline purposes and authorizations', async () => {
     const summaries = [
-      { id: 'consent-1', subjectId: 'alice', serviceId: 'svc', state: 'ACTIVE', timestamp: 1 },
-      { id: 'consent-2', subjectId: 'bob', serviceId: 'svc', state: 'ACTIVE', timestamp: 2 },
+      {
+        id: 'consent-1',
+        subjectId: 'alice',
+        serviceId: 'svc',
+        state: 'ACTIVE',
+        timestamp: 1,
+        purposes: [{ id: 'p1', name: 'marketing' }],
+        authorizations: [{ userId: 'bob', state: 'APPROVED', updatedTime: 2 }],
+      },
     ]
-    transport.httpRequest
-      .mockResolvedValueOnce({
-        status: 200,
-        data: { totalResults: 2, links: [], Consents: summaries },
-      })
-      .mockResolvedValueOnce({
-        status: 200,
-        data: { ...summaries[0], purposes: [{ id: 'p1', name: 'marketing' }] },
-      })
-      .mockRejectedValueOnce(new Error('detail lookup failed'))
+    respondWith({ totalResults: 1, links: [], Consents: summaries })
 
     const response = await fetchAdminConsents({ limit: 10 })
 
-    expect(response.Consents[0]?.purposes).toEqual([{ id: 'p1', name: 'marketing' }])
-    expect(response.Consents[1]).toEqual(summaries[1])
-    expect(response.totalResults).toBe(2)
+    expect(response.Consents).toEqual(summaries)
+    expect(transport.httpRequest).toHaveBeenCalledTimes(1)
   })
 
   it('reads next and previous cursors out of the returned links', () => {

--- a/dpdp-accelerator/react-apps/consent-portal/frontend/src/__tests__/ConsentApprovalApi.test.ts
+++ b/dpdp-accelerator/react-apps/consent-portal/frontend/src/__tests__/ConsentApprovalApi.test.ts
@@ -57,45 +57,35 @@ function pathOf(request: SentRequest): string {
 }
 
 function summary(id: string, state = 'ACTIVE'): Record<string, unknown> {
-  return { id, subjectId: 'admin', serviceId: 'dpdp-portal', state, timestamp: 1785833979893 }
-}
-
-function detail(id: string, state = 'ACTIVE'): Record<string, unknown> {
   return {
-    ...summary(id, state),
+    id,
+    subjectId: 'admin',
+    serviceId: 'dpdp-portal',
+    state,
+    timestamp: 1785833979893,
     purposes: [{ id: 'purpose-1', name: 'marketing-spike', version: '1.0.0', elements: [] }],
     authorizations: [],
   }
 }
 
-/** Answers the list endpoint with `summaries` and each detail lookup by id. */
-function routeConsents(
-  summaries: Record<string, unknown>[],
-  detailFor: (id: string) => unknown = (id) => detail(id),
-): void {
-  transport.httpRequest.mockImplementation(async (config: SentRequest) => {
-    const path = pathOf(config)
-    if (path === SELF_CONSENTS) {
-      return { status: 200, data: summaries }
-    }
-    const id = decodeURIComponent(path.slice(`${SELF_CONSENTS}/`.length))
-    return { status: 200, data: detailFor(id) }
-  })
+function detail(id: string, state = 'ACTIVE'): Record<string, unknown> {
+  return summary(id, state)
 }
 
 describe('self-service consent API', () => {
-  it('over-fetches a page, slices it locally and expands each row', async () => {
+  it('requests attributes and relation, over-fetches a page and slices it locally', async () => {
     const summaries = ['c-0', 'c-1', 'c-2', 'c-3', 'c-4'].map((id) => summary(id))
-    routeConsents(summaries)
+    transport.httpRequest.mockResolvedValue({ status: 200, data: summaries })
 
     const page = await fetchMyConsents({
       limit: 2,
       offset: 1,
       state: 'PENDING',
       serviceId: 'dpdp-portal',
+      relation: 'ANY',
     })
 
-    const [list, ...details] = sentRequests()
+    const [list] = sentRequests()
     const url = new URL(list.url)
     expect(url.pathname).toBe(SELF_CONSENTS)
     expect(Object.fromEntries(url.searchParams)).toEqual({
@@ -104,40 +94,38 @@ describe('self-service consent API', () => {
       // The upstream filter takes a single state, so only the first is sent.
       state: 'PENDING',
       serviceId: 'dpdp-portal',
+      relation: 'ANY',
+      attributes: 'purposes,authorizations',
     })
 
-    expect(details.map(pathOf)).toEqual([`${SELF_CONSENTS}/c-1`, `${SELF_CONSENTS}/c-2`])
+    // No per-row detail lookup - attributes already inlined what the table needs.
+    expect(sentRequests()).toHaveLength(1)
     expect(page.data.map((consent) => consent.id)).toEqual(['c-1', 'c-2'])
-    expect(page.data[0].purposes[0].name).toBe('marketing-spike')
+    expect(page.data[0].purposes?.[0]?.name).toBe('marketing-spike')
     expect(page.metadata).toEqual({ total: summaries.length, offset: 1, count: 2, limit: 2 })
   })
 
-  it('omits the state filter when no status is selected', async () => {
-    routeConsents([])
+  it('omits the state, relation and filter params when unset', async () => {
+    transport.httpRequest.mockResolvedValue({ status: 200, data: [] })
 
     await fetchMyConsents({ limit: 10, offset: 0 })
 
-    expect(Object.fromEntries(new URL(sentRequests()[0].url).searchParams)).toEqual({ limit: '11' })
+    expect(Object.fromEntries(new URL(sentRequests()[0].url).searchParams)).toEqual({
+      limit: '11',
+      attributes: 'purposes,authorizations',
+    })
   })
 
-  it('falls back to the summary when a detail lookup fails', async () => {
-    transport.httpRequest.mockImplementation(async (config: SentRequest) => {
-      if (pathOf(config) === SELF_CONSENTS) {
-        return { status: 200, data: [summary('c-0'), summary('c-1')] }
-      }
-      if (pathOf(config).endsWith('c-1')) {
-        throw Object.assign(new Error('failed'), {
-          response: { status: 500, data: { code: 'CMT-65001', message: 'Server error' } },
-        })
-      }
-      return { status: 200, data: detail('c-0') }
+  it('passes a timestamp filter clause through unchanged', async () => {
+    transport.httpRequest.mockResolvedValue({ status: 200, data: [] })
+
+    await fetchMyConsents({ limit: 10, offset: 0, filter: 'timestamp ge 1700000000000' })
+
+    expect(Object.fromEntries(new URL(sentRequests()[0].url).searchParams)).toEqual({
+      limit: '11',
+      filter: 'timestamp ge 1700000000000',
+      attributes: 'purposes,authorizations',
     })
-
-    const page = await fetchMyConsents({ limit: 10, offset: 0 })
-
-    // One failed lookup must not blank the whole page.
-    expect(page.data.map((consent) => consent.id)).toEqual(['c-0', 'c-1'])
-    expect(page.data[1].purposes).toEqual([])
   })
 
   it('approves a pending consent through the authorize endpoint', async () => {

--- a/dpdp-accelerator/react-apps/consent-portal/frontend/src/__tests__/ConsentApprovalApi.test.ts
+++ b/dpdp-accelerator/react-apps/consent-portal/frontend/src/__tests__/ConsentApprovalApi.test.ts
@@ -154,18 +154,70 @@ describe('self-service consent API', () => {
     expect(JSON.parse(String(authorize.data))).toEqual({ state: 'REJECTED' })
   })
 
-  it('refuses to authorize a consent that is no longer pending', async () => {
-    transport.httpRequest.mockResolvedValue({ status: 200, data: detail('db1f6e7a', 'REVOKED') })
+  it.each(['REVOKED', 'EXPIRED'])(
+    'refuses to approve a %s consent - a withdrawal or lapse stays final',
+    async (state) => {
+      transport.httpRequest.mockResolvedValue({ status: 200, data: detail('db1f6e7a', state) })
 
-    // A withdrawal has to stay final: the server itself would allow this.
-    const failure = approveMyConsent('db1f6e7a')
-    await expect(failure).rejects.toBeInstanceOf(APIError)
+      // The server itself would allow this; the client keeps it final regardless.
+      const failure = approveMyConsent('db1f6e7a')
+      await expect(failure).rejects.toBeInstanceOf(APIError)
+      await expect(failure).rejects.toMatchObject({
+        code: 'INVALID_CONSENT_STATE',
+        status: 409,
+        message: `This consent cannot be approved right now; it is ${state}.`,
+      })
+      expect(sentRequests().every((request) => request.method === 'GET')).toBe(true)
+    },
+  )
+
+  it('refuses to reject an already-rejected consent', async () => {
+    transport.httpRequest.mockResolvedValue({ status: 200, data: detail('db1f6e7a', 'REJECTED') })
+
+    const failure = rejectMyConsent('db1f6e7a')
     await expect(failure).rejects.toMatchObject({
       code: 'INVALID_CONSENT_STATE',
       status: 409,
-      message: 'Only a pending consent can be approved or rejected; this consent is REVOKED.',
+      message: 'This consent cannot be rejected right now; it is REJECTED.',
     })
     expect(sentRequests().every((request) => request.method === 'GET')).toBe(true)
+  })
+
+  it('allows approving a previously rejected consent - a rejection is reconsiderable', async () => {
+    transport.httpRequest
+      .mockResolvedValueOnce({ status: 200, data: detail('c-1', 'REJECTED') })
+      .mockResolvedValueOnce({ status: 204, data: undefined })
+
+    await expect(approveMyConsent('c-1')).resolves.toEqual({ status: 'OK' })
+
+    const [, authorize] = sentRequests()
+    expect(JSON.parse(String(authorize.data))).toEqual({ state: 'APPROVED' })
+  })
+
+  it("allows rejecting an active consent - withdraws just the caller's own approval", async () => {
+    transport.httpRequest
+      .mockResolvedValueOnce({ status: 200, data: detail('c-1', 'ACTIVE') })
+      .mockResolvedValueOnce({ status: 204, data: undefined })
+
+    await expect(rejectMyConsent('c-1')).resolves.toEqual({ status: 'OK' })
+
+    const [, authorize] = sentRequests()
+    expect(JSON.parse(String(authorize.data))).toEqual({ state: 'REJECTED' })
+  })
+
+  it("gates on the given authorizer's own decision, not the aggregate state", async () => {
+    transport.httpRequest.mockResolvedValue({
+      status: 200,
+      data: {
+        ...detail('c-1', 'PENDING'),
+        authorizations: [{ userId: 'bob', state: 'APPROVED', updatedTime: 1 }],
+      },
+    })
+
+    // The consent is still PENDING overall (waiting on other authorizers),
+    // but bob already approved, so bob cannot approve again.
+    const failure = approveMyConsent('c-1', 'bob')
+    await expect(failure).rejects.toMatchObject({ code: 'INVALID_CONSENT_STATE' })
   })
 
   it('revokes consent with POST and no request body', async () => {

--- a/dpdp-accelerator/react-apps/consent-portal/frontend/src/__tests__/ConsentAuthorization.test.ts
+++ b/dpdp-accelerator/react-apps/consent-portal/frontend/src/__tests__/ConsentAuthorization.test.ts
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { describe, expect, it } from 'vitest'
+import {
+  effectiveActionState,
+  isApprovableByCurrentUser,
+  isCurrentUserInvolved,
+  isRejectableByCurrentUser,
+} from '../features/my-consents/utils/consentAuthorization'
+import type { ConsentAuthorization } from '../types/consent'
+
+const AUTHORIZERS: ConsentAuthorization[] = [
+  { userId: 'bob', state: 'APPROVED', updatedTime: 1 },
+  { userId: 'carol', state: 'REJECTED', updatedTime: 2 },
+]
+
+describe('isCurrentUserInvolved', () => {
+  it('is true for the subject', () => {
+    expect(isCurrentUserInvolved('alice', AUTHORIZERS, 'alice')).toBe(true)
+  })
+
+  it('is true for a listed authorizer', () => {
+    expect(isCurrentUserInvolved('alice', AUTHORIZERS, 'bob')).toBe(true)
+  })
+
+  it('is false for someone who is neither', () => {
+    expect(isCurrentUserInvolved('alice', AUTHORIZERS, 'dave')).toBe(false)
+  })
+})
+
+describe('effectiveActionState', () => {
+  it("falls back to the consent's own state for the subject, who has no authorization entry", () => {
+    expect(effectiveActionState('PENDING', AUTHORIZERS, 'alice')).toBe('PENDING')
+  })
+
+  it("uses the caller's own authorization entry when they are a listed authorizer", () => {
+    expect(effectiveActionState('PENDING', AUTHORIZERS, 'bob')).toBe('APPROVED')
+    expect(effectiveActionState('PENDING', AUTHORIZERS, 'carol')).toBe('REJECTED')
+  })
+})
+
+describe('isApprovableByCurrentUser / isRejectableByCurrentUser', () => {
+  it('allows both actions while pending', () => {
+    expect(isApprovableByCurrentUser('PENDING', undefined, 'alice')).toBe(true)
+    expect(isRejectableByCurrentUser('PENDING', undefined, 'alice')).toBe(true)
+  })
+
+  it('an approved (or active) decision can only be reconsidered by rejecting', () => {
+    expect(isApprovableByCurrentUser('ACTIVE', AUTHORIZERS, 'bob')).toBe(false)
+    expect(isRejectableByCurrentUser('ACTIVE', AUTHORIZERS, 'bob')).toBe(true)
+  })
+
+  it('a rejected decision can only be reconsidered by approving', () => {
+    expect(isApprovableByCurrentUser('REJECTED', AUTHORIZERS, 'carol')).toBe(true)
+    expect(isRejectableByCurrentUser('REJECTED', AUTHORIZERS, 'carol')).toBe(false)
+  })
+
+  it('a revoked or expired decision blocks both actions - a withdrawal stays final', () => {
+    ;['REVOKED', 'EXPIRED'].forEach((state) => {
+      expect(isApprovableByCurrentUser(state, undefined, 'alice')).toBe(false)
+      expect(isRejectableByCurrentUser(state, undefined, 'alice')).toBe(false)
+    })
+  })
+
+  it('gates on the specific authorizer asking, not on the aggregate consent state', () => {
+    // The aggregate is still PENDING (waiting on carol), but bob already
+    // approved and should not be offered to approve again.
+    expect(isApprovableByCurrentUser('PENDING', AUTHORIZERS, 'bob')).toBe(false)
+    expect(isRejectableByCurrentUser('PENDING', AUTHORIZERS, 'bob')).toBe(true)
+  })
+})

--- a/dpdp-accelerator/react-apps/consent-portal/frontend/src/__tests__/ConsentDetailsPage.test.tsx
+++ b/dpdp-accelerator/react-apps/consent-portal/frontend/src/__tests__/ConsentDetailsPage.test.tsx
@@ -136,12 +136,20 @@ describe('ConsentDetailsPage lifecycle actions', () => {
     expect(screen.queryByRole('button', { name: 'Revoke' })).not.toBeInTheDocument()
   })
 
-  it('shows revoke only for active consents', async () => {
+  it("shows revoke and reject for active consents - reject withdraws just the caller's own approval", async () => {
     renderConsentDetailsPage('ACTIVE')
 
     expect(await screen.findByRole('button', { name: 'Revoke' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Reject' })).toBeInTheDocument()
     expect(screen.queryByRole('button', { name: 'Approve' })).not.toBeInTheDocument()
+  })
+
+  it('shows approve only for a rejected consent, so the caller can reconsider', async () => {
+    renderConsentDetailsPage('REJECTED')
+
+    expect(await screen.findByRole('button', { name: 'Approve' })).toBeInTheDocument()
     expect(screen.queryByRole('button', { name: 'Reject' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Revoke' })).not.toBeInTheDocument()
   })
 
   it('hides lifecycle actions without the consent write scope', async () => {
@@ -155,8 +163,8 @@ describe('ConsentDetailsPage lifecycle actions', () => {
     expect(screen.queryByRole('button', { name: 'Revoke' })).not.toBeInTheDocument()
   })
 
-  it.each(['REJECTED', 'REVOKED', 'EXPIRED'])(
-    'shows no lifecycle action for %s consents',
+  it.each(['REVOKED', 'EXPIRED'])(
+    'shows no lifecycle action for %s consents - a withdrawal or lapse stays final',
     async (state) => {
       renderConsentDetailsPage(state)
 
@@ -233,6 +241,6 @@ describe('ConsentDetailsPage content', () => {
     await waitFor(() => {
       expect(screen.getByRole('alert')).toHaveTextContent('Consent is not in PENDING state.')
     })
-    expect(consentsApi.approveMyConsent).toHaveBeenCalledWith(CONSENT_ID)
+    expect(consentsApi.approveMyConsent).toHaveBeenCalledWith(CONSENT_ID, 'test-user')
   })
 })

--- a/dpdp-accelerator/react-apps/consent-portal/frontend/src/__tests__/ConsentDetailsPageAdmin.test.tsx
+++ b/dpdp-accelerator/react-apps/consent-portal/frontend/src/__tests__/ConsentDetailsPageAdmin.test.tsx
@@ -1,0 +1,178 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { AcrylicOrangeTheme, CssBaseline, OxygenUIThemeProvider } from '@wso2/oxygen-ui'
+import { I18nextProvider } from 'react-i18next'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import ConsentDetailsPage from '../features/my-consents/ConsentDetailsPage'
+import i18n from '../i18n/i18n'
+import type { ConsentDetail } from '../types/consent'
+import { REQUIRED_SCOPES, type ScopeRequirement } from '../utils/scopes'
+import TestAuthorizationProvider from './TestAuthorizationProvider'
+
+const adminConsentsApi = vi.hoisted(() => ({
+  fetchAdminConsentByID: vi.fn(),
+  revokeAdminConsent: vi.fn(),
+}))
+
+const myConsentsApi = vi.hoisted(() => ({
+  approveMyConsent: vi.fn(),
+  rejectMyConsent: vi.fn(),
+  revokeMyConsent: vi.fn(),
+  fetchMyConsentByID: vi.fn(),
+  fetchMyConsents: vi.fn(),
+}))
+
+vi.mock('../features/admin-consents/api/adminConsentsApi', () => adminConsentsApi)
+vi.mock('../features/my-consents/api/myConsentsApi', () => myConsentsApi)
+
+const CONSENT_ID = '06168ee0-f82a-4b0f-87ea-2a37600ec3f2'
+// The signed-in identity every TestAuthorizationProvider session uses.
+const CURRENT_USER_ID = 'test-user'
+
+function buildConsent(state: string, overrides: Partial<ConsentDetail> = {}): ConsentDetail {
+  return {
+    id: CONSENT_ID,
+    subjectId: 'someone-else',
+    serviceId: 'dpdp-portal',
+    state,
+    timestamp: 1785835726132,
+    purposes: [],
+    authorizations: [],
+    properties: {},
+    ...overrides,
+  }
+}
+
+function renderAdminDetailPage(scopes: ScopeRequirement[]): void {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+
+  render(
+    <OxygenUIThemeProvider theme={AcrylicOrangeTheme}>
+      <CssBaseline />
+      <I18nextProvider i18n={i18n}>
+        <QueryClientProvider client={queryClient}>
+          <MemoryRouter initialEntries={[`/administration/consents/${CONSENT_ID}`]}>
+            <TestAuthorizationProvider scopes={scopes}>
+              <Routes>
+                <Route
+                  path="/administration/consents/:id"
+                  element={<ConsentDetailsPage variant="admin" />}
+                />
+              </Routes>
+            </TestAuthorizationProvider>
+          </MemoryRouter>
+        </QueryClientProvider>
+      </I18nextProvider>
+    </OxygenUIThemeProvider>,
+  )
+}
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+})
+
+describe('ConsentDetailsPage admin variant - acting on a consent as its own stakeholder', () => {
+  it('offers only revoke for an uninvolved consent when the admin has the any-consent scope', async () => {
+    adminConsentsApi.fetchAdminConsentByID.mockResolvedValue(buildConsent('ACTIVE'))
+
+    renderAdminDetailPage([REQUIRED_SCOPES.CONSENTS_READ_ANY, REQUIRED_SCOPES.CONSENTS_WRITE_ANY])
+
+    expect(await screen.findByRole('button', { name: 'Revoke' })).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Approve' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Reject' })).not.toBeInTheDocument()
+  })
+
+  it('offers no lifecycle action for an uninvolved consent without the any-consent write scope', async () => {
+    adminConsentsApi.fetchAdminConsentByID.mockResolvedValue(buildConsent('ACTIVE'))
+
+    renderAdminDetailPage([REQUIRED_SCOPES.CONSENTS_READ_ANY, REQUIRED_SCOPES.CONSENTS_WRITE_SELF])
+
+    expect(await screen.findByRole('heading', { name: 'Consent Details' })).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Revoke' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Approve' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Reject' })).not.toBeInTheDocument()
+  })
+
+  it('offers approve, reject and revoke when the admin is themselves the subject', async () => {
+    adminConsentsApi.fetchAdminConsentByID.mockResolvedValue(
+      buildConsent('PENDING', { subjectId: CURRENT_USER_ID }),
+    )
+
+    renderAdminDetailPage([REQUIRED_SCOPES.CONSENTS_READ_ANY, REQUIRED_SCOPES.CONSENTS_WRITE_SELF])
+
+    expect(await screen.findByRole('button', { name: 'Approve' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Reject' })).toBeInTheDocument()
+  })
+
+  it('offers approve and reject when the admin is listed as an authorizer, not the subject', async () => {
+    adminConsentsApi.fetchAdminConsentByID.mockResolvedValue(
+      buildConsent('PENDING', {
+        authorizations: [{ userId: CURRENT_USER_ID, state: 'PENDING', updatedTime: 1 }],
+      }),
+    )
+
+    renderAdminDetailPage([REQUIRED_SCOPES.CONSENTS_READ_ANY, REQUIRED_SCOPES.CONSENTS_WRITE_SELF])
+
+    expect(await screen.findByRole('button', { name: 'Approve' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Reject' })).toBeInTheDocument()
+  })
+
+  it('offers only reject when the admin, as authorizer, already approved - the aggregate is still pending on others', async () => {
+    adminConsentsApi.fetchAdminConsentByID.mockResolvedValue(
+      buildConsent('PENDING', {
+        authorizations: [{ userId: CURRENT_USER_ID, state: 'APPROVED', updatedTime: 1 }],
+      }),
+    )
+
+    renderAdminDetailPage([REQUIRED_SCOPES.CONSENTS_READ_ANY, REQUIRED_SCOPES.CONSENTS_WRITE_SELF])
+
+    expect(await screen.findByRole('button', { name: 'Reject' })).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Approve' })).not.toBeInTheDocument()
+  })
+
+  it('lets an admin who is also the subject revoke via the any-consent scope even without write-self', async () => {
+    adminConsentsApi.fetchAdminConsentByID.mockResolvedValue(
+      buildConsent('ACTIVE', { subjectId: CURRENT_USER_ID }),
+    )
+
+    renderAdminDetailPage([REQUIRED_SCOPES.CONSENTS_READ_ANY, REQUIRED_SCOPES.CONSENTS_WRITE_ANY])
+
+    expect(await screen.findByRole('button', { name: 'Revoke' })).toBeInTheDocument()
+  })
+
+  it('calls the self-service authorize endpoint (not the admin API) when approving from the admin view', async () => {
+    adminConsentsApi.fetchAdminConsentByID.mockResolvedValue(
+      buildConsent('PENDING', { subjectId: CURRENT_USER_ID }),
+    )
+    myConsentsApi.approveMyConsent.mockResolvedValue({ status: 'OK' })
+
+    renderAdminDetailPage([REQUIRED_SCOPES.CONSENTS_READ_ANY, REQUIRED_SCOPES.CONSENTS_WRITE_SELF])
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Approve' }))
+    fireEvent.click(await screen.findByRole('button', { name: 'Approve Consent' }))
+
+    await waitFor(() => {
+      expect(myConsentsApi.approveMyConsent).toHaveBeenCalledWith(CONSENT_ID, CURRENT_USER_ID)
+    })
+  })
+})

--- a/dpdp-accelerator/react-apps/consent-portal/frontend/src/__tests__/ConsentLifecycleSection.test.tsx
+++ b/dpdp-accelerator/react-apps/consent-portal/frontend/src/__tests__/ConsentLifecycleSection.test.tsx
@@ -17,7 +17,7 @@
  */
 
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { cleanup, fireEvent, render, screen, within } from '@testing-library/react'
 import { AcrylicOrangeTheme, OxygenUIThemeProvider } from '@wso2/oxygen-ui'
 import { I18nextProvider } from 'react-i18next'
 import { afterEach, describe, expect, it, vi } from 'vitest'
@@ -202,7 +202,7 @@ describe('ConsentLifecycleSection', () => {
     })
   })
 
-  it('restricts the snapshot diff to expiryTime, properties and authorizations', async () => {
+  it('restricts the snapshot diff to state, expiryTime, properties and authorizations', async () => {
     consentHistoryApi.fetchMyConsentStatusHistory.mockResolvedValue({
       consentId: CONSENT_ID,
       statusHistory: [entry()],
@@ -216,6 +216,7 @@ describe('ConsentLifecycleSection', () => {
           actionBy: 'jane@wso2.com',
           actionTime: 1785835726132,
           snapshot: {
+            state: 'ACTIVE',
             expiryTime: 1_800_000_000_000,
             properties: { region: 'EU' },
             authorizations: [
@@ -230,9 +231,11 @@ describe('ConsentLifecycleSection', () => {
     renderSection('self', SELF_SCOPE_WITH_SNAPSHOT)
 
     fireEvent.click(await screen.findByRole('button', { name: 'View Full Snapshot History' }))
-    fireEvent.click(await screen.findByRole('button', { name: /Consent created/ }))
+    const dialog = await screen.findByRole('dialog')
+    fireEvent.click(await within(dialog).findByRole('button', { name: /Consent created/ }))
 
-    expect(await screen.findByText('EU')).toBeInTheDocument()
-    expect(screen.queryByText('customer-360-portal')).not.toBeInTheDocument()
+    expect(await within(dialog).findByText('EU')).toBeInTheDocument()
+    expect(await within(dialog).findByText('Active')).toBeInTheDocument()
+    expect(within(dialog).queryByText('customer-360-portal')).not.toBeInTheDocument()
   })
 })

--- a/dpdp-accelerator/react-apps/consent-portal/frontend/src/__tests__/ConsentRegistryPage.test.tsx
+++ b/dpdp-accelerator/react-apps/consent-portal/frontend/src/__tests__/ConsentRegistryPage.test.tsx
@@ -227,6 +227,8 @@ describe('ConsentRegistryPage', () => {
     expect(listParams()).toEqual({
       state: 'PENDING',
       serviceId: 'dpdp-portal',
+      relation: 'ANY',
+      filter: undefined,
       limit: 25,
       offset: 50,
     })

--- a/dpdp-accelerator/react-apps/consent-portal/frontend/src/__tests__/ConsentRegistryPage.test.tsx
+++ b/dpdp-accelerator/react-apps/consent-portal/frontend/src/__tests__/ConsentRegistryPage.test.tsx
@@ -192,8 +192,18 @@ describe('ConsentRegistryPage', () => {
     expect(await screen.findByText('Unable to load consents right now.')).toBeInTheDocument()
   })
 
-  it('does not render approve action for rejected consents', async () => {
+  it('offers approve (not revoke) for a rejected consent, so it can be reconsidered', async () => {
     mockConsentSearch([buildConsent({ state: 'REJECTED' })])
+
+    renderConsentRegistryPage(createQueryClient())
+
+    expect(await screen.findByText('marketing-spike')).toBeInTheDocument()
+    expect(screen.getAllByLabelText('Approve').length).toBeGreaterThan(0)
+    expect(screen.queryByLabelText('Revoke')).not.toBeInTheDocument()
+  })
+
+  it('does not render approve action for a revoked consent - a withdrawal stays final', async () => {
+    mockConsentSearch([buildConsent({ state: 'REVOKED' })])
 
     renderConsentRegistryPage(createQueryClient())
 
@@ -245,6 +255,22 @@ describe('ConsentRegistryPage', () => {
       'aria-current',
       'page',
     )
+  })
+
+  it('locks state and relation to the pending queue - narrowing either means leaving this view', async () => {
+    mockConsentSearch([])
+
+    renderConsentRegistryPage(createQueryClient(), '/consents?state=PENDING&relation=AUTHORIZER')
+
+    await screen.findByRole('heading', { name: 'My Pending Consents' })
+    expect(screen.getByRole('combobox', { name: 'State' })).toHaveAttribute('aria-disabled', 'true')
+    expect(screen.getByRole('combobox', { name: 'Relation' })).toHaveTextContent('All')
+    expect(screen.getByRole('combobox', { name: 'Relation' })).toHaveAttribute(
+      'aria-disabled',
+      'true',
+    )
+    // Relation is forced to ANY server-side too, not just visually locked.
+    expect(consentsApi.fetchMyConsents.mock.calls[0]?.[0]).toMatchObject({ relation: 'ANY' })
   })
 
   it('ignores the removed CREATED status in the URL', async () => {

--- a/dpdp-accelerator/react-apps/consent-portal/frontend/src/__tests__/ConsentSnapshotDiff.test.ts
+++ b/dpdp-accelerator/react-apps/consent-portal/frontend/src/__tests__/ConsentSnapshotDiff.test.ts
@@ -22,6 +22,7 @@ import { annotateSnapshot, diffConsentSnapshots } from '../utils/consentSnapshot
 
 function buildSnapshot(overrides: Partial<ConsentSnapshot> = {}): ConsentSnapshot {
   return {
+    state: 'ACTIVE',
     expiryTime: 1_700_000_000_000,
     properties: { region: 'EU' },
     authorizations: [
@@ -46,6 +47,22 @@ describe('diffConsentSnapshots', () => {
     expect(diff.isInitial).toBe(true)
     expect(diff.hasChanges).toBe(true)
     expect(diff.properties).toEqual([{ key: 'region', kind: 'added', after: 'EU' }])
+  })
+
+  it('detects a state change, e.g. an EXPIRED consent revived to ACTIVE', () => {
+    const diff = diffConsentSnapshots(
+      buildSnapshot({ state: 'EXPIRED' }),
+      buildSnapshot({ state: 'ACTIVE' }),
+    )
+
+    expect(diff.state).toEqual({ before: 'EXPIRED', after: 'ACTIVE', changed: true })
+    expect(diff.hasChanges).toBe(true)
+  })
+
+  it('does not report a state change for the initial (no "before") snapshot', () => {
+    const diff = diffConsentSnapshots(undefined, buildSnapshot({ state: 'ACTIVE' }))
+
+    expect(diff.state).toEqual({ before: undefined, after: 'ACTIVE', changed: false })
   })
 
   it('detects an expiryTime change', () => {
@@ -188,6 +205,23 @@ describe('annotateSnapshot', () => {
         { key: 'dataCategory', before: 'financial', kind: 'removed' },
       ]),
     )
+  })
+
+  it('marks a state change', () => {
+    const before = buildSnapshot({ state: 'EXPIRED' })
+    const after = buildSnapshot({ state: 'ACTIVE' })
+    const diff = diffConsentSnapshots(before, after)
+    const annotated = annotateSnapshot(after, diff)
+
+    expect(annotated.state).toEqual({ value: 'ACTIVE', before: 'EXPIRED', kind: 'changed' })
+  })
+
+  it('leaves state unchanged when it did not change', () => {
+    const snapshot = buildSnapshot({ state: 'ACTIVE' })
+    const diff = diffConsentSnapshots(snapshot, buildSnapshot({ state: 'ACTIVE' }))
+    const annotated = annotateSnapshot(snapshot, diff)
+
+    expect(annotated.state).toEqual({ value: 'ACTIVE', before: undefined, kind: 'unchanged' })
   })
 
   it('marks an expiryTime change and leaves the rest unchanged', () => {

--- a/dpdp-accelerator/react-apps/consent-portal/frontend/src/__tests__/ConsentStatusChip.test.ts
+++ b/dpdp-accelerator/react-apps/consent-portal/frontend/src/__tests__/ConsentStatusChip.test.ts
@@ -22,8 +22,6 @@ import { describe, expect, it } from 'vitest'
 import {
   getConsentStateChipColor,
   getConsentStateLabelKey,
-  isConsentApprovableState,
-  isConsentRejectableState,
   isConsentRevokableState,
 } from '../features/my-consents/utils/statusChip'
 import { CONSENT_AUTHORIZATION_STATES, CONSENT_STATES, isConsentState } from '../types/consent'
@@ -64,18 +62,13 @@ describe('consent state presentation', () => {
     })
   })
 
-  it('limits lifecycle actions to their supported states', () => {
-    expect(isConsentApprovableState('PENDING')).toBe(true)
-    expect(isConsentRejectableState('PENDING')).toBe(true)
+  it('limits revocation to active consents', () => {
     expect(isConsentRevokableState('ACTIVE')).toBe(true)
-    expect(isConsentApprovableState('ACTIVE')).toBe(false)
-    expect(isConsentRejectableState('REJECTED')).toBe(false)
     expect(isConsentRevokableState('PENDING')).toBe(false)
   })
 
   it('no longer recognises the removed CREATED state', () => {
     expect(CONSENT_STATES).toEqual(['PENDING', 'ACTIVE', 'REJECTED', 'REVOKED', 'EXPIRED'])
     expect(isConsentState('CREATED')).toBe(false)
-    expect(isConsentApprovableState('CREATED')).toBe(false)
   })
 })

--- a/dpdp-accelerator/react-apps/consent-portal/frontend/src/features/admin-consents/AdminConsentRegistryPage.tsx
+++ b/dpdp-accelerator/react-apps/consent-portal/frontend/src/features/admin-consents/AdminConsentRegistryPage.tsx
@@ -71,7 +71,9 @@ function toSearchParams(
   const params = new URLSearchParams()
 
   Object.entries(filters).forEach(([key, value]) => {
-    if (key === 'state' ? value !== 'All' : Boolean(value)) params.set(key, value)
+    if (key === 'state' && value === 'All') return
+    if (key === 'relation' && value === 'ANY') return
+    if (value) params.set(key, value)
   })
   if (cursor.after) params.set('after', cursor.after)
   if (cursor.before) params.set('before', cursor.before)
@@ -117,11 +119,18 @@ export default function AdminConsentRegistryPage(): React.JSX.Element {
           value: filters.consentId,
         }
       : undefined,
-    filters.subjectId
+    filters.userId
       ? {
-          key: 'subjectId',
+          key: 'userId',
           label: t('consentRegistry.details.table.user'),
-          value: filters.subjectId,
+          value: filters.userId,
+        }
+      : undefined,
+    filters.userId && filters.relation !== 'ANY'
+      ? {
+          key: 'relation',
+          label: t('adminConsents.filters.relation'),
+          value: t(`adminConsents.filters.relationOptions.${filters.relation.toLowerCase()}`),
         }
       : undefined,
     filters.serviceId
@@ -137,11 +146,30 @@ export default function AdminConsentRegistryPage(): React.JSX.Element {
           value: `${filters.propertyKey} = ${filters.propertyValue}`,
         }
       : undefined,
+    filters.createdAfter || filters.createdBefore
+      ? {
+          key: 'createdRange',
+          label: t('consentRegistry.filters.advanced'),
+          value: `${filters.createdAfter || '…'} – ${filters.createdBefore || '…'}`,
+        }
+      : undefined,
   ].filter((chip): chip is ActiveFilterChip => Boolean(chip))
 
   const removeFilter = (key: string): void => {
     if (key === 'property') {
       updateParams({ ...filters, propertyKey: '', propertyValue: '' })
+      return
+    }
+    if (key === 'createdRange') {
+      updateParams({ ...filters, createdAfter: '', createdBefore: '' })
+      return
+    }
+    if (key === 'userId') {
+      updateParams({ ...filters, userId: '', relation: 'ANY' })
+      return
+    }
+    if (key === 'relation') {
+      updateParams({ ...filters, relation: 'ANY' })
       return
     }
     updateParams({

--- a/dpdp-accelerator/react-apps/consent-portal/frontend/src/features/admin-consents/api/adminConsentsApi.ts
+++ b/dpdp-accelerator/react-apps/consent-portal/frontend/src/features/admin-consents/api/adminConsentsApi.ts
@@ -49,48 +49,30 @@ export async function fetchAdminConsentByID(consentID: string): Promise<ConsentD
 /**
  * Lists consents across users.
  *
- * The Identity Server's list rows carry no purposes, so each row on the page
- * is expanded with a detail lookup - the table shows which purposes a consent
- * covers. The lookups run together, and a row whose lookup fails keeps its
- * summary rather than blanking the page.
- *
- * The expansion goes away once the list endpoint returns purposes itself:
- * https://github.com/wso2/dpdp-accelerator/issues/23
+ * `attributes=purposes,authorizations` asks the list endpoint to inline what
+ * the table needs directly, so no per-row detail lookup is required here (see
+ * https://github.com/wso2/dpdp-accelerator/issues/23). `relation` is only
+ * meaningful paired with `userId` - the server rejects one without the other
+ * - so it's omitted whenever no user is being searched for.
  */
 export async function fetchAdminConsents(
   params: AdminConsentListQueryParams,
 ): Promise<AdminConsentListResponse> {
-  const response = await apiRequest<AdminConsentListResponse>(`${CONSENT_MGT_V2}/consents`, {
+  return apiRequest<AdminConsentListResponse>(`${CONSENT_MGT_V2}/consents`, {
     method: 'GET',
     query: {
       limit: params.limit,
       after: params.after,
       before: params.before,
-      subjectId: params.subjectId,
+      userId: params.userId,
+      relation: params.userId ? params.relation : undefined,
       serviceId: params.serviceId,
       state: params.state,
       purposeId: params.purposeId,
       filter: params.filter,
+      attributes: 'purposes,authorizations',
     },
   })
-
-  const summaries = response.Consents ?? []
-  if (summaries.length === 0) {
-    return response
-  }
-
-  const consents = await Promise.all(
-    summaries.map(async (summary) => {
-      try {
-        return await fetchAdminConsentByID(summary.id)
-      } catch {
-        // One failed lookup must not blank the whole page.
-        return summary
-      }
-    }),
-  )
-
-  return { ...response, Consents: consents }
 }
 
 export async function revokeAdminConsent(consentID: string): Promise<unknown> {

--- a/dpdp-accelerator/react-apps/consent-portal/frontend/src/features/admin-consents/components/AdminConsentFilters.tsx
+++ b/dpdp-accelerator/react-apps/consent-portal/frontend/src/features/admin-consents/components/AdminConsentFilters.tsx
@@ -174,13 +174,13 @@ export default function AdminConsentFilters({
           </Box>
         </Tooltip>
 
-        <Tooltip title={!draft.userId ? t('adminConsents.filters.relationHelperText') : ''}>
+        <Tooltip
+          title={
+            !draft.userId && !filters.consentId ? t('adminConsents.filters.relationHelperText') : ''
+          }
+        >
           <Box component="span" sx={{ width: { xs: '100%', sm: 170 }, flexShrink: 0 }}>
-            <FormControl
-              size="small"
-              fullWidth
-              disabled={!draft.userId || Boolean(filters.consentId)}
-            >
+            <FormControl size="small" fullWidth disabled={Boolean(filters.consentId)}>
               <InputLabel id="admin-consent-relation-label">
                 {t('adminConsents.filters.relation')}
               </InputLabel>

--- a/dpdp-accelerator/react-apps/consent-portal/frontend/src/features/admin-consents/components/AdminConsentFilters.tsx
+++ b/dpdp-accelerator/react-apps/consent-portal/frontend/src/features/admin-consents/components/AdminConsentFilters.tsx
@@ -17,8 +17,10 @@
  */
 
 import {
+  AdapterDateFns,
   Box,
   Button,
+  DatePickers,
   FormControl,
   InputLabel,
   MenuItem,
@@ -34,12 +36,23 @@ import { ListFilter } from '@wso2/oxygen-ui-icons-react'
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import type { AdminConsentRegistryFilters } from '../../../types/consent'
-import { CONSENT_STATES } from '../../../types/consent'
+import { CONSENT_RELATIONS, CONSENT_STATES } from '../../../types/consent'
+import { parseDateOnly } from '../../../utils/dateTime'
 import { getConsentStateLabelKey } from '../../my-consents/utils/statusChip'
 import {
   EMPTY_ADMIN_CONSENT_FILTERS,
   normalizeAdminConsentFilters,
 } from '../utils/adminConsentFilters'
+
+function toDateOnly(date: Date | null): string {
+  if (!date || Number.isNaN(date.getTime())) {
+    return ''
+  }
+  const year = date.getFullYear()
+  const month = String(date.getMonth() + 1).padStart(2, '0')
+  const day = String(date.getDate()).padStart(2, '0')
+  return `${String(year)}-${month}-${day}`
+}
 
 interface AdminConsentFiltersProps {
   filters: AdminConsentRegistryFilters
@@ -62,6 +75,7 @@ export default function AdminConsentFilters({
     filters.serviceId,
     filters.purposeId,
     filters.propertyKey && filters.propertyValue ? 'set' : '',
+    filters.createdAfter || filters.createdBefore ? 'set' : '',
   ].filter(Boolean).length
 
   const applyFilters = (next: AdminConsentRegistryFilters): void => {
@@ -149,14 +163,47 @@ export default function AdminConsentFilters({
               size="small"
               fullWidth
               label={t('consentRegistry.details.table.user')}
-              value={draft.subjectId}
+              value={draft.userId}
               disabled={Boolean(filters.consentId)}
               sx={{ '& .MuiInputBase-root': { height: MAIN_FILTER_HEIGHT } }}
-              onChange={(event) => setDraft({ ...draft, subjectId: event.target.value })}
+              onChange={(event) => setDraft({ ...draft, userId: event.target.value })}
               onKeyDown={(event) => {
                 if (event.key === 'Enter') applyFilters(draft)
               }}
             />
+          </Box>
+        </Tooltip>
+
+        <Tooltip title={!draft.userId ? t('adminConsents.filters.relationHelperText') : ''}>
+          <Box component="span" sx={{ width: { xs: '100%', sm: 170 }, flexShrink: 0 }}>
+            <FormControl
+              size="small"
+              fullWidth
+              disabled={!draft.userId || Boolean(filters.consentId)}
+            >
+              <InputLabel id="admin-consent-relation-label">
+                {t('adminConsents.filters.relation')}
+              </InputLabel>
+              <Select
+                labelId="admin-consent-relation-label"
+                value={draft.relation}
+                label={t('adminConsents.filters.relation')}
+                sx={{ height: MAIN_FILTER_HEIGHT }}
+                onChange={(event) =>
+                  applyFilters({
+                    ...filters,
+                    ...draft,
+                    relation: event.target.value as AdminConsentRegistryFilters['relation'],
+                  })
+                }
+              >
+                {CONSENT_RELATIONS.map((relation) => (
+                  <MenuItem key={relation} value={relation}>
+                    {t(`adminConsents.filters.relationOptions.${relation.toLowerCase()}`)}
+                  </MenuItem>
+                ))}
+              </Select>
+            </FormControl>
           </Box>
         </Tooltip>
 
@@ -253,6 +300,35 @@ export default function AdminConsentFilters({
               />
             </Stack>
           </Stack>
+
+          <DatePickers.LocalizationProvider dateAdapter={AdapterDateFns}>
+            <Stack direction={{ xs: 'column', sm: 'row' }} spacing={2}>
+              <DatePickers.DatePicker
+                label={t('consentRegistry.filters.startDate')}
+                value={parseDateOnly(draft.createdAfter) ?? null}
+                onChange={(date) => setDraft({ ...draft, createdAfter: toDateOnly(date) })}
+                slotProps={{
+                  textField: {
+                    size: 'small',
+                    fullWidth: true,
+                    inputProps: { 'aria-label': t('consentRegistry.filters.startDateAriaLabel') },
+                  },
+                }}
+              />
+              <DatePickers.DatePicker
+                label={t('consentRegistry.filters.endDate')}
+                value={parseDateOnly(draft.createdBefore) ?? null}
+                onChange={(date) => setDraft({ ...draft, createdBefore: toDateOnly(date) })}
+                slotProps={{
+                  textField: {
+                    size: 'small',
+                    fullWidth: true,
+                    inputProps: { 'aria-label': t('consentRegistry.filters.endDateAriaLabel') },
+                  },
+                }}
+              />
+            </Stack>
+          </DatePickers.LocalizationProvider>
 
           <Stack
             direction="row"

--- a/dpdp-accelerator/react-apps/consent-portal/frontend/src/features/admin-consents/hooks/useAdminConsentQueries.ts
+++ b/dpdp-accelerator/react-apps/consent-portal/frontend/src/features/admin-consents/hooks/useAdminConsentQueries.ts
@@ -29,12 +29,11 @@ import type {
   AdminConsentRegistryFilters,
   ConsentDetail,
   ConsentRecord,
-  ConsentSummary,
 } from '../../../types/consent'
-import { isConsentState } from '../../../types/consent'
 import { getNextCursor, getPreviousCursor } from '../../../utils/cursorPagination'
-import { normalizeConsentState } from '../../my-consents/utils/statusChip'
-import { toConsentRow } from '../../my-consents/hooks/useConsentQueries'
+import { toConsentRow, toConsentRowFromSummary } from '../../../utils/consentRows'
+import { buildTimestampFilter, combineFilters } from '../../../utils/filterGrammar'
+import { endOfDayMillis, parseDateOnly, startOfDayMillis } from '../../../utils/dateTime'
 import {
   buildConsentPropertyFilter,
   fetchAdminConsentByID,
@@ -48,37 +47,30 @@ export interface AdminConsentListResult {
   previousCursor?: string
 }
 
-function toAdminConsentRow(consent: ConsentSummary): ConsentRecord {
-  const normalizedState = normalizeConsentState(consent.state)
-
-  if (!isConsentState(normalizedState)) {
-    throw new Error(`Unsupported consent state received from API: ${consent.state}`)
-  }
-
-  return {
-    id: consent.id,
-    subjectId: consent.subjectId,
-    serviceId: consent.serviceId,
-    state: normalizedState,
-    timestamp: consent.timestamp,
-    purposes: consent.purposes?.map((purpose) => purpose.name),
-  }
-}
-
 function toListParams(
   filters: AdminConsentRegistryFilters,
   rowsPerPage: number,
   cursor: { after?: string; before?: string },
 ): AdminConsentListQueryParams {
+  const afterDate = parseDateOnly(filters.createdAfter)
+  const beforeDate = parseDateOnly(filters.createdBefore)
+
   return {
     limit: rowsPerPage,
     after: cursor.after,
     before: cursor.before,
-    subjectId: filters.subjectId || undefined,
+    userId: filters.userId || undefined,
+    relation: filters.relation,
     serviceId: filters.serviceId || undefined,
     state: filters.state === 'All' ? undefined : filters.state,
     purposeId: filters.purposeId || undefined,
-    filter: buildConsentPropertyFilter(filters.propertyKey, filters.propertyValue),
+    filter: combineFilters(
+      buildConsentPropertyFilter(filters.propertyKey, filters.propertyValue),
+      buildTimestampFilter(
+        afterDate ? startOfDayMillis(afterDate) : undefined,
+        beforeDate ? endOfDayMillis(beforeDate) : undefined,
+      ),
+    ),
   }
 }
 
@@ -101,7 +93,7 @@ export function useAdminConsentListQuery(
       const response = await fetchAdminConsents(params)
 
       return {
-        rows: response.Consents.map(toAdminConsentRow),
+        rows: response.Consents.map(toConsentRowFromSummary),
         nextCursor: getNextCursor(response.links),
         previousCursor: getPreviousCursor(response.links),
       }

--- a/dpdp-accelerator/react-apps/consent-portal/frontend/src/features/admin-consents/utils/adminConsentFilters.ts
+++ b/dpdp-accelerator/react-apps/consent-portal/frontend/src/features/admin-consents/utils/adminConsentFilters.ts
@@ -16,17 +16,28 @@
  * under the License.
  */
 
-import type { AdminConsentRegistryFilters, ConsentState } from '../../../types/consent'
-import { isConsentState } from '../../../types/consent'
+import type {
+  AdminConsentRegistryFilters,
+  ConsentRelation,
+  ConsentState,
+} from '../../../types/consent'
+import { CONSENT_RELATIONS, isConsentState } from '../../../types/consent'
+
+function isConsentRelation(value: string): value is ConsentRelation {
+  return (CONSENT_RELATIONS as readonly string[]).includes(value)
+}
 
 export const EMPTY_ADMIN_CONSENT_FILTERS: AdminConsentRegistryFilters = {
   state: 'All',
   consentId: '',
-  subjectId: '',
+  userId: '',
+  relation: 'ANY',
   serviceId: '',
   purposeId: '',
   propertyKey: '',
   propertyValue: '',
+  createdAfter: '',
+  createdBefore: '',
 }
 
 export function normalizeAdminConsentFilters(
@@ -35,24 +46,31 @@ export function normalizeAdminConsentFilters(
   return {
     state: filters.state,
     consentId: filters.consentId.trim(),
-    subjectId: filters.subjectId.trim(),
+    userId: filters.userId.trim(),
+    relation: filters.relation,
     serviceId: filters.serviceId.trim(),
     purposeId: filters.purposeId.trim(),
     propertyKey: filters.propertyKey.trim(),
     propertyValue: filters.propertyValue.trim(),
+    createdAfter: filters.createdAfter.trim(),
+    createdBefore: filters.createdBefore.trim(),
   }
 }
 
 export function getAdminConsentFilters(searchParams: URLSearchParams): AdminConsentRegistryFilters {
   const state = searchParams.get('state') ?? ''
+  const relation = searchParams.get('relation') ?? ''
 
   return normalizeAdminConsentFilters({
     state: isConsentState(state) ? (state as ConsentState) : 'All',
     consentId: searchParams.get('consentId') ?? '',
-    subjectId: searchParams.get('subjectId') ?? '',
+    userId: searchParams.get('userId') ?? '',
+    relation: isConsentRelation(relation) ? relation : 'ANY',
     serviceId: searchParams.get('serviceId') ?? '',
     purposeId: searchParams.get('purposeId') ?? '',
     propertyKey: searchParams.get('propertyKey') ?? '',
     propertyValue: searchParams.get('propertyValue') ?? '',
+    createdAfter: searchParams.get('createdAfter') ?? '',
+    createdBefore: searchParams.get('createdBefore') ?? '',
   })
 }

--- a/dpdp-accelerator/react-apps/consent-portal/frontend/src/features/dashboard/DashboardPage.tsx
+++ b/dpdp-accelerator/react-apps/consent-portal/frontend/src/features/dashboard/DashboardPage.tsx
@@ -35,7 +35,7 @@ import { useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Link as RouterLink, useNavigate } from 'react-router-dom'
 import HeaderBreadcrumbs from '../../components/layout/main-layout/HeaderBreadcrumbs'
-import type { ConsentDetail } from '../../types/consent'
+import type { ConsentSummary } from '../../types/consent'
 import { formatEpochTimestamp } from '../../utils/dateTime'
 import { normalizeConsentState } from '../my-consents/utils/statusChip'
 import useDashboardConsentsQuery from './hooks/useDashboardConsentsQuery'
@@ -52,20 +52,20 @@ interface LabelledCount {
 interface DashboardData {
   activeCount: number
   pendingCount: number
-  pending: ConsentDetail[]
+  pending: ConsentSummary[]
   purposes: LabelledCount[]
   services: LabelledCount[]
 }
 
-function summarizePurposes(consent: ConsentDetail): string {
-  const labels = consent.purposes.map((purpose) => purpose.name)
+function summarizePurposes(consent: ConsentSummary): string {
+  const labels = (consent.purposes ?? []).map((purpose) => purpose.name)
 
   if (labels.length === 0) return '-'
   if (labels.length === 1) return labels[0]
   return `${labels[0]} +${String(labels.length - 1)}`
 }
 
-function PendingConsentRow({ consent }: { consent: ConsentDetail }): React.JSX.Element {
+function PendingConsentRow({ consent }: { consent: ConsentSummary }): React.JSX.Element {
   const navigate = useNavigate()
   const consentPath = `/consents/${encodeURIComponent(consent.id)}`
 
@@ -126,7 +126,7 @@ function DashboardPage(): React.JSX.Element {
 
     const purposeCounts = new Map<string, LabelledCount>()
     active.forEach((consent) => {
-      consent.purposes.forEach((purpose) => {
+      ;(consent.purposes ?? []).forEach((purpose) => {
         const existing = purposeCounts.get(purpose.id)
         purposeCounts.set(purpose.id, {
           id: purpose.id,

--- a/dpdp-accelerator/react-apps/consent-portal/frontend/src/features/dashboard/hooks/useDashboardConsentsQuery.ts
+++ b/dpdp-accelerator/react-apps/consent-portal/frontend/src/features/dashboard/hooks/useDashboardConsentsQuery.ts
@@ -17,7 +17,7 @@
  */
 
 import { type UseQueryResult, useQuery } from '@tanstack/react-query'
-import type { ConsentDetail } from '../../../types/consent'
+import type { ConsentSummary } from '../../../types/consent'
 import { fetchMyConsents } from '../../my-consents/api/myConsentsApi'
 
 const DASHBOARD_PAGE_SIZE = 100
@@ -31,9 +31,9 @@ const DASHBOARD_MAX_PAGES = 20
  */
 async function fetchConsentPage(
   offset: number,
-  collected: ConsentDetail[],
+  collected: ConsentSummary[],
   remainingPages: number,
-): Promise<ConsentDetail[]> {
+): Promise<ConsentSummary[]> {
   const response = await fetchMyConsents({ limit: DASHBOARD_PAGE_SIZE, offset })
   const consents = [...collected, ...response.data]
 
@@ -44,11 +44,11 @@ async function fetchConsentPage(
   return fetchConsentPage(offset + response.data.length, consents, remainingPages - 1)
 }
 
-async function fetchAllMyConsents(): Promise<ConsentDetail[]> {
+async function fetchAllMyConsents(): Promise<ConsentSummary[]> {
   return fetchConsentPage(0, [], DASHBOARD_MAX_PAGES)
 }
 
-export default function useDashboardConsentsQuery(): UseQueryResult<ConsentDetail[]> {
+export default function useDashboardConsentsQuery(): UseQueryResult<ConsentSummary[]> {
   return useQuery({
     queryKey: ['consents', 'dashboard'],
     queryFn: fetchAllMyConsents,

--- a/dpdp-accelerator/react-apps/consent-portal/frontend/src/features/my-consents/ConsentDetailsPage.tsx
+++ b/dpdp-accelerator/react-apps/consent-portal/frontend/src/features/my-consents/ConsentDetailsPage.tsx
@@ -47,11 +47,8 @@ import {
   useRejectConsentMutation,
   useRevokeConsentMutation,
 } from './hooks/useConsentQueries'
-import {
-  isConsentApprovableState,
-  isConsentRejectableState,
-  isConsentRevokableState,
-} from './utils/statusChip'
+import { isApprovableByCurrentUser, isRejectableByCurrentUser } from './utils/consentAuthorization'
+import { isConsentRevokableState } from './utils/statusChip'
 import { REQUIRED_SCOPES } from '../../utils/scopes'
 import {
   useAdminConsentDetailQuery,
@@ -103,7 +100,7 @@ function ConsentDetailsPage({ variant = 'self' }: ConsentDetailsPageProps): Reac
   const [approvalDialogOpen, setApprovalDialogOpen] = useState<boolean>(false)
   const [rejectionDialogOpen, setRejectionDialogOpen] = useState<boolean>(false)
   const [revocationDialogOpen, setRevocationDialogOpen] = useState<boolean>(false)
-  const { hasScope } = useAuthorization()
+  const { currentUser, hasScope } = useAuthorization()
   const canWriteSelf = hasScope(REQUIRED_SCOPES.CONSENTS_WRITE_SELF)
   const canWriteAny = hasScope(REQUIRED_SCOPES.CONSENTS_WRITE_ANY)
   const consentDetailQuery = variant === 'admin' ? adminConsentDetailQuery : selfConsentDetailQuery
@@ -131,9 +128,15 @@ function ConsentDetailsPage({ variant = 'self' }: ConsentDetailsPageProps): Reac
 
   const detail = consentDetailQuery.data
   const canApprove =
-    variant === 'self' && detail ? canWriteSelf && isConsentApprovableState(detail.state) : false
+    variant === 'self' && detail
+      ? canWriteSelf &&
+        isApprovableByCurrentUser(detail.state, detail.authorizations, currentUser.userId)
+      : false
   const canReject =
-    variant === 'self' && detail ? canWriteSelf && isConsentRejectableState(detail.state) : false
+    variant === 'self' && detail
+      ? canWriteSelf &&
+        isRejectableByCurrentUser(detail.state, detail.authorizations, currentUser.userId)
+      : false
   const canRevoke = detail
     ? (variant === 'admin' ? canWriteAny : canWriteSelf) && isConsentRevokableState(detail.state)
     : false

--- a/dpdp-accelerator/react-apps/consent-portal/frontend/src/features/my-consents/ConsentDetailsPage.tsx
+++ b/dpdp-accelerator/react-apps/consent-portal/frontend/src/features/my-consents/ConsentDetailsPage.tsx
@@ -47,7 +47,11 @@ import {
   useRejectConsentMutation,
   useRevokeConsentMutation,
 } from './hooks/useConsentQueries'
-import { isApprovableByCurrentUser, isRejectableByCurrentUser } from './utils/consentAuthorization'
+import {
+  isApprovableByCurrentUser,
+  isCurrentUserInvolved,
+  isRejectableByCurrentUser,
+} from './utils/consentAuthorization'
 import { isConsentRevokableState } from './utils/statusChip'
 import { REQUIRED_SCOPES } from '../../utils/scopes'
 import {
@@ -93,14 +97,14 @@ function ConsentDetailsPage({ variant = 'self' }: ConsentDetailsPageProps): Reac
   const navigate = useNavigate()
   const selfConsentDetailQuery = useConsentDetailQuery(variant === 'self' ? id : undefined)
   const adminConsentDetailQuery = useAdminConsentDetailQuery(variant === 'admin' ? id : undefined)
-  const approveMutation = useApproveConsentMutation()
-  const rejectMutation = useRejectConsentMutation()
+  const { currentUser, hasScope } = useAuthorization()
+  const approveMutation = useApproveConsentMutation(currentUser.userId)
+  const rejectMutation = useRejectConsentMutation(currentUser.userId)
   const revokeMutation = useRevokeConsentMutation()
   const adminRevokeMutation = useAdminRevokeConsentMutation()
   const [approvalDialogOpen, setApprovalDialogOpen] = useState<boolean>(false)
   const [rejectionDialogOpen, setRejectionDialogOpen] = useState<boolean>(false)
   const [revocationDialogOpen, setRevocationDialogOpen] = useState<boolean>(false)
-  const { currentUser, hasScope } = useAuthorization()
   const canWriteSelf = hasScope(REQUIRED_SCOPES.CONSENTS_WRITE_SELF)
   const canWriteAny = hasScope(REQUIRED_SCOPES.CONSENTS_WRITE_ANY)
   const consentDetailQuery = variant === 'admin' ? adminConsentDetailQuery : selfConsentDetailQuery
@@ -127,18 +131,26 @@ function ConsentDetailsPage({ variant = 'self' }: ConsentDetailsPageProps): Reac
   }
 
   const detail = consentDetailQuery.data
+  // The self-service endpoint only ever returns consents the caller is
+  // already involved in, so this check is only meaningful for the admin
+  // registry, which can open any consent regardless of who's viewing it.
+  const isInvolved =
+    variant === 'admin' && detail
+      ? isCurrentUserInvolved(detail.subjectId, detail.authorizations, currentUser.userId)
+      : true
   const canApprove =
-    variant === 'self' && detail
+    detail && isInvolved
       ? canWriteSelf &&
         isApprovableByCurrentUser(detail.state, detail.authorizations, currentUser.userId)
       : false
   const canReject =
-    variant === 'self' && detail
+    detail && isInvolved
       ? canWriteSelf &&
         isRejectableByCurrentUser(detail.state, detail.authorizations, currentUser.userId)
       : false
   const canRevoke = detail
-    ? (variant === 'admin' ? canWriteAny : canWriteSelf) && isConsentRevokableState(detail.state)
+    ? (variant === 'admin' ? canWriteAny || (isInvolved && canWriteSelf) : canWriteSelf) &&
+      isConsentRevokableState(detail.state)
     : false
 
   if (consentDetailQuery.isLoading) {

--- a/dpdp-accelerator/react-apps/consent-portal/frontend/src/features/my-consents/ConsentRegistryPage.tsx
+++ b/dpdp-accelerator/react-apps/consent-portal/frontend/src/features/my-consents/ConsentRegistryPage.tsx
@@ -58,11 +58,16 @@ const DEFAULT_ROWS_PER_PAGE = 10
 function getFiltersFromSearchParams(searchParams: URLSearchParams): ConsentRegistryFiltersModel {
   const stateParam = searchParams.get('state') ?? ''
   const relationParam = searchParams.get('relation') ?? ''
+  const state = isConsentState(stateParam) ? (stateParam as ConsentState) : DEFAULT_FILTERS.state
+  const urlRelation = isConsentRelation(relationParam) ? relationParam : DEFAULT_FILTERS.relation
+  // The Pending queue is every relation at once - relation narrowing (and
+  // switching away from Pending) happens by leaving this view, not inside it.
+  const relation = state === 'PENDING' ? 'ANY' : urlRelation
 
   return {
-    state: isConsentState(stateParam) ? (stateParam as ConsentState) : DEFAULT_FILTERS.state,
+    state,
     serviceId: searchParams.get('serviceId') ?? DEFAULT_FILTERS.serviceId,
-    relation: isConsentRelation(relationParam) ? relationParam : DEFAULT_FILTERS.relation,
+    relation,
     createdAfter: searchParams.get('createdAfter') ?? DEFAULT_FILTERS.createdAfter,
     createdBefore: searchParams.get('createdBefore') ?? DEFAULT_FILTERS.createdBefore,
   }
@@ -131,9 +136,9 @@ function ConsentRegistryPage(): React.JSX.Element {
   const page = useMemo(() => getPageFromSearchParams(searchParams), [searchParams])
   const rowsPerPage = useMemo(() => getRowsPerPageFromSearchParams(searchParams), [searchParams])
   const consentListQuery = useConsentListQuery(filters, page, rowsPerPage)
-  const approveMutation = useApproveConsentMutation()
-  const revokeMutation = useRevokeConsentMutation()
   const { currentUser, hasScope } = useAuthorization()
+  const approveMutation = useApproveConsentMutation(currentUser.userId)
+  const revokeMutation = useRevokeConsentMutation()
   const canWriteSelf = hasScope(REQUIRED_SCOPES.CONSENTS_WRITE_SELF)
   const isTableLoading = consentListQuery.isPending || consentListQuery.isPlaceholderData
 

--- a/dpdp-accelerator/react-apps/consent-portal/frontend/src/features/my-consents/ConsentRegistryPage.tsx
+++ b/dpdp-accelerator/react-apps/consent-portal/frontend/src/features/my-consents/ConsentRegistryPage.tsx
@@ -28,9 +28,10 @@ import ConsentRevocationDialog from './components/ConsentRevocationDialog'
 import { CONSENT_REGISTRY_ROWS_PER_PAGE_OPTIONS } from './constants'
 import type {
   ConsentRegistryFilters as ConsentRegistryFiltersModel,
+  ConsentRelation,
   ConsentState,
 } from '../../types/consent'
-import { isConsentState } from '../../types/consent'
+import { CONSENT_RELATIONS, isConsentState } from '../../types/consent'
 import { REQUIRED_SCOPES } from '../../utils/scopes'
 import useAuthorization from '../auth/useAuthorization'
 import {
@@ -42,6 +43,13 @@ import {
 const DEFAULT_FILTERS: ConsentRegistryFiltersModel = {
   state: 'All',
   serviceId: '',
+  relation: 'ANY',
+  createdAfter: '',
+  createdBefore: '',
+}
+
+function isConsentRelation(value: string): value is ConsentRelation {
+  return (CONSENT_RELATIONS as readonly string[]).includes(value)
 }
 
 const DEFAULT_PAGE = 0
@@ -49,10 +57,14 @@ const DEFAULT_ROWS_PER_PAGE = 10
 
 function getFiltersFromSearchParams(searchParams: URLSearchParams): ConsentRegistryFiltersModel {
   const stateParam = searchParams.get('state') ?? ''
+  const relationParam = searchParams.get('relation') ?? ''
 
   return {
     state: isConsentState(stateParam) ? (stateParam as ConsentState) : DEFAULT_FILTERS.state,
     serviceId: searchParams.get('serviceId') ?? DEFAULT_FILTERS.serviceId,
+    relation: isConsentRelation(relationParam) ? relationParam : DEFAULT_FILTERS.relation,
+    createdAfter: searchParams.get('createdAfter') ?? DEFAULT_FILTERS.createdAfter,
+    createdBefore: searchParams.get('createdBefore') ?? DEFAULT_FILTERS.createdBefore,
   }
 }
 
@@ -87,6 +99,18 @@ function toSearchParams(
     params.set('serviceId', filters.serviceId.trim())
   }
 
+  if (filters.relation !== DEFAULT_FILTERS.relation) {
+    params.set('relation', filters.relation)
+  }
+
+  if (filters.createdAfter) {
+    params.set('createdAfter', filters.createdAfter)
+  }
+
+  if (filters.createdBefore) {
+    params.set('createdBefore', filters.createdBefore)
+  }
+
   if (page !== DEFAULT_PAGE) {
     params.set('page', String(page + 1))
   }
@@ -109,7 +133,7 @@ function ConsentRegistryPage(): React.JSX.Element {
   const consentListQuery = useConsentListQuery(filters, page, rowsPerPage)
   const approveMutation = useApproveConsentMutation()
   const revokeMutation = useRevokeConsentMutation()
-  const { hasScope } = useAuthorization()
+  const { currentUser, hasScope } = useAuthorization()
   const canWriteSelf = hasScope(REQUIRED_SCOPES.CONSENTS_WRITE_SELF)
   const isTableLoading = consentListQuery.isPending || consentListQuery.isPlaceholderData
 
@@ -151,6 +175,8 @@ function ConsentRegistryPage(): React.JSX.Element {
             updateParams(filters, DEFAULT_PAGE, nextRowsPerPage)
           }
           onRetry={() => consentListQuery.refetch()}
+          showSubject={filters.relation !== 'SUBJECT'}
+          currentUserId={currentUser.userId}
           canApprove={canWriteSelf}
           canRevoke={canWriteSelf}
           onApprove={setApprovalConsentID}

--- a/dpdp-accelerator/react-apps/consent-portal/frontend/src/features/my-consents/api/myConsentsApi.ts
+++ b/dpdp-accelerator/react-apps/consent-portal/frontend/src/features/my-consents/api/myConsentsApi.ts
@@ -37,18 +37,14 @@ function consentPath(consentID: string, suffix = ''): string {
   return `${SELF_CONSENTS}/${encodeURIComponent(consentID)}${suffix}`
 }
 
-function summaryAsDetail(summary: ConsentSummary): ConsentDetail {
-  return { ...summary, purposes: [] }
-}
-
 /**
  * Lists the signed in user's consents.
  *
- * The Identity Server returns a cursor based array of
- * {@code {id, serviceId, state, timestamp}} with no grand total and no offset
- * support, while the table wants an offset page of full records. Over-fetch by
- * one page, slice locally, then expand each row on the page with a detail
- * lookup.
+ * The Identity Server returns a cursor based array with no grand total and no
+ * offset support, while the table wants an offset page. Over-fetch by one
+ * page and slice locally. `attributes=purposes,authorizations` asks the list
+ * endpoint to inline what the table needs directly, so no per-row detail
+ * lookup is required here.
  */
 export async function fetchMyConsents(
   params: ConsentListQueryParams,
@@ -62,28 +58,21 @@ export async function fetchMyConsents(
       limit: Math.min(offset + limit + 1, MAX_FETCH),
       serviceId: params.serviceId ? params.serviceId : undefined,
       state: params.state,
+      relation: params.relation,
+      filter: params.filter,
+      attributes: 'purposes,authorizations',
     },
   })
 
   const page = summaries.slice(offset, offset + limit)
-  const data = await Promise.all(
-    page.map(async (summary) => {
-      try {
-        return await fetchMyConsentByID(summary.id)
-      } catch {
-        // One failed lookup must not blank the whole page.
-        return summaryAsDetail(summary)
-      }
-    }),
-  )
 
   return {
-    data,
+    data: page,
     metadata: {
       // Cursor based upstream: this counts what has been seen, not the total.
       total: summaries.length,
       offset,
-      count: data.length,
+      count: page.length,
       limit,
     },
   }

--- a/dpdp-accelerator/react-apps/consent-portal/frontend/src/features/my-consents/api/myConsentsApi.ts
+++ b/dpdp-accelerator/react-apps/consent-portal/frontend/src/features/my-consents/api/myConsentsApi.ts
@@ -23,6 +23,7 @@ import type {
   ConsentSummary,
 } from '../../../types/consent'
 import { APIError, apiRequest, apiRequestOptionalContent } from '../../../utils/apiClient'
+import { isApprovableByCurrentUser, isRejectableByCurrentUser } from '../utils/consentAuthorization'
 
 /** The Identity Server's self-service consent API. */
 const SELF_CONSENTS = '/api/users/v1/me/consents'
@@ -86,17 +87,32 @@ export async function fetchMyConsentByID(consentID: string): Promise<ConsentDeta
  * Approves or rejects a consent as a whole - the Identity Server has no per
  * element authorization.
  *
- * The server accepts authorize on a consent in any state, which would move an
- * already revoked or expired consent back to active. A withdrawal has to stay
- * final, so only a pending consent is authorizable.
+ * A caller can reconsider their own prior decision (approve after rejecting,
+ * or vice versa) as long as it's still theirs to decide. The server accepts
+ * authorize on a consent in any state, which would otherwise let an already
+ * revoked or expired consent be pulled back to active - a withdrawal has to
+ * stay final, so those two states block both actions regardless of who asks.
+ * `currentUserId` defaults to empty for callers with no signed-in identity to
+ * check against, which falls back to gating on the consent's own aggregate
+ * state - the same behavior this function had before per-authorizer decisions
+ * existed.
  */
-async function authorizeMyConsent(consentID: string, state: 'APPROVED' | 'REJECTED') {
+async function authorizeMyConsent(
+  consentID: string,
+  state: 'APPROVED' | 'REJECTED',
+  currentUserId = '',
+): Promise<unknown> {
   const consent = await fetchMyConsentByID(consentID)
-  if (consent.state !== 'PENDING') {
+  const canAct =
+    state === 'APPROVED'
+      ? isApprovableByCurrentUser(consent.state, consent.authorizations, currentUserId)
+      : isRejectableByCurrentUser(consent.state, consent.authorizations, currentUserId)
+
+  if (!canAct) {
     throw new APIError(
       409,
       'INVALID_CONSENT_STATE',
-      `Only a pending consent can be approved or rejected; this consent is ${consent.state}.`,
+      `This consent cannot be ${state === 'APPROVED' ? 'approved' : 'rejected'} right now; it is ${consent.state}.`,
     )
   }
 
@@ -108,12 +124,12 @@ async function authorizeMyConsent(consentID: string, state: 'APPROVED' | 'REJECT
   return { status: 'OK' }
 }
 
-export async function approveMyConsent(consentID: string): Promise<unknown> {
-  return authorizeMyConsent(consentID, 'APPROVED')
+export async function approveMyConsent(consentID: string, currentUserId = ''): Promise<unknown> {
+  return authorizeMyConsent(consentID, 'APPROVED', currentUserId)
 }
 
-export async function rejectMyConsent(consentID: string): Promise<unknown> {
-  return authorizeMyConsent(consentID, 'REJECTED')
+export async function rejectMyConsent(consentID: string, currentUserId = ''): Promise<unknown> {
+  return authorizeMyConsent(consentID, 'REJECTED', currentUserId)
 }
 
 export async function revokeMyConsent(consentID: string): Promise<unknown> {

--- a/dpdp-accelerator/react-apps/consent-portal/frontend/src/features/my-consents/components/ConsentRegistryFilters.tsx
+++ b/dpdp-accelerator/react-apps/consent-portal/frontend/src/features/my-consents/components/ConsentRegistryFilters.tsx
@@ -94,6 +94,7 @@ function ConsentRegistryFilters({
 
         <FormControl
           size="small"
+          disabled={filters.state === 'PENDING'}
           sx={{ width: { xs: '100%', sm: 220 }, height: MAIN_FILTER_HEIGHT, flexShrink: 0 }}
         >
           <InputLabel id="consent-state-label">{t('consentRegistry.filters.state')}</InputLabel>
@@ -122,6 +123,7 @@ function ConsentRegistryFilters({
 
         <FormControl
           size="small"
+          disabled={filters.state === 'PENDING'}
           sx={{ width: { xs: '100%', sm: 200 }, height: MAIN_FILTER_HEIGHT, flexShrink: 0 }}
         >
           <InputLabel id="consent-relation-label">

--- a/dpdp-accelerator/react-apps/consent-portal/frontend/src/features/my-consents/components/ConsentRegistryFilters.tsx
+++ b/dpdp-accelerator/react-apps/consent-portal/frontend/src/features/my-consents/components/ConsentRegistryFilters.tsx
@@ -17,19 +17,25 @@
  */
 
 import {
+  AdapterDateFns,
   Box,
   Button,
+  DatePickers,
   FormControl,
   InputLabel,
   MenuItem,
+  Popover,
   SearchBar,
   Select,
   Stack,
+  Typography,
 } from '@wso2/oxygen-ui'
+import { ListFilter } from '@wso2/oxygen-ui-icons-react'
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { CONSENT_STATES } from '../../../types/consent'
+import { CONSENT_RELATIONS, CONSENT_STATES } from '../../../types/consent'
 import type { ConsentRegistryFilters as ConsentRegistryFiltersModel } from '../../../types/consent'
+import { parseDateOnly } from '../../../utils/dateTime'
 import { getConsentStateLabelKey } from '../utils/statusChip'
 
 interface ConsentRegistryFiltersProps {
@@ -40,6 +46,16 @@ interface ConsentRegistryFiltersProps {
 
 const MAIN_FILTER_HEIGHT = 40
 
+function toDateOnly(date: Date | null): string {
+  if (!date || Number.isNaN(date.getTime())) {
+    return ''
+  }
+  const year = date.getFullYear()
+  const month = String(date.getMonth() + 1).padStart(2, '0')
+  const day = String(date.getDate()).padStart(2, '0')
+  return `${String(year)}-${month}-${day}`
+}
+
 function ConsentRegistryFilters({
   filters,
   onFilterChange,
@@ -49,6 +65,13 @@ function ConsentRegistryFilters({
   // The parent remounts this component when the applied filters change, so the
   // draft is seeded from the props rather than synchronised in an effect.
   const [serviceIdDraft, setServiceIdDraft] = useState(filters.serviceId)
+  const [dateDraft, setDateDraft] = useState({
+    createdAfter: filters.createdAfter,
+    createdBefore: filters.createdBefore,
+  })
+  const [dateAnchor, setDateAnchor] = useState<HTMLElement | null>(null)
+  const dateFilterOpen = Boolean(dateAnchor)
+  const hasDateFilter = Boolean(filters.createdAfter || filters.createdBefore)
 
   return (
     <Box component="section" aria-label={t('consentRegistry.filters.sectionAriaLabel')}>
@@ -97,6 +120,59 @@ function ConsentRegistryFilters({
           </Select>
         </FormControl>
 
+        <FormControl
+          size="small"
+          sx={{ width: { xs: '100%', sm: 200 }, height: MAIN_FILTER_HEIGHT, flexShrink: 0 }}
+        >
+          <InputLabel id="consent-relation-label">
+            {t('consentRegistry.filters.relation')}
+          </InputLabel>
+          <Select
+            labelId="consent-relation-label"
+            id="consent-relation"
+            value={filters.relation}
+            label={t('consentRegistry.filters.relation')}
+            sx={{ height: MAIN_FILTER_HEIGHT }}
+            onChange={(event) => {
+              onFilterChange({
+                ...filters,
+                serviceId: serviceIdDraft,
+                relation: event.target.value as ConsentRegistryFiltersModel['relation'],
+              })
+            }}
+          >
+            {CONSENT_RELATIONS.map((relation) => (
+              <MenuItem key={relation} value={relation}>
+                {t(`consentRegistry.filters.relationOptions.${relation.toLowerCase()}`)}
+              </MenuItem>
+            ))}
+          </Select>
+        </FormControl>
+
+        <Box component="span" sx={{ position: 'relative', flexShrink: 0 }}>
+          <Button
+            variant={hasDateFilter ? 'contained' : 'outlined'}
+            color={dateFilterOpen || hasDateFilter ? 'primary' : 'inherit'}
+            startIcon={<ListFilter size={16} />}
+            aria-haspopup="dialog"
+            aria-expanded={dateFilterOpen}
+            sx={{
+              height: MAIN_FILTER_HEIGHT,
+              width: { xs: '100%', sm: 'auto' },
+              whiteSpace: 'nowrap',
+            }}
+            onClick={(event) => {
+              setDateDraft({
+                createdAfter: filters.createdAfter,
+                createdBefore: filters.createdBefore,
+              })
+              setDateAnchor(event.currentTarget)
+            }}
+          >
+            {t('consentRegistry.filters.advanced')}
+          </Button>
+        </Box>
+
         <Button
           variant="text"
           aria-label={t('consentRegistry.filters.clearAriaLabel')}
@@ -105,6 +181,87 @@ function ConsentRegistryFilters({
           {t('consentRegistry.filters.clear')}
         </Button>
       </Stack>
+
+      <Popover
+        open={dateFilterOpen}
+        anchorEl={dateAnchor}
+        onClose={() => setDateAnchor(null)}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'left' }}
+        transformOrigin={{ vertical: 'top', horizontal: 'left' }}
+        slotProps={{
+          paper: { sx: { width: { xs: 'calc(100vw - 32px)', sm: 420 }, mt: 1, p: 2.5 } },
+        }}
+      >
+        <Stack spacing={2.5}>
+          <Typography variant="subtitle2" fontWeight={600}>
+            {t('consentRegistry.filters.advanced')}
+          </Typography>
+          <DatePickers.LocalizationProvider dateAdapter={AdapterDateFns}>
+            <Stack direction={{ xs: 'column', sm: 'row' }} spacing={2}>
+              <DatePickers.DatePicker
+                label={t('consentRegistry.filters.startDate')}
+                value={parseDateOnly(dateDraft.createdAfter) ?? null}
+                onChange={(date) => setDateDraft({ ...dateDraft, createdAfter: toDateOnly(date) })}
+                slotProps={{
+                  textField: {
+                    size: 'small',
+                    fullWidth: true,
+                    inputProps: { 'aria-label': t('consentRegistry.filters.startDateAriaLabel') },
+                  },
+                }}
+              />
+              <DatePickers.DatePicker
+                label={t('consentRegistry.filters.endDate')}
+                value={parseDateOnly(dateDraft.createdBefore) ?? null}
+                onChange={(date) => setDateDraft({ ...dateDraft, createdBefore: toDateOnly(date) })}
+                slotProps={{
+                  textField: {
+                    size: 'small',
+                    fullWidth: true,
+                    inputProps: { 'aria-label': t('consentRegistry.filters.endDateAriaLabel') },
+                  },
+                }}
+              />
+            </Stack>
+          </DatePickers.LocalizationProvider>
+
+          <Stack
+            direction="row"
+            justifyContent="space-between"
+            sx={{ pt: 2, borderTop: 1, borderColor: 'divider' }}
+          >
+            <Button
+              variant="text"
+              onClick={() => {
+                setDateDraft({ createdAfter: '', createdBefore: '' })
+                setDateAnchor(null)
+                onFilterChange({
+                  ...filters,
+                  serviceId: serviceIdDraft,
+                  createdAfter: '',
+                  createdBefore: '',
+                })
+              }}
+            >
+              {t('consentRegistry.filters.clear')}
+            </Button>
+            <Stack direction="row" spacing={1}>
+              <Button onClick={() => setDateAnchor(null)}>
+                {t('consentRegistry.filters.cancel')}
+              </Button>
+              <Button
+                variant="contained"
+                onClick={() => {
+                  onFilterChange({ ...filters, serviceId: serviceIdDraft, ...dateDraft })
+                  setDateAnchor(null)
+                }}
+              >
+                {t('consentRegistry.filters.apply')}
+              </Button>
+            </Stack>
+          </Stack>
+        </Stack>
+      </Popover>
     </Box>
   )
 }

--- a/dpdp-accelerator/react-apps/consent-portal/frontend/src/features/my-consents/components/ConsentRegistryTable.tsx
+++ b/dpdp-accelerator/react-apps/consent-portal/frontend/src/features/my-consents/components/ConsentRegistryTable.tsx
@@ -50,10 +50,10 @@ import CursorPaginationFooter from '../../../components/CursorPaginationFooter'
 import type { ConsentRecord } from '../../../types/consent'
 import { formatEpochTimestamp } from '../../../utils/dateTime'
 import { CONSENT_REGISTRY_ROWS_PER_PAGE_OPTIONS } from '../constants'
+import { isApprovableByCurrentUser } from '../utils/consentAuthorization'
 import {
   getConsentStateChipColor,
   getConsentStateLabelKey,
-  isConsentApprovableState,
   isConsentRevokableState,
 } from '../utils/statusChip'
 
@@ -71,6 +71,12 @@ interface ConsentRegistryTableProps {
   detailBasePath?: string
   showSubject?: boolean
   showPurposes?: boolean
+  /**
+   * The signed-in user's own ID. Required when `canApprove` is set, so the
+   * approve action is gated on the caller's own authorization entry rather
+   * than only the consent's aggregate state - see `consentAuthorization.ts`.
+   */
+  currentUserId?: string
   canApprove?: boolean
   canRevoke?: boolean
   onApprove?: (consentID: string) => void
@@ -94,6 +100,7 @@ export default function ConsentRegistryTable({
   detailBasePath = '/consents',
   showSubject = false,
   showPurposes = true,
+  currentUserId = '',
   canApprove = false,
   canRevoke = false,
   onApprove,
@@ -233,7 +240,9 @@ export default function ConsentRegistryTable({
           {!isLoading && !isError
             ? rows.map((row) => {
                 const rowPurposes = row.purposes ?? []
-                const approvable = canApprove && isConsentApprovableState(row.state)
+                const approvable =
+                  canApprove &&
+                  isApprovableByCurrentUser(row.state, row.authorizations, currentUserId)
                 const revokable = canRevoke && isConsentRevokableState(row.state)
 
                 return (
@@ -411,6 +420,7 @@ ConsentRegistryTable.defaultProps = {
   detailBasePath: '/consents',
   showSubject: false,
   showPurposes: true,
+  currentUserId: '',
   canApprove: false,
   canRevoke: false,
   onApprove: undefined,

--- a/dpdp-accelerator/react-apps/consent-portal/frontend/src/features/my-consents/components/ConsentSnapshotView.tsx
+++ b/dpdp-accelerator/react-apps/consent-portal/frontend/src/features/my-consents/components/ConsentSnapshotView.tsx
@@ -36,6 +36,7 @@ import type {
   AnnotatedField,
   AnnotatedProperty,
   AnnotatedSnapshot,
+  AnnotatedState,
 } from '../../../utils/consentSnapshotDiff'
 import { formatEpochTimestamp } from '../../../utils/dateTime'
 import { getConsentStateChipColor, getConsentStateLabelKey } from '../utils/statusChip'
@@ -69,6 +70,43 @@ function ChangeTag({ kind }: { kind: AnnotatedChangeKind }): React.JSX.Element |
     <Typography variant="caption" sx={{ color: changeColor(kind), whiteSpace: 'nowrap' }}>
       {t(`consentRegistry.history.snapshot.${kind}`)}
     </Typography>
+  )
+}
+
+function StateSummary({ state }: { state: AnnotatedState }): React.JSX.Element {
+  const { t } = useTranslation('common')
+
+  return (
+    <Box>
+      <Typography
+        variant="caption"
+        color="text.disabled"
+        sx={{ textTransform: 'uppercase', letterSpacing: 0.4, display: 'block' }}
+      >
+        {t('consentRegistry.details.table.state')}
+      </Typography>
+      <Stack direction="row" alignItems="center" spacing={0.75} sx={{ mt: 0.5 }}>
+        {state.kind === 'changed' && state.before ? (
+          <>
+            <Chip
+              size="small"
+              variant="outlined"
+              color={getConsentStateChipColor(state.before)}
+              label={t(`consentRegistry.status.${getConsentStateLabelKey(state.before)}`)}
+            />
+            <Typography variant="body2" color="text.disabled">
+              →
+            </Typography>
+          </>
+        ) : null}
+        <Chip
+          size="small"
+          variant="outlined"
+          color={getConsentStateChipColor(state.value)}
+          label={t(`consentRegistry.status.${getConsentStateLabelKey(state.value)}`)}
+        />
+      </Stack>
+    </Box>
   )
 }
 
@@ -268,16 +306,19 @@ function SnapshotSection({
 }
 
 /**
- * Deliberately shows only the fields the Identity Server's own consent update path
+ * Shows the resulting state plus the fields the Identity Server's own consent update path
  * (`ReceiptUpdateInput`) can actually change - expiry, properties, authorizations - not the full
- * stored snapshot. `state`/`piiPrincipalId`/`language`/`services`/`purposes`/`elements` never
- * change via update, so diffing them would only ever add noise to this view.
+ * stored snapshot. `state` is included even though `ReceiptUpdateInput` has no `state` field of
+ * its own, because an update can still change the consent's resolved status (e.g. reviving an
+ * EXPIRED consent by extending its expiry). `piiPrincipalId`/`language`/`services`/`purposes`/
+ * `elements` never change via update, so diffing those would only ever add noise to this view.
  */
 function ConsentSnapshotView({ snapshot }: ConsentSnapshotViewProps): React.JSX.Element {
   const { t } = useTranslation('common')
 
   return (
     <Stack spacing={2}>
+      <StateSummary state={snapshot.state} />
       <FieldsSummary fields={snapshot.fields} />
 
       <SnapshotSection title={t('catalog.fields.properties')}>

--- a/dpdp-accelerator/react-apps/consent-portal/frontend/src/features/my-consents/hooks/useConsentQueries.ts
+++ b/dpdp-accelerator/react-apps/consent-portal/frontend/src/features/my-consents/hooks/useConsentQueries.ts
@@ -113,12 +113,16 @@ function useConsentLifecycleMutation(
   })
 }
 
-export function useApproveConsentMutation(): UseMutationResult<unknown, Error, string> {
-  return useConsentLifecycleMutation(approveMyConsent)
+export function useApproveConsentMutation(
+  currentUserId: string,
+): UseMutationResult<unknown, Error, string> {
+  return useConsentLifecycleMutation((consentID) => approveMyConsent(consentID, currentUserId))
 }
 
-export function useRejectConsentMutation(): UseMutationResult<unknown, Error, string> {
-  return useConsentLifecycleMutation(rejectMyConsent)
+export function useRejectConsentMutation(
+  currentUserId: string,
+): UseMutationResult<unknown, Error, string> {
+  return useConsentLifecycleMutation((consentID) => rejectMyConsent(consentID, currentUserId))
 }
 
 export function useRevokeConsentMutation(): UseMutationResult<unknown, Error, string> {

--- a/dpdp-accelerator/react-apps/consent-portal/frontend/src/features/my-consents/hooks/useConsentQueries.ts
+++ b/dpdp-accelerator/react-apps/consent-portal/frontend/src/features/my-consents/hooks/useConsentQueries.ts
@@ -31,14 +31,15 @@ import {
   rejectMyConsent,
   revokeMyConsent,
 } from '../api/myConsentsApi'
-import { normalizeConsentState } from '../utils/statusChip'
 import type {
   ConsentDetail,
   ConsentListQueryParams,
   ConsentRecord,
   ConsentRegistryFilters,
 } from '../../../types/consent'
-import { isConsentState } from '../../../types/consent'
+import { toConsentRowFromSummary } from '../../../utils/consentRows'
+import { buildTimestampFilter } from '../../../utils/filterGrammar'
+import { endOfDayMillis, parseDateOnly, startOfDayMillis } from '../../../utils/dateTime'
 
 export interface ConsentListResult {
   rows: ConsentRecord[]
@@ -46,31 +47,22 @@ export interface ConsentListResult {
   hasNextPage: boolean
 }
 
-export function toConsentRow(consent: ConsentDetail): ConsentRecord {
-  const normalizedState = normalizeConsentState(consent.state)
-
-  if (!isConsentState(normalizedState)) {
-    throw new Error(`Unsupported consent state received from API: ${consent.state}`)
-  }
-
-  return {
-    id: consent.id,
-    subjectId: consent.subjectId,
-    serviceId: consent.serviceId,
-    state: normalizedState,
-    timestamp: consent.timestamp,
-    purposes: consent.purposes.map((purpose) => purpose.name),
-  }
-}
-
 function toListParams(
   filters: ConsentRegistryFilters,
   page: number,
   rowsPerPage: number,
 ): ConsentListQueryParams {
+  const afterDate = parseDateOnly(filters.createdAfter)
+  const beforeDate = parseDateOnly(filters.createdBefore)
+
   return {
     state: filters.state === 'All' ? undefined : filters.state,
     serviceId: filters.serviceId.trim() || undefined,
+    relation: filters.relation,
+    filter: buildTimestampFilter(
+      afterDate ? startOfDayMillis(afterDate) : undefined,
+      beforeDate ? endOfDayMillis(beforeDate) : undefined,
+    ),
     limit: rowsPerPage,
     offset: page * rowsPerPage,
   }
@@ -89,7 +81,7 @@ export function useConsentListQuery(
       const response = await fetchMyConsents(params)
 
       return {
-        rows: response.data.map(toConsentRow),
+        rows: response.data.map(toConsentRowFromSummary),
         hasNextPage: response.data.length >= params.limit,
       }
     },

--- a/dpdp-accelerator/react-apps/consent-portal/frontend/src/features/my-consents/utils/consentAuthorization.ts
+++ b/dpdp-accelerator/react-apps/consent-portal/frontend/src/features/my-consents/utils/consentAuthorization.ts
@@ -17,7 +17,7 @@
  */
 
 import type { ConsentAuthorization, ConsentState } from '../../../types/consent'
-import { isConsentApprovableState, isConsentRejectableState } from './statusChip'
+import { normalizeConsentState } from './statusChip'
 
 /**
  * `authorizations` never carries an entry for the consent's own subject -
@@ -31,6 +31,21 @@ function myAuthorization(
   currentUserId: string,
 ): ConsentAuthorization | undefined {
   return authorizations?.find((authorization) => authorization.userId === currentUserId)
+}
+
+/**
+ * Whether the signed-in user has any personal stake in this consent - as its
+ * subject, or as one of its listed authorizers. Meant for surfaces that can
+ * show an arbitrary consent (the admin registry) rather than an endpoint
+ * already scoped to the caller (self-service `/me/consents`), where every
+ * result is inherently the caller's concern and this check would be redundant.
+ */
+export function isCurrentUserInvolved(
+  subjectId: string,
+  authorizations: ConsentAuthorization[] | undefined,
+  currentUserId: string,
+): boolean {
+  return subjectId === currentUserId || Boolean(myAuthorization(authorizations, currentUserId))
 }
 
 /**
@@ -48,21 +63,34 @@ export function effectiveActionState(
   authorizations: ConsentAuthorization[] | undefined,
   currentUserId: string,
 ): string {
-  return myAuthorization(authorizations, currentUserId)?.state ?? consentState
+  return normalizeConsentState(
+    myAuthorization(authorizations, currentUserId)?.state ?? consentState,
+  )
 }
 
+/**
+ * A caller can (re)approve as long as they haven't already approved - a
+ * previous rejection is reconsiderable, same as a still-pending decision.
+ * `REVOKED` and `EXPIRED` stay final and block both actions: `revokeMyConsent`
+ * already documents that a withdrawal has to stay final, and the same rule
+ * applies here so a finalised decision can't be reopened through the other
+ * action either.
+ */
 export function isApprovableByCurrentUser(
   consentState: ConsentState | string,
   authorizations: ConsentAuthorization[] | undefined,
   currentUserId: string,
 ): boolean {
-  return isConsentApprovableState(effectiveActionState(consentState, authorizations, currentUserId))
+  const effective = effectiveActionState(consentState, authorizations, currentUserId)
+  return effective === 'PENDING' || effective === 'REJECTED'
 }
 
+/** Mirrors `isApprovableByCurrentUser` for the reject action. */
 export function isRejectableByCurrentUser(
   consentState: ConsentState | string,
   authorizations: ConsentAuthorization[] | undefined,
   currentUserId: string,
 ): boolean {
-  return isConsentRejectableState(effectiveActionState(consentState, authorizations, currentUserId))
+  const effective = effectiveActionState(consentState, authorizations, currentUserId)
+  return effective === 'PENDING' || effective === 'APPROVED' || effective === 'ACTIVE'
 }

--- a/dpdp-accelerator/react-apps/consent-portal/frontend/src/features/my-consents/utils/consentAuthorization.ts
+++ b/dpdp-accelerator/react-apps/consent-portal/frontend/src/features/my-consents/utils/consentAuthorization.ts
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import type { ConsentAuthorization, ConsentState } from '../../../types/consent'
+import { isConsentApprovableState, isConsentRejectableState } from './statusChip'
+
+/**
+ * `authorizations` never carries an entry for the consent's own subject -
+ * only for the other people listed to approve or reject it on the subject's
+ * behalf. So a signed-in user acting as the subject falls through to the
+ * consent's own state below, same as before this consent could have more
+ * than one decision-maker.
+ */
+function myAuthorization(
+  authorizations: ConsentAuthorization[] | undefined,
+  currentUserId: string,
+): ConsentAuthorization | undefined {
+  return authorizations?.find((authorization) => authorization.userId === currentUserId)
+}
+
+/**
+ * The state to gate the signed-in user's own approve/reject buttons on.
+ *
+ * A consent's aggregate `state` can stay `PENDING` while it's waiting on
+ * other authorizers after the current user has already recorded their own
+ * decision - gating purely on the aggregate state would keep showing them an
+ * action button for a decision they already made. When the caller has their
+ * own authorization entry, that entry - not the aggregate state - is
+ * authoritative for whether they can still act.
+ */
+export function effectiveActionState(
+  consentState: ConsentState | string,
+  authorizations: ConsentAuthorization[] | undefined,
+  currentUserId: string,
+): string {
+  return myAuthorization(authorizations, currentUserId)?.state ?? consentState
+}
+
+export function isApprovableByCurrentUser(
+  consentState: ConsentState | string,
+  authorizations: ConsentAuthorization[] | undefined,
+  currentUserId: string,
+): boolean {
+  return isConsentApprovableState(effectiveActionState(consentState, authorizations, currentUserId))
+}
+
+export function isRejectableByCurrentUser(
+  consentState: ConsentState | string,
+  authorizations: ConsentAuthorization[] | undefined,
+  currentUserId: string,
+): boolean {
+  return isConsentRejectableState(effectiveActionState(consentState, authorizations, currentUserId))
+}

--- a/dpdp-accelerator/react-apps/consent-portal/frontend/src/features/my-consents/utils/statusChip.ts
+++ b/dpdp-accelerator/react-apps/consent-portal/frontend/src/features/my-consents/utils/statusChip.ts
@@ -24,14 +24,6 @@ export function normalizeConsentState(state: string): string {
   return state.trim().toUpperCase()
 }
 
-export function isConsentApprovableState(state: string): boolean {
-  return normalizeConsentState(state) === 'PENDING'
-}
-
-export function isConsentRejectableState(state: string): boolean {
-  return normalizeConsentState(state) === 'PENDING'
-}
-
 export function isConsentRevokableState(state: string): boolean {
   return normalizeConsentState(state) === 'ACTIVE'
 }

--- a/dpdp-accelerator/react-apps/consent-portal/frontend/src/types/consent.ts
+++ b/dpdp-accelerator/react-apps/consent-portal/frontend/src/types/consent.ts
@@ -31,6 +31,15 @@ export const CONSENT_AUTHORIZATION_STATES = ['APPROVED', 'REJECTED', 'REVOKED', 
 export type ConsentAuthorizationState = (typeof CONSENT_AUTHORIZATION_STATES)[number]
 
 /**
+ * A caller's relationship to a consent: the data `SUBJECT` it's about, an
+ * `AUTHORIZER` listed to approve/reject it on the subject's behalf (DPDP's
+ * guardian/delegate model), or `ANY` for either.
+ */
+export const CONSENT_RELATIONS = ['SUBJECT', 'AUTHORIZER', 'ANY'] as const
+
+export type ConsentRelation = (typeof CONSENT_RELATIONS)[number]
+
+/**
  * An element referenced by a consented purpose.
  *
  * Consent level elements carry no approval or requirement flags in WSO2
@@ -74,11 +83,12 @@ export interface ConsentDetail {
 }
 
 /**
- * Consents returned by the administrative list endpoint.
+ * Consents returned by the self-service and administrative list endpoints.
  *
- * The Identity Server's raw list rows carry no purposes; `fetchAdminConsents`
- * expands each row on the page with a detail lookup, so `purposes` is present
- * in practice - except on a row whose lookup failed.
+ * `purposes` and `authorizations` are present whenever the list call asked
+ * for them via `attributes=purposes,authorizations` - both list endpoints
+ * request that, so in practice they're populated except on a row whose
+ * expansion the server itself could not resolve.
  */
 export interface ConsentSummary {
   id: string
@@ -87,12 +97,15 @@ export interface ConsentSummary {
   state: ConsentState | string
   timestamp: number
   purposes?: ConsentPurpose[]
+  authorizations?: ConsentAuthorization[]
 }
 
 /**
  * Row model shared by the self-service and administrative consent tables.
  *
  * `purposes` is undefined when the source endpoint does not return them.
+ * `authorizations` backs per-caller approve/reject gating - see
+ * `features/my-consents/utils/consentAuthorization.ts`.
  */
 export interface ConsentRecord {
   id: string
@@ -101,16 +114,20 @@ export interface ConsentRecord {
   state: ConsentState
   timestamp: number
   purposes?: string[]
+  authorizations?: ConsentAuthorization[]
 }
 
 export interface ConsentRegistryFilters {
   state: 'All' | ConsentState
   serviceId: string
+  relation: ConsentRelation
+  createdAfter: string
+  createdBefore: string
 }
 
 export interface AdminConsentRegistryFilters extends ConsentRegistryFilters {
   consentId: string
-  subjectId: string
+  userId: string
   purposeId: string
   propertyKey: string
   propertyValue: string
@@ -130,7 +147,7 @@ export interface ConsentSearchMetadata {
 }
 
 export interface ConsentSearchResponse {
-  data: ConsentDetail[]
+  data: ConsentSummary[]
   metadata: ConsentSearchMetadata
 }
 
@@ -140,13 +157,19 @@ export interface ConsentListQueryParams {
   /** One state, or undefined for all: the filter is a single-select. */
   state?: ConsentState
   serviceId?: string
+  /** Always paired with the signed-in user's own ID; defaults to `ANY` server-side. */
+  relation?: ConsentRelation
+  /** A `timestamp ge/le <epoch-ms>` clause built by `buildTimestampFilter`. */
+  filter?: string
 }
 
 export interface AdminConsentListQueryParams {
   limit: number
   after?: string
   before?: string
-  subjectId?: string
+  userId?: string
+  /** Only meaningful paired with `userId` - never sent alone. */
+  relation?: ConsentRelation
   serviceId?: string
   state?: string
   purposeId?: string

--- a/dpdp-accelerator/react-apps/consent-portal/frontend/src/types/consentHistory.ts
+++ b/dpdp-accelerator/react-apps/consent-portal/frontend/src/types/consentHistory.ts
@@ -78,11 +78,11 @@ export const CONSENT_LIFECYCLE_FETCH_LIMIT = 100
 
 /**
  * The snapshot stored per history entry is a trimmed view of the consent mgt core `Receipt`
- * (`DPDPConsentSnapshotBuilder` on the server) and carries far more than these three fields
- * (state, piiPrincipalId, language, services/purposes/elements). Only `expiryTime`,
- * `properties` and `authorizations` are typed here because those are the only fields
- * `ReceiptUpdateInput` (the update model IS's own consent-mgt core accepts a PATCH against)
- * can actually change - the full-snapshot view only ever needs to diff what update can affect.
+ * (`DPDPConsentSnapshotBuilder` on the server) and carries far more than these fields
+ * (piiPrincipalId, language, services/purposes/elements aren't typed here). `state` is included
+ * because, despite `ReceiptUpdateInput` having no `state` field of its own, an update can still
+ * change the consent's resolved status - e.g. extending `expiryTime` back into the future revives
+ * an EXPIRED consent to ACTIVE - so it's a real, diffable per-entry value, not a constant.
  */
 export interface ConsentSnapshotAuthorization {
   userId: string
@@ -92,6 +92,7 @@ export interface ConsentSnapshotAuthorization {
 }
 
 export interface ConsentSnapshot {
+  state: string
   expiryTime?: number
   properties?: Record<string, string>
   authorizations?: ConsentSnapshotAuthorization[]

--- a/dpdp-accelerator/react-apps/consent-portal/frontend/src/utils/consentRows.ts
+++ b/dpdp-accelerator/react-apps/consent-portal/frontend/src/utils/consentRows.ts
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import type { ConsentDetail, ConsentRecord, ConsentSummary } from '../types/consent'
+import { isConsentState } from '../types/consent'
+import { normalizeConsentState } from '../features/my-consents/utils/statusChip'
+
+function toRecord(
+  id: string,
+  subjectId: string,
+  serviceId: string,
+  state: string,
+  timestamp: number,
+  purposeNames: string[] | undefined,
+  authorizations: ConsentRecord['authorizations'],
+): ConsentRecord {
+  const normalizedState = normalizeConsentState(state)
+
+  if (!isConsentState(normalizedState)) {
+    throw new Error(`Unsupported consent state received from API: ${state}`)
+  }
+
+  return {
+    id,
+    subjectId,
+    serviceId,
+    state: normalizedState,
+    timestamp,
+    purposes: purposeNames,
+    authorizations,
+  }
+}
+
+/** Maps a full consent record (single-consent GET) to a table row. */
+export function toConsentRow(consent: ConsentDetail): ConsentRecord {
+  return toRecord(
+    consent.id,
+    consent.subjectId,
+    consent.serviceId,
+    consent.state,
+    consent.timestamp,
+    consent.purposes.map((purpose) => purpose.name),
+    consent.authorizations,
+  )
+}
+
+/** Maps a list-endpoint summary (requested with `attributes=purposes,authorizations`) to a table row. */
+export function toConsentRowFromSummary(consent: ConsentSummary): ConsentRecord {
+  return toRecord(
+    consent.id,
+    consent.subjectId,
+    consent.serviceId,
+    consent.state,
+    consent.timestamp,
+    consent.purposes?.map((purpose) => purpose.name),
+    consent.authorizations,
+  )
+}

--- a/dpdp-accelerator/react-apps/consent-portal/frontend/src/utils/consentSnapshotDiff.ts
+++ b/dpdp-accelerator/react-apps/consent-portal/frontend/src/utils/consentSnapshotDiff.ts
@@ -20,6 +20,12 @@ import type { ConsentSnapshot, ConsentSnapshotAuthorization } from '../types/con
 
 export type ConsentSnapshotChangeKind = 'added' | 'removed' | 'changed'
 
+export interface ConsentSnapshotStateChange {
+  before?: string
+  after: string
+  changed: boolean
+}
+
 export interface ConsentSnapshotFieldChange {
   field: 'expiryTime'
   before?: number
@@ -44,9 +50,21 @@ export interface ConsentSnapshotDiff {
   /** True for the very first entry a consent ever has - there is no earlier snapshot to diff. */
   isInitial: boolean
   hasChanges: boolean
+  state: ConsentSnapshotStateChange
   fields: ConsentSnapshotFieldChange[]
   properties: ConsentSnapshotPropertyChange[]
   authorizations: ConsentSnapshotAuthorizationChange[]
+}
+
+function diffState(
+  before: ConsentSnapshot | undefined,
+  after: ConsentSnapshot,
+): ConsentSnapshotStateChange {
+  return {
+    before: before?.state,
+    after: after.state,
+    changed: before !== undefined && before.state !== after.state,
+  }
 }
 
 function diffFields(
@@ -122,12 +140,13 @@ function diffAuthorizations(
 }
 
 /**
- * Diffs one history entry's snapshot against the chronologically previous one, restricted to
- * `expiryTime`, `properties` and `authorizations` - the only fields `ReceiptUpdateInput` (the
- * model backing the Identity Server's own consent update path) can actually change. Diffing
- * `state`/`piiPrincipalId`/`language`/`services` would only ever show noise: those fields never
- * change via update, and state transitions are already shown by the lifecycle table's own
- * per-entry status dot.
+ * Diffs one history entry's snapshot against the chronologically previous one. `state` is diffed
+ * because an update can genuinely change it (e.g. reviving an EXPIRED consent by extending its
+ * expiry) even though `ReceiptUpdateInput` has no `state` field of its own - this mirrors what
+ * `previousStatus`/`currentStatus` already track per-entry in the status-history table, just
+ * scoped to this one snapshot's before/after. `expiryTime`, `properties` and `authorizations` are
+ * the other fields `ReceiptUpdateInput` can actually change; `piiPrincipalId`/`language`/`services`
+ * never change via update, so diffing them would only ever add noise.
  *
  * `before` is undefined for the CREATE entry - there is nothing earlier to compare against, so
  * every property/authorization in `after` reports as "added" rather than the caller needing a
@@ -137,13 +156,16 @@ export function diffConsentSnapshots(
   before: ConsentSnapshot | undefined,
   after: ConsentSnapshot,
 ): ConsentSnapshotDiff {
+  const state = diffState(before, after)
   const fields = diffFields(before, after)
   const properties = diffProperties(before?.properties, after.properties)
   const authorizations = diffAuthorizations(before?.authorizations, after.authorizations)
 
   return {
     isInitial: before === undefined,
-    hasChanges: fields.length > 0 || properties.length > 0 || authorizations.length > 0,
+    hasChanges:
+      state.changed || fields.length > 0 || properties.length > 0 || authorizations.length > 0,
+    state,
     fields,
     properties,
     authorizations,
@@ -159,6 +181,12 @@ export function diffConsentSnapshots(
  * visible instead of disappearing.
  */
 export type AnnotatedChangeKind = 'unchanged' | 'added' | 'removed' | 'changed'
+
+export interface AnnotatedState {
+  value: string
+  before?: string
+  kind: AnnotatedChangeKind
+}
 
 export interface AnnotatedField {
   field: ConsentSnapshotFieldChange['field']
@@ -184,9 +212,18 @@ export interface AnnotatedAuthorization {
 }
 
 export interface AnnotatedSnapshot {
+  state: AnnotatedState
   fields: AnnotatedField[]
   properties: AnnotatedProperty[]
   authorizations: AnnotatedAuthorization[]
+}
+
+function annotateState(snapshot: ConsentSnapshot, diff: ConsentSnapshotDiff): AnnotatedState {
+  return {
+    value: snapshot.state,
+    before: diff.state.changed ? diff.state.before : undefined,
+    kind: diff.state.changed ? 'changed' : 'unchanged',
+  }
 }
 
 function annotateFields(snapshot: ConsentSnapshot, diff: ConsentSnapshotDiff): AnnotatedField[] {
@@ -248,6 +285,7 @@ export function annotateSnapshot(
   diff: ConsentSnapshotDiff,
 ): AnnotatedSnapshot {
   return {
+    state: annotateState(snapshot, diff),
     fields: annotateFields(snapshot, diff),
     properties: annotateProperties(snapshot, diff),
     authorizations: annotateAuthorizations(snapshot, diff),

--- a/dpdp-accelerator/react-apps/consent-portal/frontend/src/utils/dateTime.ts
+++ b/dpdp-accelerator/react-apps/consent-portal/frontend/src/utils/dateTime.ts
@@ -81,6 +81,36 @@ export function formatEpochTimestamp(
   )
 }
 
+/**
+ * Parses a `YYYY-MM-DD` date-only string (as produced by a date picker) into
+ * a local `Date`. Deliberately does not use `new Date(value)`, which parses
+ * a bare date as UTC midnight and can read back as the previous day in a
+ * negative UTC-offset timezone.
+ */
+export function parseDateOnly(value: string): Date | undefined {
+  if (!value) {
+    return undefined
+  }
+
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value)
+  if (!match) {
+    return undefined
+  }
+
+  const [, year, month, day] = match
+  return new Date(Number(year), Number(month) - 1, Number(day))
+}
+
+/** Midnight at the start of the given date's local day, as epoch milliseconds. */
+export function startOfDayMillis(date: Date): number {
+  return new Date(date.getFullYear(), date.getMonth(), date.getDate()).getTime()
+}
+
+/** The last millisecond of the given date's local day, as epoch milliseconds. */
+export function endOfDayMillis(date: Date): number {
+  return new Date(date.getFullYear(), date.getMonth(), date.getDate(), 23, 59, 59, 999).getTime()
+}
+
 export function formatIsoDateTime(
   dateTimeText: string | null | undefined,
   options?: Intl.DateTimeFormatOptions,

--- a/dpdp-accelerator/react-apps/consent-portal/frontend/src/utils/filterGrammar.ts
+++ b/dpdp-accelerator/react-apps/consent-portal/frontend/src/utils/filterGrammar.ts
@@ -25,3 +25,23 @@
 export function escapeFilterValue(value: string): string {
   return value.replace(/\\/g, '\\\\').replace(/"/g, '\\"')
 }
+
+/** Joins non-empty filter clauses with the grammar's `and` operator. */
+export function combineFilters(...clauses: (string | undefined)[]): string | undefined {
+  const nonEmpty = clauses.filter((clause): clause is string => Boolean(clause))
+  return nonEmpty.length > 0 ? nonEmpty.join(' and ') : undefined
+}
+
+/**
+ * Builds a `timestamp ge/le <epoch-ms>` clause (or both, joined with `and`)
+ * for the consent creation time. Either bound may be omitted.
+ */
+export function buildTimestampFilter(
+  afterEpochMillis?: number,
+  beforeEpochMillis?: number,
+): string | undefined {
+  return combineFilters(
+    afterEpochMillis !== undefined ? `timestamp ge ${String(afterEpochMillis)}` : undefined,
+    beforeEpochMillis !== undefined ? `timestamp le ${String(beforeEpochMillis)}` : undefined,
+  )
+}


### PR DESCRIPTION
Description

- Implement latest IS consent API changes in the UI
- Fix postUpdateConsent silently dropping real state transitions from status-history (e.g. an EXPIRED consent revived to ACTIVE via expiry renewal).
- Show the resulting consent state in each expanded snapshot history entry (frontend).
- Consent list APIs (self + admin) now fetch purposes/authorizations inline instead of per-row lookups, and support relation/filter query params.
- Let a listed authorizer approve/reject a consent from the admin view, not just the subject from self-service.
- Generalize merge.sh's stale-webapp cleanup into one loop over every shipped webapp, instead of a hardcoded block per webapp.
- Fix CH-00002 (Forbidden - not the owner) incorrectly blocking a delegated consent's authorizer (e.g. a guardian) from viewing its status-history/full-history — the ownership check now also allows listed authorizers, not just the subject.