### PR TITLE
Fix purpose/element name overflow and element picker search (#24, #7)

### DIFF
--- a/dpdp-accelerator/react-apps/consent-portal/frontend/src/features/catalog/ElementListPage.tsx
+++ b/dpdp-accelerator/react-apps/consent-portal/frontend/src/features/catalog/ElementListPage.tsx
@@ -169,7 +169,14 @@ function ElementListPage(): React.JSX.Element {
                         }}
                       >
                         <TableCell>
-                          <Typography component="code" variant="body2" fontWeight={600} noWrap>
+                          <Typography
+                            component="code"
+                            variant="body2"
+                            fontWeight={600}
+                            noWrap
+                            title={element.name}
+                            sx={{ display: 'block' }}
+                          >
                             {element.name}
                           </Typography>
                         </TableCell>

--- a/dpdp-accelerator/react-apps/consent-portal/frontend/src/features/catalog/PurposeListPage.tsx
+++ b/dpdp-accelerator/react-apps/consent-portal/frontend/src/features/catalog/PurposeListPage.tsx
@@ -194,7 +194,14 @@ function PurposeListPage(): React.JSX.Element {
                         }}
                       >
                         <TableCell>
-                          <Typography component="code" variant="body2" fontWeight={600} noWrap>
+                          <Typography
+                            component="code"
+                            variant="body2"
+                            fontWeight={600}
+                            noWrap
+                            title={purpose.name}
+                            sx={{ display: 'block' }}
+                          >
                             {purpose.name}
                           </Typography>
                         </TableCell>

--- a/dpdp-accelerator/react-apps/consent-portal/frontend/src/features/catalog/components/PurposeElementPicker.tsx
+++ b/dpdp-accelerator/react-apps/consent-portal/frontend/src/features/catalog/components/PurposeElementPicker.tsx
@@ -24,8 +24,10 @@ import {
   TextField,
   Typography,
 } from '@wso2/oxygen-ui'
+import { useEffect, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import type { PurposeElementInput } from '../../../types/catalog'
+import { buildElementNameFilter } from '../api/catalogApi'
 import { useElementsQuery } from '../hooks/useCatalogQueries'
 
 export interface SelectedElement extends PurposeElementInput {
@@ -39,8 +41,16 @@ interface PurposeElementPickerProps {
   onChange: (selected: SelectedElement[]) => void
 }
 
-/** Best-effort single-page fetch for the picker; not a true "list everything". */
-const ELEMENT_PICKER_PAGE_SIZE = 200
+/**
+ * The Identity Server caps paginated results at 100 regardless of the limit
+ * requested, so a static fetch can never surface every element once the
+ * catalog grows past that - see
+ * https://github.com/wso2/dpdp-accelerator/issues/7. Typing into the picker
+ * now searches server-side via `buildElementNameFilter`, the same filter the
+ * Elements list page itself uses, instead of filtering this one page client-side.
+ */
+const ELEMENT_PICKER_PAGE_SIZE = 100
+const ELEMENT_SEARCH_DEBOUNCE_MS = 300
 
 /** Multi-select against the Elements catalog, with a per-selection Mandatory toggle. */
 function PurposeElementPicker({
@@ -49,19 +59,41 @@ function PurposeElementPicker({
   onChange,
 }: PurposeElementPickerProps): React.JSX.Element {
   const { t } = useTranslation('common')
-  const elementsQuery = useElementsQuery({ limit: ELEMENT_PICKER_PAGE_SIZE })
+  const [inputValue, setInputValue] = useState('')
+  const [searchTerm, setSearchTerm] = useState('')
+
+  useEffect(() => {
+    const timer = setTimeout(() => setSearchTerm(inputValue), ELEMENT_SEARCH_DEBOUNCE_MS)
+    return () => clearTimeout(timer)
+  }, [inputValue])
+
+  const elementsQuery = useElementsQuery({
+    limit: ELEMENT_PICKER_PAGE_SIZE,
+    filter: buildElementNameFilter(searchTerm),
+  })
   const options = elementsQuery.data?.Elements ?? []
   // A selection seeded from an existing version may not be on this page of
   // options (the query is still pending, or the catalog exceeds the page
   // size), so fall back to the metadata already carried on `selected`
   // rather than silently dropping it from the value and the next submit.
-  const selectedOptions = selected.map(
-    (item) =>
-      options.find((option) => option.id === item.id) ?? {
-        id: item.id,
-        name: item.name,
-        displayName: item.displayName,
-      },
+  //
+  // Memoized so this array keeps the same reference across renders that
+  // don't actually change the selection - otherwise Autocomplete sees a
+  // "new" value on every keystroke (searchTerm/options changing re-renders
+  // this component) and resets its typed input text back to empty, making
+  // the field appear untypable.
+  const selectedOptions = useMemo(
+    () =>
+      selected.map(
+        (item) =>
+          options.find((option) => option.id === item.id) ?? {
+            id: item.id,
+            name: item.name,
+            displayName: item.displayName,
+          },
+      ),
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- re-deriving on every `options` page change would recreate this on every keystroke, defeating the memoization
+    [selected],
   )
 
   return (
@@ -72,6 +104,13 @@ function PurposeElementPicker({
         loading={elementsQuery.isPending}
         options={options}
         value={selectedOptions}
+        inputValue={inputValue}
+        onInputChange={(_event, newInputValue) => setInputValue(newInputValue)}
+        // The options list is already name-filtered server-side (see
+        // useElementsQuery above); re-filtering client-side here would just
+        // hide results whose display name doesn't share the typed substring
+        // even though the server matched on the underlying name.
+        filterOptions={(currentOptions) => currentOptions}
         getOptionLabel={(option) => option.displayName ?? option.name}
         isOptionEqualToValue={(option, optionValue) => option.id === optionValue.id}
         onChange={(_event, newValue) => {


### PR DESCRIPTION
## Summary
- Fix #24: long Purpose/Element names overlapped the adjacent Type/DisplayName column. Root cause: `Typography component="code" noWrap` renders an inline `<code>` element, and MUI's `noWrap` ellipsis/overflow styles don't visually clip inline boxes. Forced `display: block` and added a `title` tooltip with the full name.
- Fix #7: the Purpose creation element picker could only ever see the first 100 elements (Identity Server's hard pagination cap), making anything created after that unreachable. Replaced the static fetch with a debounced (300ms) server-side search via the existing `buildElementNameFilter`, same filter the Elements list page already uses.
- Fixed a regression introduced while building the above: the picker's selected-options array was rebuilt on every render, so Autocomplete saw its `value` "change" on every keystroke and reset the typed text back to empty. Memoized it so typing actually works.

## Test plan
- [x] `tsc -b`, `eslint`, full frontend test suite (297/297) pass
- [x] Manually verified against a live tenant with 107 elements: typing "emergency" now finds an element past the 100-item cap that was previously unreachable
