### PR TITLE
Add consent-history UI tests

### DIFF
--- a/dpdp-integration-test-suite/pages/ConsentDetailPage.ts
+++ b/dpdp-integration-test-suite/pages/ConsentDetailPage.ts
@@ -62,8 +62,7 @@ export class ConsentDetailPage {
     this.authorizationsSection = page
       .locator('.MuiCard-root')
       .filter({ has: page.getByRole('heading', { name: 'Authorizations' }) })
-    // ConsentLifecycleSection.tsx - the status-audit timeline card. Rows are read from `tbody`
-    // directly (not `getByRole('row')`) so the header row never gets swept in.
+    // ConsentLifecycleSection.tsx timeline card; `tbody tr` avoids sweeping in the header row.
     this.lifecycleSection = page
       .locator('.MuiCard-root')
       .filter({ has: page.getByRole('heading', { name: 'Consent Lifecycle' }) })
@@ -94,11 +93,9 @@ export class ConsentDetailPage {
   }
 
   /**
-   * A lifecycle-table row, matched by its rendered "<action> by <actor>" description
-   * (ConsentLifecycleSection.describeEntry's i18n template). Bridges with `.*` rather than a
-   * literal " by " - confirmed live that the AUTHORIZE_REVOKE action label is itself "Revoked by
-   * reviewer", so a whole-consent revoke renders "Revoked by reviewer by <actor>": a second,
-   * unrelated "by" sits between the action and the actor this locator is matching on.
+   * Lifecycle-table row matching "<action>...<actor>". Bridges with `.*`, not literal " by " -
+   * AUTHORIZE_REVOKE's own label is "Revoked by reviewer", so a whole-consent revoke row reads
+   * "Revoked by reviewer by <actor>" with an extra "by" in between.
    */
   lifecycleRow(action: string, actor: string): Locator {
     return this.lifecycleRows.filter({ hasText: new RegExp(`${action}.*${actor}`) })

--- a/dpdp-integration-test-suite/pages/ConsentDetailPage.ts
+++ b/dpdp-integration-test-suite/pages/ConsentDetailPage.ts
@@ -45,6 +45,9 @@ export class ConsentDetailPage {
   readonly backButton: Locator
   readonly purposesSection: Locator
   readonly authorizationsSection: Locator
+  readonly lifecycleSection: Locator
+  readonly lifecycleRows: Locator
+  readonly viewFullSnapshotButton: Locator
 
   constructor(
     private readonly page: Page,
@@ -59,6 +62,13 @@ export class ConsentDetailPage {
     this.authorizationsSection = page
       .locator('.MuiCard-root')
       .filter({ has: page.getByRole('heading', { name: 'Authorizations' }) })
+    // ConsentLifecycleSection.tsx - the status-audit timeline card. Rows are read from `tbody`
+    // directly (not `getByRole('row')`) so the header row never gets swept in.
+    this.lifecycleSection = page
+      .locator('.MuiCard-root')
+      .filter({ has: page.getByRole('heading', { name: 'Consent Lifecycle' }) })
+    this.lifecycleRows = this.lifecycleSection.locator('tbody tr')
+    this.viewFullSnapshotButton = page.getByRole('button', { name: 'View Full Snapshot History' })
   }
 
   async goto(consentId: string): Promise<void> {
@@ -81,6 +91,21 @@ export class ConsentDetailPage {
 
   authorizationRow(userId: string): Locator {
     return this.authorizationsSection.getByRole('row', { name: new RegExp(userId) })
+  }
+
+  /**
+   * A lifecycle-table row, matched by its rendered "<action> by <actor>" description
+   * (ConsentLifecycleSection.describeEntry's i18n template). Bridges with `.*` rather than a
+   * literal " by " - confirmed live that the AUTHORIZE_REVOKE action label is itself "Revoked by
+   * reviewer", so a whole-consent revoke renders "Revoked by reviewer by <actor>": a second,
+   * unrelated "by" sits between the action and the actor this locator is matching on.
+   */
+  lifecycleRow(action: string, actor: string): Locator {
+    return this.lifecycleRows.filter({ hasText: new RegExp(`${action}.*${actor}`) })
+  }
+
+  async openFullHistoryDialog(): Promise<void> {
+    await this.viewFullSnapshotButton.click()
   }
 
   private actionButton(action: keyof typeof CONFIRM_LABEL): Locator {

--- a/dpdp-integration-test-suite/pages/ConsentFullHistoryDialogPage.ts
+++ b/dpdp-integration-test-suite/pages/ConsentFullHistoryDialogPage.ts
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { type Locator, type Page } from '@playwright/test'
+
+/**
+ * ConsentFullHistoryDialog.tsx - opened from ConsentDetailPage's "View Full Snapshot History"
+ * button. Each history entry is an independent MUI Accordion; its summary is a real button (see
+ * the frontend's own ConsentLifecycleSection.test.tsx, which locates the same way).
+ *
+ * The summary text is "<action> · <actor>" (HistoryEntryAccordion composes it with a literal
+ * middle dot) - NOT "<action> by <actor>", which is only the *lifecycle table*'s own phrasing
+ * (ConsentLifecycleSection.describeEntry's i18n template). Confirmed live: matching on "by" here
+ * finds nothing and hangs a `.click()` for the full test timeout. `entry()` takes the action label
+ * and actor separately and bridges whatever sits between them, so callers never need to know
+ * which separator applies where.
+ */
+export class ConsentFullHistoryDialogPage {
+  readonly dialog: Locator
+  readonly closeButton: Locator
+  readonly emptyMessage: Locator
+  /** DOM order of every entry's summary, newest-first - see sortHistoryDescending's contract. */
+  readonly entrySummaries: Locator
+
+  constructor(page: Page) {
+    this.dialog = page.getByRole('dialog').filter({
+      has: page.getByRole('heading', { name: 'View Full Snapshot History' }),
+    })
+    this.closeButton = this.dialog.getByRole('button', { name: 'Close' })
+    this.emptyMessage = this.dialog.getByText('No history is recorded for this consent.')
+    this.entrySummaries = this.dialog.locator('.MuiAccordionSummary-root')
+  }
+
+  /** `action` is the rendered action label (e.g. "Approved", "Consent created"), `actor` the
+   *  rendered actionBy (a username, or "System"). */
+  entry(action: string, actor: string): Locator {
+    return this.dialog.getByRole('button', { name: new RegExp(`${action}.*${actor}`) })
+  }
+
+  async expand(action: string, actor: string): Promise<void> {
+    await this.entry(action, actor).click()
+  }
+
+  /**
+   * The whole accordion (summary + details) for one entry, so a diff assertion can't match a
+   * sibling entry's panel that happens to render the same tag text.
+   *
+   * `hasText`, not `has: this.entry(...)` - confirmed live that `.filter({has: locator})` returns
+   * zero matches here even though both the base locator and the `has` locator individually match
+   * something. `this.entry()` is chained off `this.dialog`, which is itself a
+   * `.filter({has: ...})`-derived locator - using a locator built on top of one filter as the
+   * `has:` predicate of a second, outer filter silently fails to match. `hasText` takes a plain
+   * string/regex instead of a locator, sidestepping the problem entirely.
+   */
+  private accordionFor(action: string, actor: string): Locator {
+    return this.dialog
+      .locator('.MuiAccordion-root')
+      .filter({ hasText: new RegExp(`${action}.*${actor}`) })
+  }
+
+  initialSnapshotChip(action: string, actor: string): Locator {
+    return this.accordionFor(action, actor).getByText('Initial snapshot')
+  }
+
+  changedTag(action: string, actor: string): Locator {
+    return this.accordionFor(action, actor).getByText('Changed', { exact: true })
+  }
+
+  noChangesNote(action: string, actor: string): Locator {
+    return this.accordionFor(action, actor).getByText(
+      'No changes were recorded in this update.',
+    )
+  }
+
+  /**
+   * The before→after chip pair `ConsentSnapshotView`'s `StateSummary` renders when a snapshot's
+   * `state` itself changed (e.g. "Active" → "Revoked"). `state` is diffed separately from
+   * fields/properties/authorizations (see consentSnapshotDiff.ts's own comment on why) and is
+   * never routed through the shared `ChangeTag`/`noChangesNote` those three use - so a diff whose
+   * *only* change is the state transition matches neither `changedTag` nor `noChangesNote`.
+   */
+  stateTransition(action: string, actor: string, from: string, to: string): Locator {
+    return this.accordionFor(action, actor).getByText(new RegExp(`${from}.*→.*${to}`))
+  }
+
+  /**
+   * Either outcome is a legitimate diff result - which one depends on whether the product's own
+   * consent-mgt-core revoke operation also cascades onto per-authorizer records, which isn't
+   * decidable from this repo (that logic lives in a vendored jar, not here). Use this instead of
+   * `changedTag`/`noChangesNote` wherever the point is only "the diff rendered something, not the
+   * needsMoreHistory fallback" rather than a specific outcome.
+   */
+  diffRendered(action: string, actor: string): Locator {
+    return this.changedTag(action, actor).or(this.noChangesNote(action, actor))
+  }
+
+  async close(): Promise<void> {
+    await this.closeButton.click()
+  }
+}

--- a/dpdp-integration-test-suite/pages/ConsentFullHistoryDialogPage.ts
+++ b/dpdp-integration-test-suite/pages/ConsentFullHistoryDialogPage.ts
@@ -20,15 +20,10 @@ import { type Locator, type Page } from '@playwright/test'
 
 /**
  * ConsentFullHistoryDialog.tsx - opened from ConsentDetailPage's "View Full Snapshot History"
- * button. Each history entry is an independent MUI Accordion; its summary is a real button (see
- * the frontend's own ConsentLifecycleSection.test.tsx, which locates the same way).
+ * button. Each entry is an MUI Accordion with a real button as its summary.
  *
- * The summary text is "<action> · <actor>" (HistoryEntryAccordion composes it with a literal
- * middle dot) - NOT "<action> by <actor>", which is only the *lifecycle table*'s own phrasing
- * (ConsentLifecycleSection.describeEntry's i18n template). Confirmed live: matching on "by" here
- * finds nothing and hangs a `.click()` for the full test timeout. `entry()` takes the action label
- * and actor separately and bridges whatever sits between them, so callers never need to know
- * which separator applies where.
+ * Summary text is "<action> · <actor>" (a middle dot), not the lifecycle table's "<action> by
+ * <actor>" - matching on "by" here finds nothing. `entry()` bridges whatever separator applies.
  */
 export class ConsentFullHistoryDialogPage {
   readonly dialog: Locator
@@ -57,15 +52,9 @@ export class ConsentFullHistoryDialogPage {
   }
 
   /**
-   * The whole accordion (summary + details) for one entry, so a diff assertion can't match a
-   * sibling entry's panel that happens to render the same tag text.
-   *
-   * `hasText`, not `has: this.entry(...)` - confirmed live that `.filter({has: locator})` returns
-   * zero matches here even though both the base locator and the `has` locator individually match
-   * something. `this.entry()` is chained off `this.dialog`, which is itself a
-   * `.filter({has: ...})`-derived locator - using a locator built on top of one filter as the
-   * `has:` predicate of a second, outer filter silently fails to match. `hasText` takes a plain
-   * string/regex instead of a locator, sidestepping the problem entirely.
+   * The whole accordion (summary + details) for one entry, scoping diff assertions to it so they
+   * can't match a sibling entry's panel. Uses `hasText`, not `has: this.entry(...)` - chaining a
+   * filter-derived locator into another filter's `has:` silently matches nothing here.
    */
   private accordionFor(action: string, actor: string): Locator {
     return this.dialog
@@ -88,22 +77,17 @@ export class ConsentFullHistoryDialogPage {
   }
 
   /**
-   * The before→after chip pair `ConsentSnapshotView`'s `StateSummary` renders when a snapshot's
-   * `state` itself changed (e.g. "Active" → "Revoked"). `state` is diffed separately from
-   * fields/properties/authorizations (see consentSnapshotDiff.ts's own comment on why) and is
-   * never routed through the shared `ChangeTag`/`noChangesNote` those three use - so a diff whose
-   * *only* change is the state transition matches neither `changedTag` nor `noChangesNote`.
+   * The before→after chip pair rendered when a snapshot's `state` changed (e.g. "Active" →
+   * "Revoked"). `state` is diffed separately from fields/properties/authorizations, so a
+   * state-only change matches neither `changedTag` nor `noChangesNote`.
    */
   stateTransition(action: string, actor: string, from: string, to: string): Locator {
     return this.accordionFor(action, actor).getByText(new RegExp(`${from}.*→.*${to}`))
   }
 
   /**
-   * Either outcome is a legitimate diff result - which one depends on whether the product's own
-   * consent-mgt-core revoke operation also cascades onto per-authorizer records, which isn't
-   * decidable from this repo (that logic lives in a vendored jar, not here). Use this instead of
-   * `changedTag`/`noChangesNote` wherever the point is only "the diff rendered something, not the
-   * needsMoreHistory fallback" rather than a specific outcome.
+   * Either outcome is legitimate - which one depends on product-internal cascade behavior this
+   * repo can't decide. Use where the point is only "a real diff rendered", not a specific outcome.
    */
   diffRendered(action: string, actor: string): Locator {
     return this.changedTag(action, actor).or(this.noChangesNote(action, actor))

--- a/dpdp-integration-test-suite/tests/03-consents/03.07-user-viewing-consent-history.spec.ts
+++ b/dpdp-integration-test-suite/tests/03-consents/03.07-user-viewing-consent-history.spec.ts
@@ -1,0 +1,218 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { test, expect, loginAsUser, loginAsConsentAdmin } from '../../fixtures/auth.fixtures'
+import { ConsentDetailPage } from '../../pages/ConsentDetailPage'
+import { ConsentFullHistoryDialogPage } from '../../pages/ConsentFullHistoryDialogPage'
+import { env } from '../../utils/env'
+import { seedConsent } from '../../utils/consentSetup'
+
+/**
+ * A user's own consent history: ConsentLifecycleSection (status-audit timeline) and
+ * ConsentFullHistoryDialog (the per-snapshot diff view) on the self detail page
+ * (/consents/:id). See tests/03-consents/03.08-admin-viewing-consent-history.spec.ts for the
+ * admin surface (/administration/consents/:id) and the cross-persona scope-boundary tests.
+ * `dpdp-consent-user` is provisioned with STATUS_HISTORY_VIEW_SELF/HISTORY_VIEW_SELF
+ * unconditionally (DPDPIdentityExtensionTenantMgtListener), so the default user persona needs no
+ * extra setup to see either surface.
+ *
+ * `seedConsent` always creates the consent via the *admin* API (see utils/consentSetup.ts - it's
+ * the one step with no create UI), regardless of who the consent's subject is - so every "Consent
+ * created by ..." entry below is attributed to `env.consentAdmin.username`, never
+ * `env.user.username`, even on the self-service tests in this file. Confirmed live: asserting
+ * the subject's own name here finds nothing.
+ *
+ * `detailPage.goto(consentId)` is called again after every UI action that should show up in
+ * history. This is deliberate, not caution: useApproveConsentMutation/useRejectConsentMutation/
+ * useRevokeConsentMutation only invalidate the `['consent', id]` / `['consents']` query keys,
+ * never `['consent-status-history', id]` or `['consent-full-history', id]` - so the lifecycle
+ * card and full-history dialog would otherwise keep showing pre-action data until a fresh page
+ * load. A real user watching the page live would see the same staleness; that's a product gap,
+ * not something to work around silently here.
+ */
+test.describe('User viewing Consent History (UI)', () => {
+  test('02.07.01 - Approving a Pending consent records CREATE then AUTHORIZE_APPROVE, oldest-first in the table and newest-first in the dialog', async ({
+    browser,
+    consentAdminConsentApi,
+    consentCleanupTracker,
+  }) => {
+    const userPage = await loginAsUser(browser)
+    const consentAdminPage = await loginAsConsentAdmin(browser)
+    const { consentId } = await seedConsent(
+      consentAdminPage,
+      consentAdminConsentApi,
+      consentCleanupTracker,
+      env.user.username,
+      'PENDING',
+    )
+
+    const detailPage = new ConsentDetailPage(userPage, 'self')
+    await detailPage.goto(consentId)
+    await detailPage.openActionDialog('approve')
+    await detailPage.confirmAction('approve')
+    await expect(userPage.getByText('Active', { exact: true })).toBeVisible()
+
+    // See the file-level comment above - the history queries need a fresh page load.
+    await detailPage.goto(consentId)
+
+    await expect(detailPage.lifecycleSection).toBeVisible()
+    await expect(
+      detailPage.lifecycleRow('Consent created', env.consentAdmin.username),
+    ).toBeVisible()
+    await expect(detailPage.lifecycleRow('Approved', env.user.username)).toBeVisible()
+
+    // Oldest-first in the table: CREATE row precedes the AUTHORIZE_APPROVE row.
+    const rowTexts = await detailPage.lifecycleRows.allTextContents()
+    const createdIndex = rowTexts.findIndex((text) => text.includes('Consent created'))
+    const approvedIndex = rowTexts.findIndex((text) => text.includes('Approved by'))
+    expect(createdIndex).toBeGreaterThanOrEqual(0)
+    expect(approvedIndex).toBeGreaterThan(createdIndex)
+
+    await detailPage.openFullHistoryDialog()
+    const dialog = new ConsentFullHistoryDialogPage(userPage)
+    await expect(dialog.dialog).toBeVisible()
+
+    // Newest-first in the dialog: the same two entries, reversed relative to the table above.
+    // The dialog's own summary text is "<action> · <actor>", not "by" - see
+    // ConsentFullHistoryDialogPage's comment - so these substring checks drop "by".
+    const summaryTexts = await dialog.entrySummaries.allTextContents()
+    const dialogApprovedIndex = summaryTexts.findIndex((text) => text.includes('Approved'))
+    const dialogCreatedIndex = summaryTexts.findIndex((text) => text.includes('Consent created'))
+    expect(dialogApprovedIndex).toBeGreaterThanOrEqual(0)
+    expect(dialogCreatedIndex).toBeGreaterThan(dialogApprovedIndex)
+
+    await dialog.expand('Consent created', env.consentAdmin.username)
+    await expect(
+      dialog.initialSnapshotChip('Consent created', env.consentAdmin.username),
+    ).toBeVisible()
+
+    // The subject's own authorization moves from its pre-approval status to APPROVED - a real
+    // diff against real server data, not a fixture.
+    await dialog.expand('Approved', env.user.username)
+    await expect(dialog.changedTag('Approved', env.user.username)).toBeVisible()
+
+    await dialog.close()
+    await userPage.context().close()
+    await consentAdminPage.context().close()
+  })
+
+  test('02.07.02 - Rejecting a Pending consent records AUTHORIZE_REJECT with a diffed authorization', async ({
+    browser,
+    consentAdminConsentApi,
+    consentCleanupTracker,
+  }) => {
+    const userPage = await loginAsUser(browser)
+    const consentAdminPage = await loginAsConsentAdmin(browser)
+    const { consentId } = await seedConsent(
+      consentAdminPage,
+      consentAdminConsentApi,
+      consentCleanupTracker,
+      env.user.username,
+      'PENDING',
+    )
+
+    const detailPage = new ConsentDetailPage(userPage, 'self')
+    await detailPage.goto(consentId)
+    await detailPage.openActionDialog('reject')
+    await detailPage.confirmAction('reject')
+    // .first(): the metadata card's state chip and the authorizations table's own state chip
+    // both render the literal state text (see 02.01.02's identical comment).
+    await expect(userPage.getByText('Rejected', { exact: true }).first()).toBeVisible()
+
+    await detailPage.goto(consentId)
+
+    await expect(detailPage.lifecycleRow('Rejected', env.user.username)).toBeVisible()
+
+    await detailPage.openFullHistoryDialog()
+    const dialog = new ConsentFullHistoryDialogPage(userPage)
+    await dialog.expand('Rejected', env.user.username)
+    await expect(dialog.changedTag('Rejected', env.user.username)).toBeVisible()
+
+    await dialog.close()
+    await userPage.context().close()
+    await consentAdminPage.context().close()
+  })
+
+  test('02.07.03 - A full self-service lifecycle (created, approved, then revoked) is captured in order end to end', async ({
+    browser,
+    consentAdminConsentApi,
+    consentCleanupTracker,
+  }) => {
+    const userPage = await loginAsUser(browser)
+    const consentAdminPage = await loginAsConsentAdmin(browser)
+    const { consentId } = await seedConsent(
+      consentAdminPage,
+      consentAdminConsentApi,
+      consentCleanupTracker,
+      env.user.username,
+      'PENDING',
+    )
+
+    const detailPage = new ConsentDetailPage(userPage, 'self')
+    await detailPage.goto(consentId)
+    await detailPage.openActionDialog('approve')
+    await detailPage.confirmAction('approve')
+    await expect(userPage.getByText('Active', { exact: true })).toBeVisible()
+
+    // Chained on the same loaded page, no intermediate reload - the Revoke action becomes
+    // available reactively once the Active state above is reflected (see 02.01.03/04's identical
+    // pattern of chaining UI actions without a navigation between them).
+    await detailPage.openActionDialog('revoke')
+    await detailPage.confirmAction('revoke')
+    await expect(userPage.getByText('Revoked', { exact: true }).first()).toBeVisible()
+
+    // See the file-level comment above - the history queries need a fresh page load.
+    await detailPage.goto(consentId)
+
+    // Waiting on a visible element (rather than reading text straight off goto()) absorbs this
+    // app's post-navigation OAuth redirect settling - every full page load re-drives the SPA's
+    // silent sign-in redirect (see fixtures/auth.fixtures.ts's own comments on this), and reading
+    // .allTextContents() immediately after goto() can hit a destroyed execution context mid-redirect.
+    await expect(detailPage.lifecycleRow('Revoked', env.user.username)).toBeVisible()
+
+    const rowTexts = await detailPage.lifecycleRows.allTextContents()
+    const createdIndex = rowTexts.findIndex((text) => text.includes('Consent created'))
+    const approvedIndex = rowTexts.findIndex((text) => text.includes('Approved by'))
+    const revokedIndex = rowTexts.findIndex((text) => text.includes('Revoked by'))
+    expect(createdIndex).toBeGreaterThanOrEqual(0)
+    expect(approvedIndex).toBeGreaterThan(createdIndex)
+    expect(revokedIndex).toBeGreaterThan(approvedIndex)
+
+    await detailPage.openFullHistoryDialog()
+    const dialog = new ConsentFullHistoryDialogPage(userPage)
+    await expect(dialog.dialog).toBeVisible()
+    const summaryTexts = await dialog.entrySummaries.allTextContents()
+    const dialogCreatedIndex = summaryTexts.findIndex((text) => text.includes('Consent created'))
+    const dialogApprovedIndex = summaryTexts.findIndex((text) => text.includes('Approved'))
+    const dialogRevokedIndex = summaryTexts.findIndex((text) => text.includes('Revoked'))
+    // Newest-first: REVOKE, then APPROVE, then CREATE.
+    expect(dialogRevokedIndex).toBeGreaterThanOrEqual(0)
+    expect(dialogApprovedIndex).toBeGreaterThan(dialogRevokedIndex)
+    expect(dialogCreatedIndex).toBeGreaterThan(dialogApprovedIndex)
+
+    // The REVOKE step's diff outcome (whether the authorization itself is also touched) isn't
+    // decidable from this repo - see ConsentFullHistoryDialogPage.diffRendered's own comment.
+    // This only proves the diff rendered a real result, not the needsMoreHistory fallback.
+    await dialog.expand('Revoked', env.user.username)
+    await expect(dialog.diffRendered('Revoked', env.user.username)).toBeVisible()
+
+    await dialog.close()
+    await userPage.context().close()
+    await consentAdminPage.context().close()
+  })
+})

--- a/dpdp-integration-test-suite/tests/03-consents/03.07-user-viewing-consent-history.spec.ts
+++ b/dpdp-integration-test-suite/tests/03-consents/03.07-user-viewing-consent-history.spec.ts
@@ -23,27 +23,17 @@ import { env } from '../../utils/env'
 import { seedConsent } from '../../utils/consentSetup'
 
 /**
- * A user's own consent history: ConsentLifecycleSection (status-audit timeline) and
- * ConsentFullHistoryDialog (the per-snapshot diff view) on the self detail page
- * (/consents/:id). See tests/03-consents/03.08-admin-viewing-consent-history.spec.ts for the
- * admin surface (/administration/consents/:id) and the cross-persona scope-boundary tests.
- * `dpdp-consent-user` is provisioned with STATUS_HISTORY_VIEW_SELF/HISTORY_VIEW_SELF
- * unconditionally (DPDPIdentityExtensionTenantMgtListener), so the default user persona needs no
- * extra setup to see either surface.
+ * A user's own consent history: the lifecycle timeline and full-history dialog on the self
+ * detail page (/consents/:id). See 03.08-admin-viewing-consent-history.spec.ts for the admin
+ * surface and cross-persona checks. `dpdp-consent-user` gets *_VIEW_SELF scopes by default, so
+ * no extra setup is needed here.
  *
- * `seedConsent` always creates the consent via the *admin* API (see utils/consentSetup.ts - it's
- * the one step with no create UI), regardless of who the consent's subject is - so every "Consent
- * created by ..." entry below is attributed to `env.consentAdmin.username`, never
- * `env.user.username`, even on the self-service tests in this file. Confirmed live: asserting
- * the subject's own name here finds nothing.
+ * `seedConsent` always creates via the admin API, so every "Consent created by ..." entry below
+ * is attributed to `env.consentAdmin.username`, even in these self-service tests.
  *
- * `detailPage.goto(consentId)` is called again after every UI action that should show up in
- * history. This is deliberate, not caution: useApproveConsentMutation/useRejectConsentMutation/
- * useRevokeConsentMutation only invalidate the `['consent', id]` / `['consents']` query keys,
- * never `['consent-status-history', id]` or `['consent-full-history', id]` - so the lifecycle
- * card and full-history dialog would otherwise keep showing pre-action data until a fresh page
- * load. A real user watching the page live would see the same staleness; that's a product gap,
- * not something to work around silently here.
+ * `detailPage.goto(consentId)` is called again after each action that should appear in history:
+ * the approve/reject/revoke mutations don't invalidate the history query keys, so the lifecycle
+ * card and dialog would otherwise keep showing stale data - a real product gap, not a test quirk.
  */
 test.describe('User viewing Consent History (UI)', () => {
   test('02.07.01 - Approving a Pending consent records CREATE then AUTHORIZE_APPROVE, oldest-first in the table and newest-first in the dialog', async ({
@@ -87,9 +77,8 @@ test.describe('User viewing Consent History (UI)', () => {
     const dialog = new ConsentFullHistoryDialogPage(userPage)
     await expect(dialog.dialog).toBeVisible()
 
-    // Newest-first in the dialog: the same two entries, reversed relative to the table above.
-    // The dialog's own summary text is "<action> · <actor>", not "by" - see
-    // ConsentFullHistoryDialogPage's comment - so these substring checks drop "by".
+    // Newest-first in the dialog, reversed relative to the table above. Summary text uses "·",
+    // not "by" - see ConsentFullHistoryDialogPage - so these checks drop "by".
     const summaryTexts = await dialog.entrySummaries.allTextContents()
     const dialogApprovedIndex = summaryTexts.findIndex((text) => text.includes('Approved'))
     const dialogCreatedIndex = summaryTexts.findIndex((text) => text.includes('Consent created'))
@@ -101,8 +90,7 @@ test.describe('User viewing Consent History (UI)', () => {
       dialog.initialSnapshotChip('Consent created', env.consentAdmin.username),
     ).toBeVisible()
 
-    // The subject's own authorization moves from its pre-approval status to APPROVED - a real
-    // diff against real server data, not a fixture.
+    // A real diff against real server data: the subject's authorization moves to APPROVED.
     await dialog.expand('Approved', env.user.username)
     await expect(dialog.changedTag('Approved', env.user.username)).toBeVisible()
 
@@ -169,9 +157,7 @@ test.describe('User viewing Consent History (UI)', () => {
     await detailPage.confirmAction('approve')
     await expect(userPage.getByText('Active', { exact: true })).toBeVisible()
 
-    // Chained on the same loaded page, no intermediate reload - the Revoke action becomes
-    // available reactively once the Active state above is reflected (see 02.01.03/04's identical
-    // pattern of chaining UI actions without a navigation between them).
+    // Chained without a reload - Revoke becomes available reactively once Active is reflected.
     await detailPage.openActionDialog('revoke')
     await detailPage.confirmAction('revoke')
     await expect(userPage.getByText('Revoked', { exact: true }).first()).toBeVisible()
@@ -179,10 +165,9 @@ test.describe('User viewing Consent History (UI)', () => {
     // See the file-level comment above - the history queries need a fresh page load.
     await detailPage.goto(consentId)
 
-    // Waiting on a visible element (rather than reading text straight off goto()) absorbs this
-    // app's post-navigation OAuth redirect settling - every full page load re-drives the SPA's
-    // silent sign-in redirect (see fixtures/auth.fixtures.ts's own comments on this), and reading
-    // .allTextContents() immediately after goto() can hit a destroyed execution context mid-redirect.
+    // Wait on a visible element rather than reading text straight off goto() - every full page
+    // load re-drives the SPA's silent sign-in redirect, which can otherwise hit a destroyed
+    // execution context (see fixtures/auth.fixtures.ts).
     await expect(detailPage.lifecycleRow('Revoked', env.user.username)).toBeVisible()
 
     const rowTexts = await detailPage.lifecycleRows.allTextContents()
@@ -205,9 +190,7 @@ test.describe('User viewing Consent History (UI)', () => {
     expect(dialogApprovedIndex).toBeGreaterThan(dialogRevokedIndex)
     expect(dialogCreatedIndex).toBeGreaterThan(dialogApprovedIndex)
 
-    // The REVOKE step's diff outcome (whether the authorization itself is also touched) isn't
-    // decidable from this repo - see ConsentFullHistoryDialogPage.diffRendered's own comment.
-    // This only proves the diff rendered a real result, not the needsMoreHistory fallback.
+    // Only proves the diff rendered a real result - see diffRendered's own comment.
     await dialog.expand('Revoked', env.user.username)
     await expect(dialog.diffRendered('Revoked', env.user.username)).toBeVisible()
 

--- a/dpdp-integration-test-suite/tests/03-consents/03.08-admin-viewing-consent-history.spec.ts
+++ b/dpdp-integration-test-suite/tests/03-consents/03.08-admin-viewing-consent-history.spec.ts
@@ -1,0 +1,217 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { test, expect, loginAsUser, loginAsConsentAdmin } from '../../fixtures/auth.fixtures'
+import { ConsentDetailPage } from '../../pages/ConsentDetailPage'
+import { ConsentFullHistoryDialogPage } from '../../pages/ConsentFullHistoryDialogPage'
+import { env } from '../../utils/env'
+import { seedConsent } from '../../utils/consentSetup'
+
+/**
+ * The admin surface (/administration/consents/:id) of the same two components covered in
+ * tests/03-consents/03.07-user-viewing-consent-history.spec.ts - see that file's comment for the
+ * shared "why goto() twice" note (useRevokeConsentMutation doesn't invalidate the history query
+ * keys, so a fresh page load is needed after any action that should show up in history) and for
+ * why every seeded consent's CREATE entry is attributed to the admin persona regardless of who
+ * the consent's subject is. `dpdp-consent-admin`'s role permission set is a superset that
+ * includes both the ANY and SELF variants of every consent-history scope
+ * (DPDPIdentityExtensionTenantMgtListener authorizes the whole API resource, not scope-by-scope),
+ * so the admin persona needs no extra setup either.
+ *
+ * Beyond the admin acting on its own seeded consent, this file also proves the ANY-scoped
+ * endpoints genuinely return a *different* user's own history, not just the admin's own actions -
+ * something no unit test (mocked API) or the self-viewing spec (single persona) can demonstrate.
+ */
+test.describe('Admin viewing Consent History (UI)', () => {
+  test('02.08.01 - Revoking an Active consent as admin attributes CREATE and REVOKE to the admin, showing only the state transition in the diff', async ({
+    browser,
+    consentAdminConsentApi,
+    consentCleanupTracker,
+  }) => {
+    const consentAdminPage = await loginAsConsentAdmin(browser)
+    const { consentId } = await seedConsent(
+      consentAdminPage,
+      consentAdminConsentApi,
+      consentCleanupTracker,
+      env.user.username,
+      'ACTIVE',
+    )
+
+    const detailPage = new ConsentDetailPage(consentAdminPage, 'admin')
+    await detailPage.goto(consentId)
+    await detailPage.openActionDialog('revoke')
+    await detailPage.confirmAction('revoke')
+    await expect(consentAdminPage.getByText('Revoked', { exact: true }).first()).toBeVisible()
+
+    // See the file-level comment above - the history queries need a fresh page load.
+    await detailPage.goto(consentId)
+
+    await expect(
+      detailPage.lifecycleRow('Consent created', env.consentAdmin.username),
+    ).toBeVisible()
+    await expect(detailPage.lifecycleRow('Revoked', env.consentAdmin.username)).toBeVisible()
+
+    const rowTexts = await detailPage.lifecycleRows.allTextContents()
+    const createdIndex = rowTexts.findIndex((text) => text.includes('Consent created'))
+    const revokedIndex = rowTexts.findIndex((text) => text.includes('Revoked by'))
+    expect(revokedIndex).toBeGreaterThan(createdIndex)
+
+    await detailPage.openFullHistoryDialog()
+    const dialog = new ConsentFullHistoryDialogPage(consentAdminPage)
+    await expect(dialog.dialog).toBeVisible()
+
+    // Revoking never touched expiryTime/properties/authorizations - this consent had none of the
+    // last to begin with (created with an explicit ACTIVE state, not via authorizations) - but
+    // `state` itself is diffed too (see consentSnapshotDiff.ts), and it did change (Active ->
+    // Revoked), so the diff renders that transition rather than the noChangesNote fallback.
+    // Unlike 02.07.03's revoke-after-approve case, there is no ambiguity here: no authorizer
+    // record ever existed to cascade.
+    await dialog.expand('Revoked', env.consentAdmin.username)
+    await expect(
+      dialog.stateTransition('Revoked', env.consentAdmin.username, 'Active', 'Revoked'),
+    ).toBeVisible()
+
+    await dialog.close()
+    await consentAdminPage.context().close()
+  })
+
+  test("02.08.02 - The admin surface shows the data principal's own approval, not just admin-authored history", async ({
+    browser,
+    consentAdminConsentApi,
+    consentCleanupTracker,
+  }) => {
+    const userPage = await loginAsUser(browser)
+    const consentAdminPage = await loginAsConsentAdmin(browser)
+    const { consentId } = await seedConsent(
+      consentAdminPage,
+      consentAdminConsentApi,
+      consentCleanupTracker,
+      env.user.username,
+      'PENDING',
+    )
+
+    // The data principal, not the admin, performs the approval - on the self surface.
+    const selfDetailPage = new ConsentDetailPage(userPage, 'self')
+    await selfDetailPage.goto(consentId)
+    await selfDetailPage.openActionDialog('approve')
+    await selfDetailPage.confirmAction('approve')
+    await expect(userPage.getByText('Active', { exact: true })).toBeVisible()
+
+    // The admin's first-ever load of this consent's detail page happens after the approval
+    // above already landed server-side, so this single navigation - unlike the "goto() twice"
+    // cases elsewhere in this file - already reflects fresh data; there was never a stale
+    // history query to invalidate on this page instance in the first place.
+    const adminDetailPage = new ConsentDetailPage(consentAdminPage, 'admin')
+    await adminDetailPage.goto(consentId)
+
+    await expect(
+      adminDetailPage.lifecycleRow('Consent created', env.consentAdmin.username),
+    ).toBeVisible()
+    await expect(adminDetailPage.lifecycleRow('Approved', env.user.username)).toBeVisible()
+
+    await adminDetailPage.openFullHistoryDialog()
+    const dialog = new ConsentFullHistoryDialogPage(consentAdminPage)
+    await expect(dialog.entry('Approved', env.user.username)).toBeVisible()
+
+    await dialog.expand('Approved', env.user.username)
+    await expect(dialog.changedTag('Approved', env.user.username)).toBeVisible()
+
+    await dialog.close()
+    await userPage.context().close()
+    await consentAdminPage.context().close()
+  })
+
+  test('02.08.03 - A full multi-actor lifecycle (admin creates, the data principal approves, admin revokes) is captured in order with each actor attributed correctly', async ({
+    browser,
+    consentAdminConsentApi,
+    consentCleanupTracker,
+  }) => {
+    const userPage = await loginAsUser(browser)
+    const consentAdminPage = await loginAsConsentAdmin(browser)
+    const { consentId } = await seedConsent(
+      consentAdminPage,
+      consentAdminConsentApi,
+      consentCleanupTracker,
+      env.user.username,
+      'PENDING',
+    )
+
+    const selfDetailPage = new ConsentDetailPage(userPage, 'self')
+    await selfDetailPage.goto(consentId)
+    await selfDetailPage.openActionDialog('approve')
+    await selfDetailPage.confirmAction('approve')
+    await expect(userPage.getByText('Active', { exact: true })).toBeVisible()
+
+    const adminDetailPage = new ConsentDetailPage(consentAdminPage, 'admin')
+    await adminDetailPage.goto(consentId)
+    await adminDetailPage.openActionDialog('revoke')
+    await adminDetailPage.confirmAction('revoke')
+    await expect(consentAdminPage.getByText('Revoked', { exact: true }).first()).toBeVisible()
+
+    // The revoke mutation above doesn't invalidate the history queries - see the file-level
+    // comment. This is the admin page's second navigation to this URL, specifically to pick up
+    // the REVOKE entry it just produced.
+    await adminDetailPage.goto(consentId)
+
+    // Waiting on a visible element (rather than reading text straight off goto()) absorbs this
+    // app's post-navigation OAuth redirect settling - every full page load re-drives the SPA's
+    // silent sign-in redirect (see fixtures/auth.fixtures.ts's own comments on this), and reading
+    // .allTextContents() immediately after goto() can hit a destroyed execution context mid-redirect.
+    await expect(
+      adminDetailPage.lifecycleRow('Revoked', env.consentAdmin.username),
+    ).toBeVisible()
+
+    const rowTexts = await adminDetailPage.lifecycleRows.allTextContents()
+    const createdIndex = rowTexts.findIndex(
+      (text) => text.includes('Consent created') && text.includes(env.consentAdmin.username),
+    )
+    const approvedIndex = rowTexts.findIndex(
+      (text) => text.includes('Approved by') && text.includes(env.user.username),
+    )
+    const revokedIndex = rowTexts.findIndex(
+      (text) => text.includes('Revoked by') && text.includes(env.consentAdmin.username),
+    )
+    expect(createdIndex).toBeGreaterThanOrEqual(0)
+    expect(approvedIndex).toBeGreaterThan(createdIndex)
+    expect(revokedIndex).toBeGreaterThan(approvedIndex)
+
+    await adminDetailPage.openFullHistoryDialog()
+    const dialog = new ConsentFullHistoryDialogPage(consentAdminPage)
+    await expect(dialog.dialog).toBeVisible()
+    // The dialog's own summary text is "<action> · <actor>", not "by" - see
+    // ConsentFullHistoryDialogPage's comment - so these substring checks drop "by".
+    const summaryTexts = await dialog.entrySummaries.allTextContents()
+    const dialogCreatedIndex = summaryTexts.findIndex(
+      (text) => text.includes('Consent created') && text.includes(env.consentAdmin.username),
+    )
+    const dialogApprovedIndex = summaryTexts.findIndex(
+      (text) => text.includes('Approved') && text.includes(env.user.username),
+    )
+    const dialogRevokedIndex = summaryTexts.findIndex(
+      (text) => text.includes('Revoked') && text.includes(env.consentAdmin.username),
+    )
+    // Newest-first: REVOKE (admin), then APPROVE (user), then CREATE (admin).
+    expect(dialogRevokedIndex).toBeGreaterThanOrEqual(0)
+    expect(dialogApprovedIndex).toBeGreaterThan(dialogRevokedIndex)
+    expect(dialogCreatedIndex).toBeGreaterThan(dialogApprovedIndex)
+
+    await dialog.close()
+    await userPage.context().close()
+    await consentAdminPage.context().close()
+  })
+})

--- a/dpdp-integration-test-suite/tests/03-consents/03.08-admin-viewing-consent-history.spec.ts
+++ b/dpdp-integration-test-suite/tests/03-consents/03.08-admin-viewing-consent-history.spec.ts
@@ -24,18 +24,12 @@ import { seedConsent } from '../../utils/consentSetup'
 
 /**
  * The admin surface (/administration/consents/:id) of the same two components covered in
- * tests/03-consents/03.07-user-viewing-consent-history.spec.ts - see that file's comment for the
- * shared "why goto() twice" note (useRevokeConsentMutation doesn't invalidate the history query
- * keys, so a fresh page load is needed after any action that should show up in history) and for
- * why every seeded consent's CREATE entry is attributed to the admin persona regardless of who
- * the consent's subject is. `dpdp-consent-admin`'s role permission set is a superset that
- * includes both the ANY and SELF variants of every consent-history scope
- * (DPDPIdentityExtensionTenantMgtListener authorizes the whole API resource, not scope-by-scope),
- * so the admin persona needs no extra setup either.
+ * 03.07-user-viewing-consent-history.spec.ts - see that file's comment for why `goto()` runs
+ * twice and why CREATE is always attributed to the admin persona. `dpdp-consent-admin` gets both
+ * ANY and SELF history scopes by default, so no extra setup is needed here either.
  *
- * Beyond the admin acting on its own seeded consent, this file also proves the ANY-scoped
- * endpoints genuinely return a *different* user's own history, not just the admin's own actions -
- * something no unit test (mocked API) or the self-viewing spec (single persona) can demonstrate.
+ * This file also proves the ANY-scoped endpoints return a *different* user's own history, not
+ * just the admin's own actions - something the self-viewing spec's single persona can't show.
  */
 test.describe('Admin viewing Consent History (UI)', () => {
   test('02.08.01 - Revoking an Active consent as admin attributes CREATE and REVOKE to the admin, showing only the state transition in the diff', async ({
@@ -75,12 +69,9 @@ test.describe('Admin viewing Consent History (UI)', () => {
     const dialog = new ConsentFullHistoryDialogPage(consentAdminPage)
     await expect(dialog.dialog).toBeVisible()
 
-    // Revoking never touched expiryTime/properties/authorizations - this consent had none of the
-    // last to begin with (created with an explicit ACTIVE state, not via authorizations) - but
-    // `state` itself is diffed too (see consentSnapshotDiff.ts), and it did change (Active ->
-    // Revoked), so the diff renders that transition rather than the noChangesNote fallback.
-    // Unlike 02.07.03's revoke-after-approve case, there is no ambiguity here: no authorizer
-    // record ever existed to cascade.
+    // This consent was created directly in ACTIVE state with no authorizations to cascade, so
+    // the only change is `state` itself (Active -> Revoked) - no ambiguity like 02.07.03's
+    // revoke-after-approve case.
     await dialog.expand('Revoked', env.consentAdmin.username)
     await expect(
       dialog.stateTransition('Revoked', env.consentAdmin.username, 'Active', 'Revoked'),
@@ -112,10 +103,8 @@ test.describe('Admin viewing Consent History (UI)', () => {
     await selfDetailPage.confirmAction('approve')
     await expect(userPage.getByText('Active', { exact: true })).toBeVisible()
 
-    // The admin's first-ever load of this consent's detail page happens after the approval
-    // above already landed server-side, so this single navigation - unlike the "goto() twice"
-    // cases elsewhere in this file - already reflects fresh data; there was never a stale
-    // history query to invalidate on this page instance in the first place.
+    // First load happens after the approval already landed server-side, so a single navigation
+    // is enough here - unlike the "goto() twice" cases elsewhere in this file.
     const adminDetailPage = new ConsentDetailPage(consentAdminPage, 'admin')
     await adminDetailPage.goto(consentId)
 
@@ -163,15 +152,11 @@ test.describe('Admin viewing Consent History (UI)', () => {
     await adminDetailPage.confirmAction('revoke')
     await expect(consentAdminPage.getByText('Revoked', { exact: true }).first()).toBeVisible()
 
-    // The revoke mutation above doesn't invalidate the history queries - see the file-level
-    // comment. This is the admin page's second navigation to this URL, specifically to pick up
-    // the REVOKE entry it just produced.
+    // Second navigation to pick up the REVOKE entry - see the file-level comment.
     await adminDetailPage.goto(consentId)
 
-    // Waiting on a visible element (rather than reading text straight off goto()) absorbs this
-    // app's post-navigation OAuth redirect settling - every full page load re-drives the SPA's
-    // silent sign-in redirect (see fixtures/auth.fixtures.ts's own comments on this), and reading
-    // .allTextContents() immediately after goto() can hit a destroyed execution context mid-redirect.
+    // Wait on a visible element rather than reading text straight off goto() - see 03.07's
+    // identical comment on the SPA's post-navigation redirect settling.
     await expect(
       adminDetailPage.lifecycleRow('Revoked', env.consentAdmin.username),
     ).toBeVisible()
@@ -193,8 +178,7 @@ test.describe('Admin viewing Consent History (UI)', () => {
     await adminDetailPage.openFullHistoryDialog()
     const dialog = new ConsentFullHistoryDialogPage(consentAdminPage)
     await expect(dialog.dialog).toBeVisible()
-    // The dialog's own summary text is "<action> · <actor>", not "by" - see
-    // ConsentFullHistoryDialogPage's comment - so these substring checks drop "by".
+    // Summary text uses "·", not "by" - see ConsentFullHistoryDialogPage.
     const summaryTexts = await dialog.entrySummaries.allTextContents()
     const dialogCreatedIndex = summaryTexts.findIndex(
       (text) => text.includes('Consent created') && text.includes(env.consentAdmin.username),


### PR DESCRIPTION
## Purpose                                                                                                                                                                         
  The consent-history UI (ConsentLifecycleSection's status-audit timeline and the ConsentFullHistoryDialog per-snapshot diff view) had no E2E coverage on either the self-service    
  (`/consents/:id`) or admin (`/administration/consents/:id`) surfaces. Adds that coverage.                                                                                          
                                                                                                                                                                                     
  ## Goals                                                                                                                                                                           
  - Verify a user can see their own consent's lifecycle timeline and full snapshot history, correctly ordered (oldest-first in the table, newest-first in the dialog).               
  - Verify the admin surface shows the same two components, correctly attributing entries to whichever actor performed them — including the data principal's own actions, not just   
  the admin's.                                                                                                                                                                       
  - Verify snapshot diffs render real before/after data (state transitions, changed/unchanged tags) rather than the "no history" fallback.                                           
                                                                                                                                                                                     
  ## Approach                                                                                                                                                                        
  Added two new page objects and two new spec files to `dpdp-integration-test-suite`:                                                                                                
                                                                                                                                                                                     
  - `pages/ConsentDetailPage.ts`: extended with locators/helpers for the lifecycle timeline card (`lifecycleSection`, `lifecycleRows`, `lifecycleRow(action, actor)`) and the button 
  that opens the full history dialog.                                                                                                                                                
  - `pages/ConsentFullHistoryDialogPage.ts` (new): wraps the full-history dialog's accordion entries — expanding an entry, and asserting on its diff content (initial snapshot chip, 
  changed/unchanged tag, state transition, or either as a catch-all where the exact diff outcome isn't deterministic from this repo).                                                
  - `tests/03-consents/03.07-user-viewing-consent-history.spec.ts` (new): self-service surface — approve, reject, and a full create→approve→revoke lifecycle, asserting both the     
  table and dialog capture and order every step.                                                                                                                                     
  - `tests/03-consents/03.08-admin-viewing-consent-history.spec.ts` (new): admin surface — admin-authored revoke, the admin surface correctly showing the data principal's own       
  approval, and a full multi-actor lifecycle (admin creates, principal approves, admin revokes) with per-actor attribution.                                                          
                                                                                                                                                                                     
  Each test reloads the detail page after any UI action that should appear in history, since `useApproveConsentMutation`/`useRejectConsentMutation`/`useRevokeConsentMutation` don't 
  invalidate the `consent-status-history`/`consent-full-history` query keys — a real product staleness gap, documented inline rather than worked around silently.
  
  No UI changes — test-only PR, no screenshots needed.                                                                                                                               
                                                                                                                                                                                     
  ## User stories                                                                                                                                                                    
  - As a data principal, I can view the full audit trail of my own consent (who created it, who approved/rejected/revoked it, and what changed at each step).                        
  - As a consent admin, I can view the same audit trail for any consent, correctly attributed even when a step was performed by the data principal rather than by me.                
                                                                                                                                                                                     
  ## Release note                                                                                                                                                                    
  Added E2E test coverage for the consent lifecycle history table and full snapshot history dialog, on both the self-service and admin consent detail pages.                         
                                                                                                                                                                                     
  ## Documentation                                                                                                                                                                   
  N/A  