### PR TITLE
Added dpdp-anonymization-tool

### DIFF
--- a/tools/dpdp-anonymization-tool/LICENSE
+++ b/tools/dpdp-anonymization-tool/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/tools/dpdp-anonymization-tool/README.md
+++ b/tools/dpdp-anonymization-tool/README.md
@@ -1,0 +1,65 @@
+# WSO2 DPDP Anonymization Tool
+
+This standalone administrative tool pseudonymizes configured user identifiers in `WSO2DPDP_DB`.
+It is intentionally separate from the DPDP Accelerator runtime and the legacy Identity Anonymization Tool.
+
+## Safety model
+
+- The tenant domain is mandatory and is applied as `ORG_ID` to every query.
+- Source and replacement values must be different canonical UUIDs.
+- A target value found without the source is reported as ambiguous; it is not claimed as proof of a prior run.
+- The default mode is a dry-run; `--execute` is required to commit.
+- Covered database changes use one JDBC transaction and roll back together.
+- Event payloads are inspected only at explicitly configured topic/path combinations.
+- Full identifiers and discovered usernames are not written to reports.
+
+Stop WSO2 IS, DPDP workers, and other writers and take a tested database backup before execution.
+
+## Build
+
+The project targets Java 8.
+
+```bash
+mvn clean verify
+```
+
+Distribution:
+
+```text
+components/dpdp-anonymization-distribution/target/dpdp-anonymization-tool-1.0.0-SNAPSHOT.zip
+```
+
+## Run
+
+Dry-run:
+
+```bash
+./bin/dpdp-anonymize \
+  --tenant-domain example.com \
+  --user-id 18b7c17d-ef74-48c5-a0c8-a1df9b21ff87 \
+  --pseudonym 216d6aac-7e84-4484-a71e-c52f89b3cb1d
+```
+
+Commit only after reviewing the dry-run report:
+
+```bash
+./bin/dpdp-anonymize \
+  --tenant-domain example.com \
+  --user-id 18b7c17d-ef74-48c5-a0c8-a1df9b21ff87 \
+  --pseudonym 216d6aac-7e84-4484-a71e-c52f89b3cb1d \
+  --execute
+```
+
+Use repeatable `--username` options only for aliases independently verified by the operator.
+
+## Scope
+
+The tool covers:
+
+- `COMPLAINT.USER_ID` and its correlated `USER_NAME`.
+- `COMPLAINT_EVENT.ACTOR_USER_ID` and its correlated `ACTOR_USER_NAME`.
+- `DPDP_CONSENT_STATUS_AUDIT.ACTION_BY` for exact trusted identities.
+- `DPDP_CONSENT_HISTORY.ACTION_BY` and configured snapshot identity fields.
+- Allowlisted paths within `EVENT.PAYLOAD` after a tenant-safe `TOPIC` join.
+
+It does not provide complete erasure. Attachments, comments, descriptions, arbitrary unconfigured JSON, operational identifiers, and other databases are outside scope.

--- a/tools/dpdp-anonymization-tool/components/dpdp-anonymization-cli/pom.xml
+++ b/tools/dpdp-anonymization-tool/components/dpdp-anonymization-cli/pom.xml
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="UTF-8"?><!--
+ ~ Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ ~
+ ~ WSO2 LLC. licenses this file to you under the Apache License,
+ ~ Version 2.0 (the "License"); you may not use this file except
+ ~ in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~     http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing,
+ ~ software distributed under the License is distributed on an
+ ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ ~ KIND, either express or implied. See the License for the
+ ~ specific language governing permissions and limitations
+ ~ under the License.
+ -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.wso2.dpdp</groupId>
+        <artifactId>dpdp-anonymization-tool-parent</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+    <artifactId>dpdp-anonymization-cli</artifactId>
+    <dependencies>
+        <dependency>
+            <groupId>org.wso2.dpdp</groupId>
+            <artifactId>dpdp-anonymization-core</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>commons-cli</groupId>
+            <artifactId>commons-cli</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.mysql</groupId>
+            <artifactId>mysql-connector-j</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.5.3</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals><goal>shade</goal></goals>
+                        <configuration>
+                            <finalName>dpdp-anonymization-tool</finalName>
+                            <shadedArtifactAttached>true</shadedArtifactAttached>
+                            <shadedClassifierName>all</shadedClassifierName>
+                            <createDependencyReducedPom>false</createDependencyReducedPom>
+                            <filters>
+                                <filter>
+                                    <artifact>*:*</artifact>
+                                    <excludes>
+                                        <exclude>module-info.class</exclude>
+                                        <exclude>META-INF/versions/*/module-info.class</exclude>
+                                    </excludes>
+                                </filter>
+                            </filters>
+                            <transformers>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                                    <mainClass>org.wso2.dpdp.anonymization.cli.DpdpAnonymizationTool</mainClass>
+                                </transformer>
+                            </transformers>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/tools/dpdp-anonymization-tool/components/dpdp-anonymization-cli/src/main/java/org/wso2/dpdp/anonymization/cli/DpdpAnonymizationTool.java
+++ b/tools/dpdp-anonymization-tool/components/dpdp-anonymization-cli/src/main/java/org/wso2/dpdp/anonymization/cli/DpdpAnonymizationTool.java
@@ -41,6 +41,7 @@ import java.io.PrintStream;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedHashSet;
+import java.util.Map;
 import java.util.Set;
 
 public final class DpdpAnonymizationTool {
@@ -84,8 +85,7 @@ public final class DpdpAnonymizationTool {
             AnonymizationResult result = processor.process(request);
             File reportDirectory = resolveReportDirectory(configFile, config.getReportDirectory());
             File report = new ReportWriter().write(reportDirectory, request, result);
-            out.println("Result: " + result.getStatus());
-            out.println("Discovered aliases: " + result.getDiscoveredAliasCount());
+            printSummary(out, request, result);
             out.println("Report: " + report.getAbsolutePath());
             if (!command.hasOption("execute")) {
                 out.println("No database changes were committed. Re-run with --execute to apply them.");
@@ -102,6 +102,31 @@ public final class DpdpAnonymizationTool {
         } catch (IOException e) {
             err.println("Could not write the anonymization report: " + e.getMessage());
             return ExitCode.EXECUTION_ERROR;
+        }
+    }
+
+    private static void printSummary(PrintStream out, AnonymizationRequest request, AnonymizationResult result) {
+        out.println("Result: " + result.getStatus());
+        out.println("Tenant: " + request.getTenantDomain());
+        out.println("Source user ID: " + request.getSourceUserId());
+        if (request.getExplicitUsernames().isEmpty()) {
+            out.println("Supplied aliases: none");
+        } else {
+            out.println("Supplied aliases: " + String.join(", ", request.getExplicitUsernames()));
+        }
+        if (result.getTrustedUsernames().isEmpty()) {
+            out.println("Trusted aliases considered: none");
+        } else {
+            out.println("Trusted aliases considered: " + String.join(", ", result.getTrustedUsernames()));
+        }
+        out.println("Discovered aliases: " + result.getDiscoveredAliasCount());
+        if (result.getCounts().isEmpty()) {
+            out.println("Matches: none");
+        } else {
+            out.println("Matches:");
+            for (Map.Entry<String, Long> entry : result.getCounts().entrySet()) {
+                out.println("  " + entry.getKey() + ": " + entry.getValue());
+            }
         }
     }
 

--- a/tools/dpdp-anonymization-tool/components/dpdp-anonymization-cli/src/main/java/org/wso2/dpdp/anonymization/cli/DpdpAnonymizationTool.java
+++ b/tools/dpdp-anonymization-tool/components/dpdp-anonymization-cli/src/main/java/org/wso2/dpdp/anonymization/cli/DpdpAnonymizationTool.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.dpdp.anonymization.cli;
+
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.DefaultParser;
+import org.apache.commons.cli.HelpFormatter;
+import org.apache.commons.cli.Option;
+import org.apache.commons.cli.Options;
+import org.apache.commons.cli.ParseException;
+import org.wso2.dpdp.anonymization.config.ToolConfig;
+import org.wso2.dpdp.anonymization.config.ToolConfigLoader;
+import org.wso2.dpdp.anonymization.database.DriverManagerConnectionFactory;
+import org.wso2.dpdp.anonymization.model.AnonymizationRequest;
+import org.wso2.dpdp.anonymization.model.AnonymizationResult;
+import org.wso2.dpdp.anonymization.model.AnonymizationStatus;
+import org.wso2.dpdp.anonymization.model.ExecutionMode;
+import org.wso2.dpdp.anonymization.processor.DpdpAnonymizationProcessor;
+import org.wso2.dpdp.anonymization.report.ReportWriter;
+import org.wso2.dpdp.anonymization.validation.AnonymizationException;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+public final class DpdpAnonymizationTool {
+
+    private DpdpAnonymizationTool() {
+    }
+
+    public static void main(String[] args) {
+        System.exit(run(args, System.out, System.err));
+    }
+
+    static int run(String[] args, PrintStream out, PrintStream err) {
+        Options options = options();
+        File configFile = null;
+        ToolConfig config = null;
+        AnonymizationRequest request = null;
+        try {
+            CommandLine command = new DefaultParser().parse(options, args);
+            if (command.hasOption("help")) {
+                printHelp(options, out);
+                return ExitCode.SUCCESS;
+            }
+            require(command, "tenant-domain");
+            require(command, "user-id");
+            require(command, "pseudonym");
+
+            configFile = new File(command.getOptionValue("config", "conf/config.json"));
+            config = ToolConfigLoader.load(configFile);
+            Set<String> usernames = command.hasOption("username")
+                    ? new LinkedHashSet<>(Arrays.asList(command.getOptionValues("username")))
+                    : Collections.<String>emptySet();
+            request = new AnonymizationRequest(
+                    command.getOptionValue("tenant-domain"),
+                    command.getOptionValue("user-id"),
+                    command.getOptionValue("pseudonym"),
+                    usernames,
+                    command.hasOption("execute") ? ExecutionMode.EXECUTE : ExecutionMode.DRY_RUN);
+
+            DpdpAnonymizationProcessor processor = new DpdpAnonymizationProcessor(
+                    new DriverManagerConnectionFactory(config.getDatabase()), config);
+            AnonymizationResult result = processor.process(request);
+            File reportDirectory = resolveReportDirectory(configFile, config.getReportDirectory());
+            File report = new ReportWriter().write(reportDirectory, request, result);
+            out.println("Result: " + result.getStatus());
+            out.println("Discovered aliases: " + result.getDiscoveredAliasCount());
+            out.println("Report: " + report.getAbsolutePath());
+            if (!command.hasOption("execute")) {
+                out.println("No database changes were committed. Re-run with --execute to apply them.");
+            }
+            return ExitCode.SUCCESS;
+        } catch (ParseException e) {
+            err.println("Invalid arguments: " + e.getMessage());
+            printHelp(options, err);
+            return ExitCode.INVALID_ARGUMENTS;
+        } catch (AnonymizationException e) {
+            err.println("Anonymization failed: " + e.getMessage());
+            writeFailureReport(configFile, config, request, e.getMessage(), err);
+            return ExitCode.EXECUTION_ERROR;
+        } catch (IOException e) {
+            err.println("Could not write the anonymization report: " + e.getMessage());
+            return ExitCode.EXECUTION_ERROR;
+        }
+    }
+
+    private static void writeFailureReport(File configFile, ToolConfig config, AnonymizationRequest request,
+                                           String failureMessage, PrintStream err) {
+        if (configFile == null || config == null || request == null) {
+            return;
+        }
+        AnonymizationResult failure = new AnonymizationResult();
+        failure.setStatus(AnonymizationStatus.FAILED);
+        try {
+            File report = new ReportWriter().writeFailure(
+                    resolveReportDirectory(configFile, config.getReportDirectory()), request, failure, failureMessage);
+            err.println("Failure report: " + report.getAbsolutePath());
+        } catch (IOException reportError) {
+            err.println("Could not write failure report: " + reportError.getMessage());
+        }
+    }
+
+    private static File resolveReportDirectory(File configFile, String path) {
+        File directory = new File(path == null ? "reports" : path);
+        return directory.isAbsolute() ? directory : new File(configFile.getAbsoluteFile().getParentFile(), directory.getPath());
+    }
+
+    private static void require(CommandLine command, String option) throws ParseException {
+        if (!command.hasOption(option) || command.getOptionValue(option).trim().isEmpty()) {
+            throw new ParseException("Missing required option: --" + option);
+        }
+    }
+
+    private static Options options() {
+        Options options = new Options();
+        options.addOption(Option.builder().longOpt("config").hasArg().argName("file")
+                .desc("Configuration file (default: conf/config.json)").build());
+        options.addOption(Option.builder().longOpt("tenant-domain").hasArg().argName("tenant")
+                .desc("Tenant domain mapped to ORG_ID (required)").build());
+        options.addOption(Option.builder().longOpt("user-id").hasArg().argName("uuid")
+                .desc("Canonical source user UUID (required)").build());
+        options.addOption(Option.builder().longOpt("pseudonym").hasArg().argName("uuid")
+                .desc("Canonical replacement UUID (required)").build());
+        options.addOption(Option.builder().longOpt("username").hasArg().argName("alias")
+                .desc("Trusted username alias; may be supplied multiple times").build());
+        options.addOption(Option.builder().longOpt("execute")
+                .desc("Commit changes; without this flag the command is a dry-run").build());
+        options.addOption(Option.builder("h").longOpt("help").desc("Show help").build());
+        return options;
+    }
+
+    private static void printHelp(Options options, PrintStream stream) {
+        new HelpFormatter().printHelp(new java.io.PrintWriter(stream, true), 110, "dpdp-anonymize", null,
+                options, 2, 4, null, true);
+    }
+}

--- a/tools/dpdp-anonymization-tool/components/dpdp-anonymization-cli/src/main/java/org/wso2/dpdp/anonymization/cli/ExitCode.java
+++ b/tools/dpdp-anonymization-tool/components/dpdp-anonymization-cli/src/main/java/org/wso2/dpdp/anonymization/cli/ExitCode.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.dpdp.anonymization.cli;
+
+public final class ExitCode {
+    public static final int SUCCESS = 0;
+    public static final int INVALID_ARGUMENTS = 2;
+    public static final int CONFIGURATION_ERROR = 3;
+    public static final int EXECUTION_ERROR = 4;
+
+    private ExitCode() {
+    }
+}

--- a/tools/dpdp-anonymization-tool/components/dpdp-anonymization-cli/src/test/java/org/wso2/dpdp/anonymization/cli/DpdpAnonymizationToolTest.java
+++ b/tools/dpdp-anonymization-tool/components/dpdp-anonymization-cli/src/test/java/org/wso2/dpdp/anonymization/cli/DpdpAnonymizationToolTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.dpdp.anonymization.cli;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class DpdpAnonymizationToolTest {
+
+    @Test
+    void helpDoesNotRequireConfiguration() {
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        int exitCode = DpdpAnonymizationTool.run(new String[]{"--help"}, new PrintStream(output),
+                new PrintStream(new ByteArrayOutputStream()));
+        assertEquals(ExitCode.SUCCESS, exitCode);
+        assertTrue(output.toString().contains("--execute"));
+    }
+
+    @Test
+    void missingRequiredArgumentsReturnsNonZero() {
+        ByteArrayOutputStream errors = new ByteArrayOutputStream();
+        int exitCode = DpdpAnonymizationTool.run(new String[0], new PrintStream(new ByteArrayOutputStream()),
+                new PrintStream(errors));
+        assertEquals(ExitCode.INVALID_ARGUMENTS, exitCode);
+        assertTrue(errors.toString().contains("--tenant-domain"));
+    }
+}

--- a/tools/dpdp-anonymization-tool/components/dpdp-anonymization-core/pom.xml
+++ b/tools/dpdp-anonymization-tool/components/dpdp-anonymization-core/pom.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?><!--
+ ~ Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ ~
+ ~ WSO2 LLC. licenses this file to you under the Apache License,
+ ~ Version 2.0 (the "License"); you may not use this file except
+ ~ in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~     http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing,
+ ~ software distributed under the License is distributed on an
+ ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ ~ KIND, either express or implied. See the License for the
+ ~ specific language governing permissions and limitations
+ ~ under the License.
+ -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.wso2.dpdp</groupId>
+        <artifactId>dpdp-anonymization-tool-parent</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+    <artifactId>dpdp-anonymization-core</artifactId>
+    <dependencies>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/tools/dpdp-anonymization-tool/components/dpdp-anonymization-core/src/main/java/org/wso2/dpdp/anonymization/config/DatabaseConfig.java
+++ b/tools/dpdp-anonymization-tool/components/dpdp-anonymization-core/src/main/java/org/wso2/dpdp/anonymization/config/DatabaseConfig.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.dpdp.anonymization.config;
+
+public class DatabaseConfig {
+
+    private String driverClass;
+    private String url;
+    private String username;
+    private String password;
+
+    public String getDriverClass() {
+        return driverClass;
+    }
+
+    public void setDriverClass(String driverClass) {
+        this.driverClass = driverClass;
+    }
+
+    public String getUrl() {
+        return url;
+    }
+
+    public void setUrl(String url) {
+        this.url = url;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+}

--- a/tools/dpdp-anonymization-tool/components/dpdp-anonymization-core/src/main/java/org/wso2/dpdp/anonymization/config/EventPayloadRule.java
+++ b/tools/dpdp-anonymization-tool/components/dpdp-anonymization-core/src/main/java/org/wso2/dpdp/anonymization/config/EventPayloadRule.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.dpdp.anonymization.config;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class EventPayloadRule {
+
+    private String topic;
+    private List<String> paths = new ArrayList<>();
+
+    public String getTopic() {
+        return topic;
+    }
+
+    public void setTopic(String topic) {
+        this.topic = topic;
+    }
+
+    public List<String> getPaths() {
+        return paths;
+    }
+
+    public void setPaths(List<String> paths) {
+        this.paths = paths == null ? new ArrayList<String>() : paths;
+    }
+}

--- a/tools/dpdp-anonymization-tool/components/dpdp-anonymization-core/src/main/java/org/wso2/dpdp/anonymization/config/ToolConfig.java
+++ b/tools/dpdp-anonymization-tool/components/dpdp-anonymization-core/src/main/java/org/wso2/dpdp/anonymization/config/ToolConfig.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.dpdp.anonymization.config;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class ToolConfig {
+
+    private DatabaseConfig database = new DatabaseConfig();
+    private List<EventPayloadRule> eventPayloadRules = new ArrayList<>();
+    private String eventPayloadRulesFile = "event-payload-rules.json";
+    private int batchSize = 250;
+    private String reportDirectory = "reports";
+
+    public DatabaseConfig getDatabase() {
+        return database;
+    }
+
+    public void setDatabase(DatabaseConfig database) {
+        this.database = database;
+    }
+
+    public List<EventPayloadRule> getEventPayloadRules() {
+        return eventPayloadRules;
+    }
+
+    public void setEventPayloadRules(List<EventPayloadRule> eventPayloadRules) {
+        this.eventPayloadRules = eventPayloadRules == null ? new ArrayList<EventPayloadRule>() : eventPayloadRules;
+    }
+
+    public String getEventPayloadRulesFile() {
+        return eventPayloadRulesFile;
+    }
+
+    public void setEventPayloadRulesFile(String eventPayloadRulesFile) {
+        this.eventPayloadRulesFile = eventPayloadRulesFile;
+    }
+
+    public int getBatchSize() {
+        return batchSize;
+    }
+
+    public void setBatchSize(int batchSize) {
+        this.batchSize = batchSize;
+    }
+
+    public String getReportDirectory() {
+        return reportDirectory;
+    }
+
+    public void setReportDirectory(String reportDirectory) {
+        this.reportDirectory = reportDirectory;
+    }
+}

--- a/tools/dpdp-anonymization-tool/components/dpdp-anonymization-core/src/main/java/org/wso2/dpdp/anonymization/config/ToolConfigLoader.java
+++ b/tools/dpdp-anonymization-tool/components/dpdp-anonymization-core/src/main/java/org/wso2/dpdp/anonymization/config/ToolConfigLoader.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.dpdp.anonymization.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.wso2.dpdp.anonymization.json.JsonPathExpression;
+import org.wso2.dpdp.anonymization.validation.AnonymizationException;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public final class ToolConfigLoader {
+
+    private static final Pattern ENVIRONMENT_PLACEHOLDER = Pattern.compile("^\\$\\{([A-Za-z_][A-Za-z0-9_]*)}$");
+
+    private ToolConfigLoader() {
+    }
+
+    public static ToolConfig load(File file) throws AnonymizationException {
+        try {
+            ToolConfig config = new ObjectMapper().readValue(file, ToolConfig.class);
+            if (!blank(config.getEventPayloadRulesFile())) {
+                File rulesFile = new File(config.getEventPayloadRulesFile());
+                if (!rulesFile.isAbsolute()) {
+                    rulesFile = new File(file.getAbsoluteFile().getParentFile(), config.getEventPayloadRulesFile());
+                }
+                EventPayloadRule[] rules = new ObjectMapper().readValue(rulesFile, EventPayloadRule[].class);
+                config.setEventPayloadRules(Arrays.asList(rules));
+            }
+            validate(config);
+            DatabaseConfig database = config.getDatabase();
+            database.setUsername(resolveEnvironment(database.getUsername()));
+            database.setPassword(resolveEnvironment(database.getPassword()));
+            return config;
+        } catch (IOException e) {
+            throw new AnonymizationException("Could not read configuration: " + file.getAbsolutePath(), e);
+        }
+    }
+
+    public static void validate(ToolConfig config) throws AnonymizationException {
+        if (config == null || config.getDatabase() == null) {
+            throw new AnonymizationException("Database configuration is required.");
+        }
+        DatabaseConfig database = config.getDatabase();
+        if (blank(database.getUrl()) || blank(database.getDriverClass())) {
+            throw new AnonymizationException("database.url and database.driverClass are required.");
+        }
+        if (config.getBatchSize() < 1 || config.getBatchSize() > 10000) {
+            throw new AnonymizationException("batchSize must be between 1 and 10000.");
+        }
+        Set<String> rules = new HashSet<>();
+        for (EventPayloadRule rule : config.getEventPayloadRules()) {
+            if (rule == null || blank(rule.getTopic()) || rule.getPaths().isEmpty()) {
+                throw new AnonymizationException("Every event payload rule requires a topic and at least one path.");
+            }
+            for (String path : rule.getPaths()) {
+                JsonPathExpression.parse(path);
+                if (!rules.add(rule.getTopic() + "\u0000" + path)) {
+                    throw new AnonymizationException("Duplicate event payload rule: " + rule.getTopic() + " " + path);
+                }
+            }
+        }
+    }
+
+    private static String resolveEnvironment(String value) throws AnonymizationException {
+        if (value == null) {
+            return null;
+        }
+        Matcher matcher = ENVIRONMENT_PLACEHOLDER.matcher(value);
+        if (!matcher.matches()) {
+            return value;
+        }
+        String resolved = System.getenv(matcher.group(1));
+        if (resolved == null) {
+            throw new AnonymizationException("Environment variable " + matcher.group(1) + " is not defined.");
+        }
+        return resolved;
+    }
+
+    private static boolean blank(String value) {
+        return value == null || value.trim().isEmpty();
+    }
+}

--- a/tools/dpdp-anonymization-tool/components/dpdp-anonymization-core/src/main/java/org/wso2/dpdp/anonymization/database/ConnectionFactory.java
+++ b/tools/dpdp-anonymization-tool/components/dpdp-anonymization-core/src/main/java/org/wso2/dpdp/anonymization/database/ConnectionFactory.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.dpdp.anonymization.database;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+
+public interface ConnectionFactory {
+    Connection getConnection() throws SQLException;
+}

--- a/tools/dpdp-anonymization-tool/components/dpdp-anonymization-core/src/main/java/org/wso2/dpdp/anonymization/database/DatabaseDialect.java
+++ b/tools/dpdp-anonymization-tool/components/dpdp-anonymization-core/src/main/java/org/wso2/dpdp/anonymization/database/DatabaseDialect.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.dpdp.anonymization.database;
+
+import org.wso2.dpdp.anonymization.validation.AnonymizationException;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+
+public enum DatabaseDialect {
+    H2,
+    MYSQL;
+
+    public static DatabaseDialect detect(Connection connection) throws SQLException, AnonymizationException {
+        String name = connection.getMetaData().getDatabaseProductName().toLowerCase();
+        if (name.contains("h2")) {
+            return H2;
+        }
+        if (name.contains("mysql") || name.contains("mariadb")) {
+            return MYSQL;
+        }
+        throw new AnonymizationException("Unsupported database: " + connection.getMetaData().getDatabaseProductName());
+    }
+
+    public String forUpdate() {
+        return " FOR UPDATE";
+    }
+}

--- a/tools/dpdp-anonymization-tool/components/dpdp-anonymization-core/src/main/java/org/wso2/dpdp/anonymization/database/DriverManagerConnectionFactory.java
+++ b/tools/dpdp-anonymization-tool/components/dpdp-anonymization-core/src/main/java/org/wso2/dpdp/anonymization/database/DriverManagerConnectionFactory.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.dpdp.anonymization.database;
+
+import org.wso2.dpdp.anonymization.config.DatabaseConfig;
+import org.wso2.dpdp.anonymization.validation.AnonymizationException;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+
+public final class DriverManagerConnectionFactory implements ConnectionFactory {
+
+    private final DatabaseConfig config;
+
+    public DriverManagerConnectionFactory(DatabaseConfig config) throws AnonymizationException {
+        this.config = config;
+        try {
+            Class.forName(config.getDriverClass());
+        } catch (ClassNotFoundException e) {
+            throw new AnonymizationException("JDBC driver is not available: " + config.getDriverClass(), e);
+        }
+    }
+
+    @Override
+    public Connection getConnection() throws SQLException {
+        return DriverManager.getConnection(config.getUrl(), config.getUsername(), config.getPassword());
+    }
+}

--- a/tools/dpdp-anonymization-tool/components/dpdp-anonymization-core/src/main/java/org/wso2/dpdp/anonymization/json/JsonPathExpression.java
+++ b/tools/dpdp-anonymization-tool/components/dpdp-anonymization-core/src/main/java/org/wso2/dpdp/anonymization/json/JsonPathExpression.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.dpdp.anonymization.json;
+
+import org.wso2.dpdp.anonymization.validation.AnonymizationException;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Restricted JSON Pointer syntax with one extension: '*' selects every array element.
+ */
+public final class JsonPathExpression {
+
+    private final String source;
+    private final List<String> segments;
+
+    private JsonPathExpression(String source, List<String> segments) {
+        this.source = source;
+        this.segments = segments;
+    }
+
+    public static JsonPathExpression parse(String path) throws AnonymizationException {
+        if (path == null || path.isEmpty() || path.charAt(0) != '/') {
+            throw new AnonymizationException("JSON path must be an absolute pointer: " + path);
+        }
+        String[] raw = path.substring(1).split("/", -1);
+        List<String> segments = new ArrayList<>();
+        for (String segment : raw) {
+            String decoded = decode(segment, path);
+            if (decoded.isEmpty()) {
+                throw new AnonymizationException("JSON path cannot contain an empty segment: " + path);
+            }
+            segments.add(decoded);
+        }
+        return new JsonPathExpression(path, Collections.unmodifiableList(segments));
+    }
+
+    private static String decode(String value, String path) throws AnonymizationException {
+        StringBuilder decoded = new StringBuilder();
+        for (int i = 0; i < value.length(); i++) {
+            char current = value.charAt(i);
+            if (current != '~') {
+                decoded.append(current);
+                continue;
+            }
+            if (i + 1 >= value.length()) {
+                throw new AnonymizationException("Invalid JSON pointer escape: " + path);
+            }
+            char escaped = value.charAt(++i);
+            if (escaped == '0') {
+                decoded.append('~');
+            } else if (escaped == '1') {
+                decoded.append('/');
+            } else {
+                throw new AnonymizationException("Invalid JSON pointer escape: " + path);
+            }
+        }
+        return decoded.toString();
+    }
+
+    public List<String> getSegments() {
+        return segments;
+    }
+
+    @Override
+    public String toString() {
+        return source;
+    }
+}

--- a/tools/dpdp-anonymization-tool/components/dpdp-anonymization-core/src/main/java/org/wso2/dpdp/anonymization/json/JsonValueRewriter.java
+++ b/tools/dpdp-anonymization-tool/components/dpdp-anonymization-core/src/main/java/org/wso2/dpdp/anonymization/json/JsonValueRewriter.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.dpdp.anonymization.json;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.wso2.dpdp.anonymization.model.IdentityEvidence;
+import org.wso2.dpdp.anonymization.validation.AnonymizationException;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+
+public final class JsonValueRewriter {
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    public RewriteResult rewriteConsentSnapshot(String json, IdentityEvidence evidence, String replacement)
+            throws AnonymizationException {
+        try {
+            JsonNode root = OBJECT_MAPPER.readTree(json);
+            int replacements = rewriteAtPaths(root, evidence, replacement,
+                    asPaths("/piiPrincipalId", "/authorizations/*/userId"));
+            return new RewriteResult(replacements == 0 ? json : OBJECT_MAPPER.writeValueAsString(root), replacements);
+        } catch (IOException e) {
+            throw new AnonymizationException("Malformed consent snapshot JSON.", e);
+        }
+    }
+
+    public RewriteResult rewriteEventPayload(String json, IdentityEvidence evidence, String replacement,
+                                             List<JsonPathExpression> paths) throws AnonymizationException {
+        try {
+            JsonNode root = OBJECT_MAPPER.readTree(json);
+            int replacements = rewriteAtPaths(root, evidence, replacement, paths);
+            return new RewriteResult(replacements == 0 ? json : OBJECT_MAPPER.writeValueAsString(root), replacements);
+        } catch (IOException e) {
+            throw new AnonymizationException("Malformed event payload JSON.", e);
+        }
+    }
+
+    private int rewriteAtPaths(JsonNode root, IdentityEvidence evidence, String replacement,
+                               List<JsonPathExpression> paths) throws AnonymizationException {
+        int replacements = 0;
+        for (JsonPathExpression path : paths) {
+            replacements += rewrite(root, path.getSegments(), 0, evidence, replacement);
+        }
+        return replacements;
+    }
+
+    private int rewrite(JsonNode current, List<String> segments, int offset, IdentityEvidence evidence,
+                        String replacement) throws AnonymizationException {
+        if (current == null || offset >= segments.size()) {
+            return 0;
+        }
+        String segment = segments.get(offset);
+        boolean leaf = offset == segments.size() - 1;
+        if ("*".equals(segment)) {
+            if (!current.isArray()) {
+                return 0;
+            }
+            int count = 0;
+            for (JsonNode child : current) {
+                count += rewrite(child, segments, offset + 1, evidence, replacement);
+            }
+            return count;
+        }
+        if (current.isObject()) {
+            JsonNode child = current.get(segment);
+            if (child == null) {
+                return 0;
+            }
+            if (leaf) {
+                if (!child.isTextual()) {
+                    throw new AnonymizationException("Configured JSON path resolves to a non-string value: /" + segment);
+                }
+                if (evidence.matchesIdentifier(child.textValue())) {
+                    ((ObjectNode) current).put(segment, replacement);
+                    return 1;
+                }
+                return 0;
+            }
+            return rewrite(child, segments, offset + 1, evidence, replacement);
+        }
+        if (current.isArray()) {
+            int index;
+            try {
+                index = Integer.parseInt(segment);
+            } catch (NumberFormatException e) {
+                return 0;
+            }
+            if (index < 0 || index >= current.size()) {
+                return 0;
+            }
+            JsonNode child = current.get(index);
+            if (leaf) {
+                if (!child.isTextual()) {
+                    throw new AnonymizationException("Configured JSON path resolves to a non-string array value.");
+                }
+                if (evidence.matchesIdentifier(child.textValue())) {
+                    ((ArrayNode) current).set(index, OBJECT_MAPPER.getNodeFactory().textNode(replacement));
+                    return 1;
+                }
+                return 0;
+            }
+            return rewrite(child, segments, offset + 1, evidence, replacement);
+        }
+        return 0;
+    }
+
+    private List<JsonPathExpression> asPaths(String first, String second) throws AnonymizationException {
+        return java.util.Arrays.asList(JsonPathExpression.parse(first), JsonPathExpression.parse(second));
+    }
+
+    public static final class RewriteResult {
+
+        private final String json;
+        private final int replacementCount;
+
+        public RewriteResult(String json, int replacementCount) {
+            this.json = json;
+            this.replacementCount = replacementCount;
+        }
+
+        public String getJson() {
+            return json;
+        }
+
+        public int getReplacementCount() {
+            return replacementCount;
+        }
+    }
+}

--- a/tools/dpdp-anonymization-tool/components/dpdp-anonymization-core/src/main/java/org/wso2/dpdp/anonymization/model/AnonymizationRequest.java
+++ b/tools/dpdp-anonymization-tool/components/dpdp-anonymization-core/src/main/java/org/wso2/dpdp/anonymization/model/AnonymizationRequest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.dpdp.anonymization.model;
+
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+public final class AnonymizationRequest {
+
+    private final String tenantDomain;
+    private final String sourceUserId;
+    private final String pseudonym;
+    private final Set<String> explicitUsernames;
+    private final ExecutionMode executionMode;
+
+    public AnonymizationRequest(String tenantDomain, String sourceUserId, String pseudonym,
+                                Set<String> explicitUsernames, ExecutionMode executionMode) {
+        this.tenantDomain = tenantDomain;
+        this.sourceUserId = sourceUserId;
+        this.pseudonym = pseudonym;
+        this.explicitUsernames = explicitUsernames == null
+                ? Collections.<String>emptySet()
+                : Collections.unmodifiableSet(new LinkedHashSet<>(explicitUsernames));
+        this.executionMode = executionMode;
+    }
+
+    public String getTenantDomain() {
+        return tenantDomain;
+    }
+
+    public String getSourceUserId() {
+        return sourceUserId;
+    }
+
+    public String getPseudonym() {
+        return pseudonym;
+    }
+
+    public Set<String> getExplicitUsernames() {
+        return explicitUsernames;
+    }
+
+    public ExecutionMode getExecutionMode() {
+        return executionMode;
+    }
+}

--- a/tools/dpdp-anonymization-tool/components/dpdp-anonymization-core/src/main/java/org/wso2/dpdp/anonymization/model/AnonymizationResult.java
+++ b/tools/dpdp-anonymization-tool/components/dpdp-anonymization-core/src/main/java/org/wso2/dpdp/anonymization/model/AnonymizationResult.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.dpdp.anonymization.model;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+public final class AnonymizationResult {
+
+    private AnonymizationStatus status;
+    private final Map<String, Long> counts = new LinkedHashMap<>();
+    private int discoveredAliasCount;
+
+    public AnonymizationStatus getStatus() {
+        return status;
+    }
+
+    public void setStatus(AnonymizationStatus status) {
+        this.status = status;
+    }
+
+    public void increment(String key) {
+        counts.put(key, getCount(key) + 1L);
+    }
+
+    public long getCount(String key) {
+        Long value = counts.get(key);
+        return value == null ? 0L : value;
+    }
+
+    public Map<String, Long> getCounts() {
+        return Collections.unmodifiableMap(counts);
+    }
+
+    public int getDiscoveredAliasCount() {
+        return discoveredAliasCount;
+    }
+
+    public void setDiscoveredAliasCount(int discoveredAliasCount) {
+        this.discoveredAliasCount = discoveredAliasCount;
+    }
+}

--- a/tools/dpdp-anonymization-tool/components/dpdp-anonymization-core/src/main/java/org/wso2/dpdp/anonymization/model/AnonymizationResult.java
+++ b/tools/dpdp-anonymization-tool/components/dpdp-anonymization-core/src/main/java/org/wso2/dpdp/anonymization/model/AnonymizationResult.java
@@ -20,12 +20,15 @@ package org.wso2.dpdp.anonymization.model;
 
 import java.util.Collections;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.Map;
+import java.util.Set;
 
 public final class AnonymizationResult {
 
     private AnonymizationStatus status;
     private final Map<String, Long> counts = new LinkedHashMap<>();
+    private final Set<String> trustedUsernames = new LinkedHashSet<>();
     private int discoveredAliasCount;
 
     public AnonymizationStatus getStatus() {
@@ -55,5 +58,16 @@ public final class AnonymizationResult {
 
     public void setDiscoveredAliasCount(int discoveredAliasCount) {
         this.discoveredAliasCount = discoveredAliasCount;
+    }
+
+    public Set<String> getTrustedUsernames() {
+        return Collections.unmodifiableSet(trustedUsernames);
+    }
+
+    public void setTrustedUsernames(Set<String> usernames) {
+        trustedUsernames.clear();
+        if (usernames != null) {
+            trustedUsernames.addAll(usernames);
+        }
     }
 }

--- a/tools/dpdp-anonymization-tool/components/dpdp-anonymization-core/src/main/java/org/wso2/dpdp/anonymization/model/AnonymizationStatus.java
+++ b/tools/dpdp-anonymization-tool/components/dpdp-anonymization-core/src/main/java/org/wso2/dpdp/anonymization/model/AnonymizationStatus.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.dpdp.anonymization.model;
+
+public enum AnonymizationStatus {
+    DRY_RUN,
+    COMMITTED,
+    TARGET_PRESENT_SOURCE_ABSENT,
+    NO_TENANT_DATA,
+    NO_MATCH,
+    ROLLED_BACK,
+    FAILED
+}

--- a/tools/dpdp-anonymization-tool/components/dpdp-anonymization-core/src/main/java/org/wso2/dpdp/anonymization/model/ExecutionMode.java
+++ b/tools/dpdp-anonymization-tool/components/dpdp-anonymization-core/src/main/java/org/wso2/dpdp/anonymization/model/ExecutionMode.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.dpdp.anonymization.model;
+
+public enum ExecutionMode {
+    DRY_RUN,
+    EXECUTE
+}

--- a/tools/dpdp-anonymization-tool/components/dpdp-anonymization-core/src/main/java/org/wso2/dpdp/anonymization/model/IdentityEvidence.java
+++ b/tools/dpdp-anonymization-tool/components/dpdp-anonymization-core/src/main/java/org/wso2/dpdp/anonymization/model/IdentityEvidence.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.dpdp.anonymization.model;
+
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+public final class IdentityEvidence {
+
+    private final String sourceUserId;
+    private final Set<String> trustedUsernames = new LinkedHashSet<>();
+
+    public IdentityEvidence(String sourceUserId, Set<String> explicitUsernames) {
+        this.sourceUserId = sourceUserId;
+        if (explicitUsernames != null) {
+            for (String username : explicitUsernames) {
+                addTrustedUsername(username);
+            }
+        }
+    }
+
+    public String getSourceUserId() {
+        return sourceUserId;
+    }
+
+    public void addTrustedUsername(String username) {
+        if (username != null && !username.trim().isEmpty()) {
+            trustedUsernames.add(username);
+        }
+    }
+
+    public Set<String> getTrustedUsernames() {
+        return Collections.unmodifiableSet(trustedUsernames);
+    }
+
+    public boolean matchesIdentifier(String value) {
+        return sourceUserId.equals(value) || trustedUsernames.contains(value);
+    }
+
+    public boolean matchesTrustedUsername(String value) {
+        return trustedUsernames.contains(value);
+    }
+}

--- a/tools/dpdp-anonymization-tool/components/dpdp-anonymization-core/src/main/java/org/wso2/dpdp/anonymization/processor/DpdpAnonymizationProcessor.java
+++ b/tools/dpdp-anonymization-tool/components/dpdp-anonymization-core/src/main/java/org/wso2/dpdp/anonymization/processor/DpdpAnonymizationProcessor.java
@@ -82,7 +82,8 @@ public final class DpdpAnonymizationProcessor {
                     Collections.singleton(request.getPseudonym()));
             long replacementMatches = countMatches(connection, dialect, request.getTenantDomain(), replacementEvidence);
 
-            result.setDiscoveredAliasCount(evidence.getTrustedUsernames().size());
+            result.setDiscoveredAliasCount(discoveredAliasCount(request, evidence));
+            result.setTrustedUsernames(evidence.getTrustedUsernames());
             if (sourceMatches == 0 && replacementMatches > 0) {
                 connection.rollback();
                 result.setStatus(AnonymizationStatus.TARGET_PRESENT_SOURCE_ABSENT);
@@ -125,6 +126,12 @@ public final class DpdpAnonymizationProcessor {
         } finally {
             close(connection);
         }
+    }
+
+    private int discoveredAliasCount(AnonymizationRequest request, IdentityEvidence evidence) {
+        int explicitCount = new IdentityEvidence(request.getSourceUserId(), request.getExplicitUsernames())
+                .getTrustedUsernames().size();
+        return Math.max(0, evidence.getTrustedUsernames().size() - explicitCount);
     }
 
     private boolean hasTenantData(Connection connection, String tenant) throws SQLException {

--- a/tools/dpdp-anonymization-tool/components/dpdp-anonymization-core/src/main/java/org/wso2/dpdp/anonymization/processor/DpdpAnonymizationProcessor.java
+++ b/tools/dpdp-anonymization-tool/components/dpdp-anonymization-core/src/main/java/org/wso2/dpdp/anonymization/processor/DpdpAnonymizationProcessor.java
@@ -1,0 +1,582 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.dpdp.anonymization.processor;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.wso2.dpdp.anonymization.config.EventPayloadRule;
+import org.wso2.dpdp.anonymization.config.ToolConfig;
+import org.wso2.dpdp.anonymization.database.ConnectionFactory;
+import org.wso2.dpdp.anonymization.database.DatabaseDialect;
+import org.wso2.dpdp.anonymization.json.JsonPathExpression;
+import org.wso2.dpdp.anonymization.json.JsonValueRewriter;
+import org.wso2.dpdp.anonymization.model.AnonymizationRequest;
+import org.wso2.dpdp.anonymization.model.AnonymizationResult;
+import org.wso2.dpdp.anonymization.model.AnonymizationStatus;
+import org.wso2.dpdp.anonymization.model.ExecutionMode;
+import org.wso2.dpdp.anonymization.model.IdentityEvidence;
+import org.wso2.dpdp.anonymization.validation.AnonymizationException;
+import org.wso2.dpdp.anonymization.validation.RequestValidator;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public final class DpdpAnonymizationProcessor {
+
+    private static final Logger LOG = LoggerFactory.getLogger(DpdpAnonymizationProcessor.class);
+
+    private final ConnectionFactory connectionFactory;
+    private final Map<String, List<JsonPathExpression>> eventPaths;
+    private final int fetchSize;
+    private final JsonValueRewriter jsonRewriter = new JsonValueRewriter();
+
+    public DpdpAnonymizationProcessor(ConnectionFactory connectionFactory, ToolConfig config)
+            throws AnonymizationException {
+        this.connectionFactory = connectionFactory;
+        this.eventPaths = indexEventPaths(config.getEventPayloadRules());
+        this.fetchSize = config.getBatchSize();
+    }
+
+    public AnonymizationResult process(AnonymizationRequest request) throws AnonymizationException {
+        RequestValidator.validate(request);
+        Connection connection = null;
+        try {
+            connection = connectionFactory.getConnection();
+            connection.setAutoCommit(false);
+            connection.setTransactionIsolation(Connection.TRANSACTION_REPEATABLE_READ);
+            DatabaseDialect dialect = DatabaseDialect.detect(connection);
+            AnonymizationResult result = new AnonymizationResult();
+            if (!hasTenantData(connection, request.getTenantDomain())) {
+                connection.rollback();
+                result.setStatus(AnonymizationStatus.NO_TENANT_DATA);
+                return result;
+            }
+            IdentityEvidence evidence = discoverIdentityEvidence(connection, dialect, request);
+            validateNoAmbiguousAliases(connection, dialect, request.getTenantDomain(), evidence);
+
+            long sourceMatches = countMatches(connection, dialect, request.getTenantDomain(), evidence);
+            IdentityEvidence replacementEvidence = new IdentityEvidence(request.getPseudonym(),
+                    Collections.singleton(request.getPseudonym()));
+            long replacementMatches = countMatches(connection, dialect, request.getTenantDomain(), replacementEvidence);
+
+            result.setDiscoveredAliasCount(evidence.getTrustedUsernames().size());
+            if (sourceMatches == 0 && replacementMatches > 0) {
+                connection.rollback();
+                result.setStatus(AnonymizationStatus.TARGET_PRESENT_SOURCE_ABSENT);
+                return result;
+            }
+            if (sourceMatches == 0) {
+                connection.rollback();
+                result.setStatus(AnonymizationStatus.NO_MATCH);
+                return result;
+            }
+            if (replacementMatches > 0) {
+                throw new AnonymizationException("The replacement UUID is already present in covered fields for this tenant.");
+            }
+
+            updateComplaints(connection, dialect, request, evidence, result);
+            updateComplaintEvents(connection, dialect, request, evidence, result);
+            updateConsentAudit(connection, dialect, request, evidence, result);
+            updateConsentHistory(connection, dialect, request, evidence, result);
+            updateEvents(connection, dialect, request, evidence, result);
+
+            long remaining = countMatches(connection, dialect, request.getTenantDomain(), evidence);
+            if (remaining != 0) {
+                throw new AnonymizationException("Post-update verification found " + remaining
+                        + " remaining values in covered fields.");
+            }
+            if (request.getExecutionMode() == ExecutionMode.EXECUTE) {
+                connection.commit();
+                result.setStatus(AnonymizationStatus.COMMITTED);
+            } else {
+                connection.rollback();
+                result.setStatus(AnonymizationStatus.DRY_RUN);
+            }
+            return result;
+        } catch (SQLException e) {
+            rollback(connection);
+            throw new AnonymizationException("DPDP anonymization failed and was rolled back.", e);
+        } catch (AnonymizationException e) {
+            rollback(connection);
+            throw e;
+        } finally {
+            close(connection);
+        }
+    }
+
+    private boolean hasTenantData(Connection connection, String tenant) throws SQLException {
+        String[] tables = {"COMPLAINT", "COMPLAINT_EVENT", "DPDP_CONSENT_STATUS_AUDIT",
+                "DPDP_CONSENT_HISTORY", "EVENT"};
+        for (String table : tables) {
+            try (PreparedStatement statement = prepareQuery(connection,
+                    "SELECT 1 FROM " + table + " WHERE ORG_ID = ? LIMIT 1")) {
+                statement.setString(1, tenant);
+                try (ResultSet results = statement.executeQuery()) {
+                    if (results.next()) {
+                        return true;
+                    }
+                }
+            }
+        }
+        return false;
+    }
+
+    private IdentityEvidence discoverIdentityEvidence(Connection connection, DatabaseDialect dialect,
+                                                       AnonymizationRequest request) throws SQLException {
+        IdentityEvidence evidence = new IdentityEvidence(request.getSourceUserId(), request.getExplicitUsernames());
+        discoverAliases(connection,
+                "SELECT USER_NAME FROM COMPLAINT WHERE ORG_ID = ? AND USER_ID = ?" + dialect.forUpdate(),
+                request, evidence);
+        discoverAliases(connection,
+                "SELECT ACTOR_USER_NAME FROM COMPLAINT_EVENT WHERE ORG_ID = ? AND ACTOR_USER_ID = ?"
+                        + dialect.forUpdate(), request, evidence);
+        return evidence;
+    }
+
+    private void discoverAliases(Connection connection, String sql, AnonymizationRequest request,
+                                 IdentityEvidence evidence) throws SQLException {
+        try (PreparedStatement statement = prepareQuery(connection, sql)) {
+            statement.setString(1, request.getTenantDomain());
+            statement.setString(2, request.getSourceUserId());
+            try (ResultSet results = statement.executeQuery()) {
+                while (results.next()) {
+                    evidence.addTrustedUsername(results.getString(1));
+                }
+            }
+        }
+    }
+
+    private void validateNoAmbiguousAliases(Connection connection, DatabaseDialect dialect, String tenant,
+                                            IdentityEvidence evidence) throws SQLException, AnonymizationException {
+        if (evidence.getTrustedUsernames().isEmpty()) {
+            return;
+        }
+        String complaintSql = "SELECT USER_ID, USER_NAME FROM COMPLAINT WHERE ORG_ID = ?" + dialect.forUpdate();
+        try (PreparedStatement statement = prepareQuery(connection, complaintSql)) {
+            statement.setString(1, tenant);
+            try (ResultSet results = statement.executeQuery()) {
+                while (results.next()) {
+                    String id = results.getString("USER_ID");
+                    String username = results.getString("USER_NAME");
+                    if (evidence.matchesTrustedUsername(username) && !evidence.matchesIdentifier(id)) {
+                        throw new AnonymizationException("A trusted username is associated with a different complaint user ID.");
+                    }
+                }
+            }
+        }
+        String eventSql = "SELECT ACTOR_USER_ID, ACTOR_USER_NAME FROM COMPLAINT_EVENT WHERE ORG_ID = ?"
+                + dialect.forUpdate();
+        try (PreparedStatement statement = prepareQuery(connection, eventSql)) {
+            statement.setString(1, tenant);
+            try (ResultSet results = statement.executeQuery()) {
+                while (results.next()) {
+                    String id = results.getString("ACTOR_USER_ID");
+                    String username = results.getString("ACTOR_USER_NAME");
+                    if (id != null && evidence.matchesTrustedUsername(username) && !evidence.matchesIdentifier(id)) {
+                        throw new AnonymizationException(
+                                "A trusted username is associated with a different complaint-event actor ID.");
+                    }
+                }
+            }
+        }
+    }
+
+    private long countMatches(Connection connection, DatabaseDialect dialect, String tenant,
+                              IdentityEvidence evidence) throws SQLException, AnonymizationException {
+        long count = 0;
+        count += countComplaintMatches(connection, dialect, tenant, evidence);
+        count += countComplaintEventMatches(connection, dialect, tenant, evidence);
+        count += countColumnMatches(connection, dialect, "DPDP_CONSENT_STATUS_AUDIT", "ACTION_BY", tenant, evidence);
+        count += countConsentHistoryMatches(connection, dialect, tenant, evidence);
+        count += countEventMatches(connection, dialect, tenant, evidence);
+        return count;
+    }
+
+    private long countComplaintMatches(Connection connection, DatabaseDialect dialect, String tenant,
+                                       IdentityEvidence evidence) throws SQLException {
+        long count = 0;
+        String sql = "SELECT USER_ID, USER_NAME FROM COMPLAINT WHERE ORG_ID = ?" + dialect.forUpdate();
+        try (PreparedStatement statement = prepareQuery(connection, sql)) {
+            statement.setString(1, tenant);
+            try (ResultSet results = statement.executeQuery()) {
+                while (results.next()) {
+                    if (evidence.matchesIdentifier(results.getString("USER_ID"))) {
+                        count++;
+                    } else if (evidence.matchesTrustedUsername(results.getString("USER_NAME"))) {
+                        // A username alone is collision evidence but never authorizes replacing a different ID.
+                        count++;
+                    }
+                }
+            }
+        }
+        return count;
+    }
+
+    private long countComplaintEventMatches(Connection connection, DatabaseDialect dialect, String tenant,
+                                            IdentityEvidence evidence) throws SQLException {
+        long count = 0;
+        String sql = "SELECT ACTOR_USER_ID, ACTOR_USER_NAME FROM COMPLAINT_EVENT WHERE ORG_ID = ?"
+                + dialect.forUpdate();
+        try (PreparedStatement statement = prepareQuery(connection, sql)) {
+            statement.setString(1, tenant);
+            try (ResultSet results = statement.executeQuery()) {
+                while (results.next()) {
+                    if (evidence.matchesIdentifier(results.getString("ACTOR_USER_ID"))) {
+                        count++;
+                    } else if (evidence.matchesTrustedUsername(results.getString("ACTOR_USER_NAME"))) {
+                        count++;
+                    }
+                }
+            }
+        }
+        return count;
+    }
+
+    private long countColumnMatches(Connection connection, DatabaseDialect dialect, String table, String column,
+                                    String tenant, IdentityEvidence evidence) throws SQLException {
+        long count = 0;
+        String sql = "SELECT " + column + " FROM " + table + " WHERE ORG_ID = ?" + dialect.forUpdate();
+        try (PreparedStatement statement = prepareQuery(connection, sql)) {
+            statement.setString(1, tenant);
+            try (ResultSet results = statement.executeQuery()) {
+                while (results.next()) {
+                    if (evidence.matchesIdentifier(results.getString(1))) {
+                        count++;
+                    }
+                }
+            }
+        }
+        return count;
+    }
+
+    private long countConsentHistoryMatches(Connection connection, DatabaseDialect dialect, String tenant,
+                                            IdentityEvidence evidence) throws SQLException, AnonymizationException {
+        long count = 0;
+        String sql = "SELECT SNAPSHOT, ACTION_BY FROM DPDP_CONSENT_HISTORY WHERE ORG_ID = ?" + dialect.forUpdate();
+        try (PreparedStatement statement = prepareQuery(connection, sql)) {
+            statement.setString(1, tenant);
+            try (ResultSet results = statement.executeQuery()) {
+                while (results.next()) {
+                    String actionBy = results.getString("ACTION_BY");
+                    if (evidence.matchesIdentifier(actionBy)) {
+                        count++;
+                    }
+                    String snapshot = results.getString("SNAPSHOT");
+                    if (snapshot != null) {
+                        count += jsonRewriter.rewriteConsentSnapshot(snapshot, evidence, evidence.getSourceUserId())
+                                .getReplacementCount();
+                    }
+                }
+            }
+        }
+        return count;
+    }
+
+    private long countEventMatches(Connection connection, DatabaseDialect dialect, String tenant,
+                                   IdentityEvidence evidence) throws SQLException, AnonymizationException {
+        long count = 0;
+        String sql = "SELECT E.PAYLOAD, T.NAME FROM EVENT E JOIN TOPIC T ON T.TOPIC_ID = E.TOPIC_ID "
+                + "AND T.ORG_ID = E.ORG_ID WHERE E.ORG_ID = ?" + dialect.forUpdate();
+        try (PreparedStatement statement = prepareQuery(connection, sql)) {
+            statement.setString(1, tenant);
+            try (ResultSet results = statement.executeQuery()) {
+                while (results.next()) {
+                    List<JsonPathExpression> paths = eventPaths.get(results.getString("NAME"));
+                    if (paths != null) {
+                        count += jsonRewriter.rewriteEventPayload(results.getString("PAYLOAD"), evidence,
+                                evidence.getSourceUserId(), paths).getReplacementCount();
+                    }
+                }
+            }
+        }
+        return count;
+    }
+
+    private void updateComplaints(Connection connection, DatabaseDialect dialect, AnonymizationRequest request,
+                                  IdentityEvidence evidence, AnonymizationResult result) throws SQLException {
+        String select = "SELECT COMPLAINT_ID, USER_ID, USER_NAME FROM COMPLAINT WHERE ORG_ID = ?"
+                + dialect.forUpdate();
+        List<String> ids = new ArrayList<>();
+        try (PreparedStatement statement = prepareQuery(connection, select)) {
+            statement.setString(1, request.getTenantDomain());
+            try (ResultSet results = statement.executeQuery()) {
+                while (results.next()) {
+                    if (evidence.matchesIdentifier(results.getString("USER_ID"))) {
+                        ids.add(results.getString("COMPLAINT_ID"));
+                    }
+                }
+            }
+        }
+        String update = "UPDATE COMPLAINT SET USER_ID = ?, USER_NAME = ? WHERE COMPLAINT_ID = ? AND ORG_ID = ?";
+        for (String id : ids) {
+            executeUpdate(connection, update, request.getPseudonym(), request.getPseudonym(), id,
+                    request.getTenantDomain());
+            result.increment("complaint.rows");
+        }
+    }
+
+    private void updateComplaintEvents(Connection connection, DatabaseDialect dialect, AnonymizationRequest request,
+                                       IdentityEvidence evidence, AnonymizationResult result) throws SQLException {
+        String select = "SELECT COMPLAINT_EVENT_ID, ACTOR_USER_ID, ACTOR_USER_NAME FROM COMPLAINT_EVENT WHERE ORG_ID = ?"
+                + dialect.forUpdate();
+        List<ComplaintEventChange> changes = new ArrayList<>();
+        try (PreparedStatement statement = prepareQuery(connection, select)) {
+            statement.setString(1, request.getTenantDomain());
+            try (ResultSet results = statement.executeQuery()) {
+                while (results.next()) {
+                    String actorId = results.getString("ACTOR_USER_ID");
+                    String actorName = results.getString("ACTOR_USER_NAME");
+                    if (evidence.matchesIdentifier(actorId)) {
+                        changes.add(new ComplaintEventChange(results.getString("COMPLAINT_EVENT_ID"), true));
+                    } else if (actorId == null && evidence.matchesTrustedUsername(actorName)) {
+                        changes.add(new ComplaintEventChange(results.getString("COMPLAINT_EVENT_ID"), false));
+                    }
+                }
+            }
+        }
+        for (ComplaintEventChange change : changes) {
+            String update = change.replaceId
+                    ? "UPDATE COMPLAINT_EVENT SET ACTOR_USER_ID = ?, ACTOR_USER_NAME = ? "
+                        + "WHERE COMPLAINT_EVENT_ID = ? AND ORG_ID = ?"
+                    : "UPDATE COMPLAINT_EVENT SET ACTOR_USER_NAME = ? WHERE COMPLAINT_EVENT_ID = ? AND ORG_ID = ?";
+            if (change.replaceId) {
+                executeUpdate(connection, update, request.getPseudonym(), request.getPseudonym(), change.id,
+                        request.getTenantDomain());
+            } else {
+                executeUpdate(connection, update, request.getPseudonym(), change.id, request.getTenantDomain());
+            }
+            result.increment("complaintEvent.rows");
+        }
+    }
+
+    private void updateConsentAudit(Connection connection, DatabaseDialect dialect, AnonymizationRequest request,
+                                    IdentityEvidence evidence, AnonymizationResult result) throws SQLException {
+        String select = "SELECT AUDIT_ID, ACTION_BY FROM DPDP_CONSENT_STATUS_AUDIT WHERE ORG_ID = ?"
+                + dialect.forUpdate();
+        List<String> ids = new ArrayList<>();
+        try (PreparedStatement statement = prepareQuery(connection, select)) {
+            statement.setString(1, request.getTenantDomain());
+            try (ResultSet results = statement.executeQuery()) {
+                while (results.next()) {
+                    if (evidence.matchesIdentifier(results.getString("ACTION_BY"))) {
+                        ids.add(results.getString("AUDIT_ID"));
+                    }
+                }
+            }
+        }
+        String update = "UPDATE DPDP_CONSENT_STATUS_AUDIT SET ACTION_BY = ? WHERE AUDIT_ID = ? AND ORG_ID = ?";
+        for (String id : ids) {
+            executeUpdate(connection, update, request.getPseudonym(), id, request.getTenantDomain());
+            result.increment("consentAudit.rows");
+        }
+    }
+
+    private void updateConsentHistory(Connection connection, DatabaseDialect dialect, AnonymizationRequest request,
+                                      IdentityEvidence evidence, AnonymizationResult result)
+            throws SQLException, AnonymizationException {
+        String select = "SELECT HISTORY_ID, SNAPSHOT, ACTION_BY FROM DPDP_CONSENT_HISTORY WHERE ORG_ID = ?"
+                + dialect.forUpdate();
+        List<HistoryChange> changes = new ArrayList<>();
+        try (PreparedStatement statement = prepareQuery(connection, select)) {
+            statement.setString(1, request.getTenantDomain());
+            try (ResultSet results = statement.executeQuery()) {
+                while (results.next()) {
+                    String snapshot = results.getString("SNAPSHOT");
+                    JsonValueRewriter.RewriteResult rewritten = snapshot == null
+                            ? new JsonValueRewriter.RewriteResult(null, 0)
+                            : jsonRewriter.rewriteConsentSnapshot(snapshot, evidence, request.getPseudonym());
+                    boolean actionChanged = evidence.matchesIdentifier(results.getString("ACTION_BY"));
+                    if (rewritten.getReplacementCount() > 0 || actionChanged) {
+                        changes.add(new HistoryChange(results.getString("HISTORY_ID"), rewritten.getJson(), actionChanged,
+                                rewritten.getReplacementCount()));
+                    }
+                }
+            }
+        }
+        String update = "UPDATE DPDP_CONSENT_HISTORY SET SNAPSHOT = ?, ACTION_BY = ? WHERE HISTORY_ID = ? AND ORG_ID = ?";
+        for (HistoryChange change : changes) {
+            try (PreparedStatement statement = connection.prepareStatement(update)) {
+                statement.setString(1, change.snapshot);
+                if (change.actionChanged) {
+                    statement.setString(2, request.getPseudonym());
+                } else {
+                    String actionBy = loadHistoryActionBy(connection, change.id, request.getTenantDomain());
+                    statement.setString(2, actionBy);
+                }
+                statement.setString(3, change.id);
+                statement.setString(4, request.getTenantDomain());
+                requireSingleUpdate(statement);
+            }
+            result.increment("consentHistory.rows");
+            for (int i = 0; i < change.jsonReplacementCount; i++) {
+                result.increment("consentHistory.jsonValues");
+            }
+        }
+    }
+
+    private String loadHistoryActionBy(Connection connection, String id, String tenant) throws SQLException {
+        try (PreparedStatement statement = prepareQuery(connection,
+                "SELECT ACTION_BY FROM DPDP_CONSENT_HISTORY WHERE HISTORY_ID = ? AND ORG_ID = ?")) {
+            statement.setString(1, id);
+            statement.setString(2, tenant);
+            try (ResultSet result = statement.executeQuery()) {
+                if (!result.next()) {
+                    throw new SQLException("Consent history row disappeared during anonymization.");
+                }
+                return result.getString(1);
+            }
+        }
+    }
+
+    private void updateEvents(Connection connection, DatabaseDialect dialect, AnonymizationRequest request,
+                              IdentityEvidence evidence, AnonymizationResult result)
+            throws SQLException, AnonymizationException {
+        String select = "SELECT E.EVENT_ID, E.PAYLOAD, T.NAME FROM EVENT E JOIN TOPIC T ON T.TOPIC_ID = E.TOPIC_ID "
+                + "AND T.ORG_ID = E.ORG_ID WHERE E.ORG_ID = ?" + dialect.forUpdate();
+        List<EventChange> changes = new ArrayList<>();
+        try (PreparedStatement statement = prepareQuery(connection, select)) {
+            statement.setString(1, request.getTenantDomain());
+            try (ResultSet results = statement.executeQuery()) {
+                while (results.next()) {
+                    String topic = results.getString("NAME");
+                    List<JsonPathExpression> paths = eventPaths.get(topic);
+                    if (paths == null) {
+                        result.increment("event.unconfiguredTopics");
+                        continue;
+                    }
+                    JsonValueRewriter.RewriteResult rewritten = jsonRewriter.rewriteEventPayload(
+                            results.getString("PAYLOAD"), evidence, request.getPseudonym(), paths);
+                    if (rewritten.getReplacementCount() > 0) {
+                        changes.add(new EventChange(results.getString("EVENT_ID"), rewritten.getJson(),
+                                rewritten.getReplacementCount()));
+                    }
+                }
+            }
+        }
+        String update = "UPDATE EVENT SET PAYLOAD = ? WHERE EVENT_ID = ? AND ORG_ID = ?";
+        for (EventChange change : changes) {
+            executeUpdate(connection, update, change.payload, change.id, request.getTenantDomain());
+            result.increment("event.rows");
+            for (int i = 0; i < change.jsonReplacementCount; i++) {
+                result.increment("event.jsonValues");
+            }
+        }
+    }
+
+    private static void executeUpdate(Connection connection, String sql, String... values) throws SQLException {
+        try (PreparedStatement statement = connection.prepareStatement(sql)) {
+            for (int i = 0; i < values.length; i++) {
+                statement.setString(i + 1, values[i]);
+            }
+            requireSingleUpdate(statement);
+        }
+    }
+
+    private PreparedStatement prepareQuery(Connection connection, String sql) throws SQLException {
+        PreparedStatement statement = connection.prepareStatement(sql);
+        statement.setFetchSize(fetchSize);
+        return statement;
+    }
+
+    private static void requireSingleUpdate(PreparedStatement statement) throws SQLException {
+        int updated = statement.executeUpdate();
+        if (updated != 1) {
+            throw new SQLException("Expected to update exactly one locked row but updated " + updated + '.');
+        }
+    }
+
+    private static Map<String, List<JsonPathExpression>> indexEventPaths(List<EventPayloadRule> rules)
+            throws AnonymizationException {
+        Map<String, List<JsonPathExpression>> indexed = new HashMap<>();
+        for (EventPayloadRule rule : rules) {
+            List<JsonPathExpression> paths = indexed.get(rule.getTopic());
+            if (paths == null) {
+                paths = new ArrayList<>();
+                indexed.put(rule.getTopic(), paths);
+            }
+            for (String path : rule.getPaths()) {
+                paths.add(JsonPathExpression.parse(path));
+            }
+        }
+        return indexed;
+    }
+
+    private static void rollback(Connection connection) {
+        if (connection != null) {
+            try {
+                connection.rollback();
+            } catch (SQLException e) {
+                LOG.error("Could not roll back the DPDP anonymization transaction.", e);
+            }
+        }
+    }
+
+    private static void close(Connection connection) {
+        if (connection != null) {
+            try {
+                connection.close();
+            } catch (SQLException e) {
+                LOG.warn("Could not close the DPDP database connection.", e);
+            }
+        }
+    }
+
+    private static final class HistoryChange {
+        private final String id;
+        private final String snapshot;
+        private final boolean actionChanged;
+        private final int jsonReplacementCount;
+
+        private HistoryChange(String id, String snapshot, boolean actionChanged, int jsonReplacementCount) {
+            this.id = id;
+            this.snapshot = snapshot;
+            this.actionChanged = actionChanged;
+            this.jsonReplacementCount = jsonReplacementCount;
+        }
+    }
+
+    private static final class EventChange {
+        private final String id;
+        private final String payload;
+        private final int jsonReplacementCount;
+
+        private EventChange(String id, String payload, int jsonReplacementCount) {
+            this.id = id;
+            this.payload = payload;
+            this.jsonReplacementCount = jsonReplacementCount;
+        }
+    }
+
+    private static final class ComplaintEventChange {
+        private final String id;
+        private final boolean replaceId;
+
+        private ComplaintEventChange(String id, boolean replaceId) {
+            this.id = id;
+            this.replaceId = replaceId;
+        }
+    }
+}

--- a/tools/dpdp-anonymization-tool/components/dpdp-anonymization-core/src/main/java/org/wso2/dpdp/anonymization/report/ReportWriter.java
+++ b/tools/dpdp-anonymization-tool/components/dpdp-anonymization-core/src/main/java/org/wso2/dpdp/anonymization/report/ReportWriter.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.dpdp.anonymization.report;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import org.wso2.dpdp.anonymization.model.AnonymizationRequest;
+import org.wso2.dpdp.anonymization.model.AnonymizationResult;
+
+import java.io.File;
+import java.io.IOException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.TimeZone;
+import java.util.UUID;
+
+public final class ReportWriter {
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper().enable(SerializationFeature.INDENT_OUTPUT);
+
+    public File write(File directory, AnonymizationRequest request, AnonymizationResult result) throws IOException {
+        return write(directory, request, result, null);
+    }
+
+    public File writeFailure(File directory, AnonymizationRequest request, AnonymizationResult result,
+                             String failureMessage) throws IOException {
+        return write(directory, request, result, failureMessage);
+    }
+
+    private File write(File directory, AnonymizationRequest request, AnonymizationResult result,
+                       String failureMessage) throws IOException {
+        if (!directory.exists() && !directory.mkdirs()) {
+            throw new IOException("Could not create report directory: " + directory.getAbsolutePath());
+        }
+        String timestamp = timestamp();
+        File report = new File(directory, "dpdp-anonymization-" + timestamp + ".json");
+        Map<String, Object> values = new LinkedHashMap<>();
+        values.put("runId", UUID.randomUUID().toString());
+        values.put("timestamp", timestamp);
+        values.put("tenant", request.getTenantDomain());
+        values.put("sourceUserId", mask(request.getSourceUserId()));
+        values.put("replacementUuid", mask(request.getPseudonym()));
+        values.put("mode", request.getExecutionMode().name());
+        values.put("status", result.getStatus().name());
+        values.put("discoveredAliasCount", result.getDiscoveredAliasCount());
+        values.put("counts", result.getCounts());
+        if (failureMessage != null) {
+            values.put("failure", failureMessage);
+            values.put("databaseChangesCommitted", false);
+        }
+        OBJECT_MAPPER.writeValue(report, values);
+        return report;
+    }
+
+    private static String timestamp() {
+        SimpleDateFormat format = new SimpleDateFormat("yyyyMMdd-HHmmss-SSS");
+        format.setTimeZone(TimeZone.getTimeZone("UTC"));
+        return format.format(new Date());
+    }
+
+    static String mask(String value) {
+        if (value == null || value.length() < 8) {
+            return "****";
+        }
+        return "****" + value.substring(value.length() - 4);
+    }
+}

--- a/tools/dpdp-anonymization-tool/components/dpdp-anonymization-core/src/main/java/org/wso2/dpdp/anonymization/validation/AnonymizationException.java
+++ b/tools/dpdp-anonymization-tool/components/dpdp-anonymization-core/src/main/java/org/wso2/dpdp/anonymization/validation/AnonymizationException.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.dpdp.anonymization.validation;
+
+public class AnonymizationException extends Exception {
+
+    public AnonymizationException(String message) {
+        super(message);
+    }
+
+    public AnonymizationException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/tools/dpdp-anonymization-tool/components/dpdp-anonymization-core/src/main/java/org/wso2/dpdp/anonymization/validation/RequestValidator.java
+++ b/tools/dpdp-anonymization-tool/components/dpdp-anonymization-core/src/main/java/org/wso2/dpdp/anonymization/validation/RequestValidator.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.dpdp.anonymization.validation;
+
+import org.wso2.dpdp.anonymization.model.AnonymizationRequest;
+
+import java.util.UUID;
+
+public final class RequestValidator {
+
+    private RequestValidator() {
+    }
+
+    public static void validate(AnonymizationRequest request) throws AnonymizationException {
+        if (request == null) {
+            throw new AnonymizationException("Anonymization request is required.");
+        }
+        if (isBlank(request.getTenantDomain())) {
+            throw new AnonymizationException("Tenant domain is required.");
+        }
+        String source = canonicalUuid(request.getSourceUserId(), "Source user ID");
+        String target = canonicalUuid(request.getPseudonym(), "Pseudonym");
+        if (source.equals(target)) {
+            throw new AnonymizationException("Source user ID and pseudonym must be different.");
+        }
+        if (request.getExecutionMode() == null) {
+            throw new AnonymizationException("Execution mode is required.");
+        }
+    }
+
+    public static String canonicalUuid(String value, String label) throws AnonymizationException {
+        if (isBlank(value)) {
+            throw new AnonymizationException(label + " is required.");
+        }
+        try {
+            String canonical = UUID.fromString(value.trim()).toString();
+            if (!canonical.equalsIgnoreCase(value.trim())) {
+                throw new IllegalArgumentException("non-canonical UUID");
+            }
+            return canonical;
+        } catch (IllegalArgumentException e) {
+            throw new AnonymizationException(label + " must be a canonical UUID.");
+        }
+    }
+
+    private static boolean isBlank(String value) {
+        return value == null || value.trim().isEmpty();
+    }
+}

--- a/tools/dpdp-anonymization-tool/components/dpdp-anonymization-core/src/test/java/org/wso2/dpdp/anonymization/json/JsonValueRewriterTest.java
+++ b/tools/dpdp-anonymization-tool/components/dpdp-anonymization-core/src/test/java/org/wso2/dpdp/anonymization/json/JsonValueRewriterTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.dpdp.anonymization.json;
+
+import org.junit.jupiter.api.Test;
+import org.wso2.dpdp.anonymization.model.IdentityEvidence;
+import org.wso2.dpdp.anonymization.validation.AnonymizationException;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class JsonValueRewriterTest {
+
+    private static final String SOURCE = "18b7c17d-ef74-48c5-a0c8-a1df9b21ff87";
+    private static final String TARGET = "216d6aac-7e84-4484-a71e-c52f89b3cb1d";
+
+    @Test
+    void rewritesOnlyConfiguredExactScalars() throws Exception {
+        String json = "{\"userId\":\"" + SOURCE + "\",\"description\":\"prefix " + SOURCE
+                + " suffix\",\"nested\":[{\"userId\":\"" + SOURCE + "\"}]}";
+        JsonValueRewriter.RewriteResult result = new JsonValueRewriter().rewriteEventPayload(json,
+                new IdentityEvidence(SOURCE, Collections.<String>emptySet()), TARGET,
+                Arrays.asList(JsonPathExpression.parse("/userId"),
+                        JsonPathExpression.parse("/nested/*/userId")));
+
+        assertEquals(2, result.getReplacementCount());
+        assertTrue(result.getJson().contains("prefix " + SOURCE + " suffix"));
+    }
+
+    @Test
+    void rejectsNonStringConfiguredValue() throws Exception {
+        assertThrows(AnonymizationException.class, () -> new JsonValueRewriter().rewriteEventPayload(
+                "{\"userId\":42}", new IdentityEvidence(SOURCE, Collections.<String>emptySet()), TARGET,
+                Collections.singletonList(JsonPathExpression.parse("/userId"))));
+    }
+
+    @Test
+    void rejectsInvalidPointerEscape() {
+        assertThrows(AnonymizationException.class, () -> JsonPathExpression.parse("/user~2id"));
+    }
+}

--- a/tools/dpdp-anonymization-tool/components/dpdp-anonymization-core/src/test/java/org/wso2/dpdp/anonymization/validation/RequestValidatorTest.java
+++ b/tools/dpdp-anonymization-tool/components/dpdp-anonymization-core/src/test/java/org/wso2/dpdp/anonymization/validation/RequestValidatorTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.dpdp.anonymization.validation;
+
+import org.junit.jupiter.api.Test;
+import org.wso2.dpdp.anonymization.model.AnonymizationRequest;
+import org.wso2.dpdp.anonymization.model.ExecutionMode;
+
+import java.util.Collections;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class RequestValidatorTest {
+
+    @Test
+    void acceptsCanonicalDifferentUuids() {
+        AnonymizationRequest request = new AnonymizationRequest("example.com",
+                "18b7c17d-ef74-48c5-a0c8-a1df9b21ff87",
+                "216d6aac-7e84-4484-a71e-c52f89b3cb1d",
+                Collections.<String>emptySet(), ExecutionMode.DRY_RUN);
+        assertDoesNotThrow(() -> RequestValidator.validate(request));
+    }
+
+    @Test
+    void rejectsNonCanonicalSourceUuid() {
+        AnonymizationRequest request = new AnonymizationRequest("example.com", "1234",
+                "216d6aac-7e84-4484-a71e-c52f89b3cb1d",
+                Collections.<String>emptySet(), ExecutionMode.DRY_RUN);
+        assertThrows(AnonymizationException.class, () -> RequestValidator.validate(request));
+    }
+
+    @Test
+    void rejectsSameUuid() {
+        String uuid = "18b7c17d-ef74-48c5-a0c8-a1df9b21ff87";
+        AnonymizationRequest request = new AnonymizationRequest("example.com", uuid, uuid,
+                Collections.<String>emptySet(), ExecutionMode.DRY_RUN);
+        assertThrows(AnonymizationException.class, () -> RequestValidator.validate(request));
+    }
+}

--- a/tools/dpdp-anonymization-tool/components/dpdp-anonymization-distribution/pom.xml
+++ b/tools/dpdp-anonymization-tool/components/dpdp-anonymization-distribution/pom.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?><!--
+ ~ Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ ~
+ ~ WSO2 LLC. licenses this file to you under the Apache License,
+ ~ Version 2.0 (the "License"); you may not use this file except
+ ~ in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~     http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing,
+ ~ software distributed under the License is distributed on an
+ ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ ~ KIND, either express or implied. See the License for the
+ ~ specific language governing permissions and limitations
+ ~ under the License.
+ -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.wso2.dpdp</groupId>
+        <artifactId>dpdp-anonymization-tool-parent</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+    <artifactId>dpdp-anonymization-distribution</artifactId>
+    <packaging>pom</packaging>
+    <dependencies>
+        <dependency>
+            <groupId>org.wso2.dpdp</groupId>
+            <artifactId>dpdp-anonymization-cli</artifactId>
+            <version>${project.version}</version>
+            <classifier>all</classifier>
+        </dependency>
+    </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <version>3.7.1</version>
+                <configuration>
+                    <descriptors>
+                        <descriptor>src/main/assembly/bin.xml</descriptor>
+                    </descriptors>
+                    <finalName>dpdp-anonymization-tool-${project.version}</finalName>
+                    <appendAssemblyId>false</appendAssemblyId>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>distribution</id>
+                        <phase>package</phase>
+                        <goals><goal>single</goal></goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/tools/dpdp-anonymization-tool/components/dpdp-anonymization-distribution/src/main/assembly/bin.xml
+++ b/tools/dpdp-anonymization-tool/components/dpdp-anonymization-distribution/src/main/assembly/bin.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?><!--
+ ~ Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ ~
+ ~ WSO2 LLC. licenses this file to you under the Apache License,
+ ~ Version 2.0 (the "License"); you may not use this file except
+ ~ in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~     http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing,
+ ~ software distributed under the License is distributed on an
+ ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ ~ KIND, either express or implied. See the License for the
+ ~ specific language governing permissions and limitations
+ ~ under the License.
+ -->
+<assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 https://maven.apache.org/xsd/assembly-1.1.3.xsd">
+    <id>bin</id>
+    <formats>
+        <format>zip</format>
+    </formats>
+    <includeBaseDirectory>true</includeBaseDirectory>
+    <baseDirectory>dpdp-anonymization-tool</baseDirectory>
+    <fileSets>
+        <fileSet>
+            <directory>src/main/resources/bin</directory>
+            <outputDirectory>bin</outputDirectory>
+            <fileMode>0755</fileMode>
+        </fileSet>
+        <fileSet>
+            <directory>src/main/resources/conf</directory>
+            <outputDirectory>conf</outputDirectory>
+            <fileMode>0644</fileMode>
+        </fileSet>
+        <fileSet>
+            <directory>${project.parent.basedir}</directory>
+            <outputDirectory>/</outputDirectory>
+            <includes>
+                <include>README.md</include>
+                <include>LICENSE</include>
+                <include>docs/**</include>
+            </includes>
+        </fileSet>
+    </fileSets>
+    <dependencySets>
+        <dependencySet>
+            <outputDirectory>lib</outputDirectory>
+            <useProjectArtifact>false</useProjectArtifact>
+            <unpack>false</unpack>
+            <includes>
+                <include>org.wso2.dpdp:dpdp-anonymization-cli:jar:all</include>
+            </includes>
+            <outputFileNameMapping>dpdp-anonymization-tool.jar</outputFileNameMapping>
+        </dependencySet>
+    </dependencySets>
+</assembly>

--- a/tools/dpdp-anonymization-tool/components/dpdp-anonymization-distribution/src/main/resources/bin/dpdp-anonymize
+++ b/tools/dpdp-anonymization-tool/components/dpdp-anonymization-distribution/src/main/resources/bin/dpdp-anonymize
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+TOOL_HOME=$(CDPATH= cd -- "$SCRIPT_DIR/.." && pwd)
+
+exec java -jar "$TOOL_HOME/lib/dpdp-anonymization-tool.jar" \
+  --config "$TOOL_HOME/conf/config.json" "$@"

--- a/tools/dpdp-anonymization-tool/components/dpdp-anonymization-distribution/src/main/resources/bin/dpdp-anonymize.bat
+++ b/tools/dpdp-anonymization-tool/components/dpdp-anonymization-distribution/src/main/resources/bin/dpdp-anonymize.bat
@@ -1,0 +1,5 @@
+@echo off
+setlocal
+set "TOOL_HOME=%~dp0.."
+java -jar "%TOOL_HOME%\lib\dpdp-anonymization-tool.jar" --config "%TOOL_HOME%\conf\config.json" %*
+exit /b %ERRORLEVEL%

--- a/tools/dpdp-anonymization-tool/components/dpdp-anonymization-distribution/src/main/resources/conf/config.json
+++ b/tools/dpdp-anonymization-tool/components/dpdp-anonymization-distribution/src/main/resources/conf/config.json
@@ -1,0 +1,11 @@
+{
+  "database": {
+    "driverClass": "com.mysql.cj.jdbc.Driver",
+    "url": "jdbc:mysql://localhost:3306/WSO2DPDP_DB?useSSL=true",
+    "username": "${DPDP_DB_USERNAME}",
+    "password": "${DPDP_DB_PASSWORD}"
+  },
+  "eventPayloadRulesFile": "event-payload-rules.json",
+  "batchSize": 250,
+  "reportDirectory": "../reports"
+}

--- a/tools/dpdp-anonymization-tool/components/dpdp-anonymization-distribution/src/main/resources/conf/event-payload-rules.json
+++ b/tools/dpdp-anonymization-tool/components/dpdp-anonymization-distribution/src/main/resources/conf/event-payload-rules.json
@@ -1,0 +1,14 @@
+[
+  {
+    "topic": "user.data.change",
+    "paths": [
+      "/userId"
+    ]
+  },
+  {
+    "topic": "user.account.delete",
+    "paths": [
+      "/userId"
+    ]
+  }
+]

--- a/tools/dpdp-anonymization-tool/components/dpdp-anonymization-distribution/src/main/resources/conf/log4j.properties
+++ b/tools/dpdp-anonymization-tool/components/dpdp-anonymization-distribution/src/main/resources/conf/log4j.properties
@@ -1,0 +1,4 @@
+org.slf4j.simpleLogger.defaultLogLevel=info
+org.slf4j.simpleLogger.showDateTime=true
+org.slf4j.simpleLogger.dateTimeFormat=yyyy-MM-dd'T'HH:mm:ss.SSSXXX
+org.slf4j.simpleLogger.showThreadName=false

--- a/tools/dpdp-anonymization-tool/docs/configuration.md
+++ b/tools/dpdp-anonymization-tool/docs/configuration.md
@@ -1,0 +1,7 @@
+# Configuration
+
+`conf/config.json` defines the JDBC connection, event-rule file, JDBC fetch size, and report directory.
+Database credentials should be environment placeholders such as `${DPDP_DB_USERNAME}` and `${DPDP_DB_PASSWORD}`.
+Do not commit operational credentials.
+
+Supported databases in the initial release are H2 2.x and MySQL 8.x. The complete operation has not been validated for PostgreSQL or SQLite.

--- a/tools/dpdp-anonymization-tool/docs/database-support.md
+++ b/tools/dpdp-anonymization-tool/docs/database-support.md
@@ -1,0 +1,5 @@
+# Database support
+
+The initial implementation supports H2 2.x and MySQL 8.x. Every supported table must exist before a run starts.
+
+The processor uses repeatable-read transactions and row locks. Services must remain stopped for the complete run, including verification and commit.

--- a/tools/dpdp-anonymization-tool/docs/event-payload-rules.md
+++ b/tools/dpdp-anonymization-tool/docs/event-payload-rules.md
@@ -1,0 +1,15 @@
+# Event payload rules
+
+Rules are keyed by topic name. The tool resolves the name through a join between `EVENT` and `TOPIC` constrained by both `TOPIC_ID` and `ORG_ID`.
+
+Paths use RFC 6901 JSON Pointer escaping, plus one restricted extension: `*` iterates array elements. For example:
+
+```json
+{
+  "topic": "example.topic",
+  "paths": ["/userId", "/data/authorizations/*/userId"]
+}
+```
+
+Only textual scalar values exactly matching a trusted identity are replaced. A configured path resolving to a non-string value fails the run.
+Topics without rules are counted as unconfigured and are not inspected recursively.

--- a/tools/dpdp-anonymization-tool/docs/security-and-recovery.md
+++ b/tools/dpdp-anonymization-tool/docs/security-and-recovery.md
@@ -1,0 +1,10 @@
+# Security and recovery
+
+1. Stop WSO2 IS and every process that reads or writes `WSO2DPDP_DB`.
+2. Create a database backup and verify that it can be restored.
+3. Protect configuration files and environment variables containing database credentials.
+4. Run without `--execute` and review the generated report.
+5. Run with `--execute` only after confirming the tenant, source UUID, replacement UUID, aliases, and event paths.
+6. Retain the report according to the organization's privacy and audit policy.
+
+The tool provides database transaction atomicity only. A report file and the database cannot participate in one atomic transaction.

--- a/tools/dpdp-anonymization-tool/integration-tests/pom.xml
+++ b/tools/dpdp-anonymization-tool/integration-tests/pom.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?><!--
+ ~ Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ ~
+ ~ WSO2 LLC. licenses this file to you under the Apache License,
+ ~ Version 2.0 (the "License"); you may not use this file except
+ ~ in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~     http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing,
+ ~ software distributed under the License is distributed on an
+ ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ ~ KIND, either express or implied. See the License for the
+ ~ specific language governing permissions and limitations
+ ~ under the License.
+ -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.wso2.dpdp</groupId>
+        <artifactId>dpdp-anonymization-tool-parent</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+    <artifactId>dpdp-anonymization-integration-tests</artifactId>
+    <dependencies>
+        <dependency>
+            <groupId>org.wso2.dpdp</groupId>
+            <artifactId>dpdp-anonymization-core</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/tools/dpdp-anonymization-tool/integration-tests/src/test/java/org/wso2/dpdp/anonymization/integration/H2AnonymizationIntegrationTest.java
+++ b/tools/dpdp-anonymization-tool/integration-tests/src/test/java/org/wso2/dpdp/anonymization/integration/H2AnonymizationIntegrationTest.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.dpdp.anonymization.integration;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.wso2.dpdp.anonymization.config.EventPayloadRule;
+import org.wso2.dpdp.anonymization.config.ToolConfig;
+import org.wso2.dpdp.anonymization.database.ConnectionFactory;
+import org.wso2.dpdp.anonymization.model.AnonymizationRequest;
+import org.wso2.dpdp.anonymization.model.AnonymizationResult;
+import org.wso2.dpdp.anonymization.model.AnonymizationStatus;
+import org.wso2.dpdp.anonymization.model.ExecutionMode;
+import org.wso2.dpdp.anonymization.processor.DpdpAnonymizationProcessor;
+import org.wso2.dpdp.anonymization.validation.AnonymizationException;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.Statement;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class H2AnonymizationIntegrationTest {
+
+    private static final String SOURCE = "18b7c17d-ef74-48c5-a0c8-a1df9b21ff87";
+    private static final String TARGET = "216d6aac-7e84-4484-a71e-c52f89b3cb1d";
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    private String url;
+    private DpdpAnonymizationProcessor processor;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        url = "jdbc:h2:mem:dpdp_" + System.nanoTime() + ";DB_CLOSE_DELAY=-1";
+        Class.forName("org.h2.Driver");
+        try (Connection connection = DriverManager.getConnection(url, "sa", "");
+             Statement statement = connection.createStatement()) {
+            createSchema(statement);
+            seed(statement);
+        }
+        EventPayloadRule rule = new EventPayloadRule();
+        rule.setTopic("user.data.change");
+        rule.setPaths(Collections.singletonList("/data/userId"));
+        ToolConfig config = new ToolConfig();
+        config.setEventPayloadRules(Collections.singletonList(rule));
+        ConnectionFactory factory = () -> DriverManager.getConnection(url, "sa", "");
+        processor = new DpdpAnonymizationProcessor(factory, config);
+    }
+
+    @Test
+    void dryRunRollsBackEveryCoveredField() throws Exception {
+        AnonymizationResult result = processor.process(request(ExecutionMode.DRY_RUN));
+        assertEquals(AnonymizationStatus.DRY_RUN, result.getStatus());
+        assertEquals(SOURCE, scalar("SELECT USER_ID FROM COMPLAINT WHERE ORG_ID='example.com'"));
+        assertEquals(SOURCE, jsonScalar("SELECT PAYLOAD FROM EVENT WHERE ORG_ID='example.com'", "/data/userId"));
+    }
+
+    @Test
+    void executeIsTenantScopedAndSecondRunIsIdempotent() throws Exception {
+        AnonymizationResult result = processor.process(request(ExecutionMode.EXECUTE));
+        assertEquals(AnonymizationStatus.COMMITTED, result.getStatus());
+        assertEquals(TARGET, scalar("SELECT USER_ID FROM COMPLAINT WHERE ORG_ID='example.com'"));
+        assertEquals(TARGET, scalar("SELECT ACTOR_USER_ID FROM COMPLAINT_EVENT WHERE ORG_ID='example.com'"));
+        assertEquals(TARGET, scalar("SELECT ACTION_BY FROM DPDP_CONSENT_STATUS_AUDIT WHERE ORG_ID='example.com'"));
+        assertEquals(TARGET, jsonScalar("SELECT SNAPSHOT FROM DPDP_CONSENT_HISTORY WHERE ORG_ID='example.com'", "/piiPrincipalId"));
+        assertEquals(TARGET, jsonScalar("SELECT PAYLOAD FROM EVENT WHERE ORG_ID='example.com'", "/data/userId"));
+        assertEquals(SOURCE, scalar("SELECT USER_ID FROM COMPLAINT WHERE ORG_ID='other.com'"));
+
+        AnonymizationResult second = processor.process(request(ExecutionMode.EXECUTE));
+        assertEquals(AnonymizationStatus.TARGET_PRESENT_SOURCE_ABSENT, second.getStatus());
+    }
+
+    @Test
+    void trustedUsernameCannotOverwriteDifferentNonNullId() throws Exception {
+        try (Connection connection = DriverManager.getConnection(url, "sa", ""); Statement statement = connection.createStatement()) {
+            statement.execute("INSERT INTO COMPLAINT VALUES ('c3','example.com','aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa','shared','r3','cat','LOW','OPEN','d',1,1,1)");
+        }
+        AnonymizationRequest request = new AnonymizationRequest("example.com", SOURCE, TARGET,
+                new LinkedHashSet<>(Collections.singletonList("shared")), ExecutionMode.EXECUTE);
+        assertThrows(AnonymizationException.class, () -> processor.process(request));
+        assertEquals("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+                scalar("SELECT USER_ID FROM COMPLAINT WHERE COMPLAINT_ID='c3'"));
+        assertEquals(SOURCE, scalar("SELECT USER_ID FROM COMPLAINT WHERE COMPLAINT_ID='c1'"));
+    }
+
+    @Test
+    void malformedJsonRollsBack() throws Exception {
+        try (Connection connection = DriverManager.getConnection(url, "sa", ""); Statement statement = connection.createStatement()) {
+            statement.execute("UPDATE DPDP_CONSENT_HISTORY SET SNAPSHOT='{broken' WHERE HISTORY_ID='h1'");
+        }
+        assertThrows(AnonymizationException.class, () -> processor.process(request(ExecutionMode.EXECUTE)));
+        assertEquals(SOURCE, scalar("SELECT USER_ID FROM COMPLAINT WHERE ORG_ID='example.com'"));
+    }
+
+    @Test
+    void distinguishesTenantWithoutDpdpData() throws Exception {
+        AnonymizationRequest request = new AnonymizationRequest("empty.example", SOURCE, TARGET,
+                Collections.<String>emptySet(), ExecutionMode.DRY_RUN);
+        assertEquals(AnonymizationStatus.NO_TENANT_DATA, processor.process(request).getStatus());
+    }
+
+    private AnonymizationRequest request(ExecutionMode mode) {
+        return new AnonymizationRequest("example.com", SOURCE, TARGET, Collections.<String>emptySet(), mode);
+    }
+
+    private String scalar(String sql) throws Exception {
+        try (Connection connection = DriverManager.getConnection(url, "sa", "");
+             Statement statement = connection.createStatement(); ResultSet result = statement.executeQuery(sql)) {
+            result.next();
+            return result.getString(1);
+        }
+    }
+
+    private String jsonScalar(String sql, String pointer) throws Exception {
+        JsonNode value = OBJECT_MAPPER.readTree(scalar(sql)).at(pointer);
+        return value.asText();
+    }
+
+    private void createSchema(Statement statement) throws Exception {
+        statement.execute("CREATE TABLE COMPLAINT (COMPLAINT_ID VARCHAR(36), ORG_ID VARCHAR(255), USER_ID VARCHAR(255), USER_NAME VARCHAR(255), REFERENCE_ID VARCHAR(32), CATEGORY VARCHAR(64), PRIORITY VARCHAR(16), STATUS VARCHAR(32), DESCRIPTION CLOB, CREATED_TIME BIGINT, UPDATED_TIME BIGINT, STATUTORY_DUE_TIME BIGINT, PRIMARY KEY(COMPLAINT_ID, ORG_ID))");
+        statement.execute("CREATE TABLE COMPLAINT_EVENT (COMPLAINT_EVENT_ID VARCHAR(36), ORG_ID VARCHAR(255), COMPLAINT_ID VARCHAR(36), ACTOR_USER_ID VARCHAR(255), ACTOR_USER_NAME VARCHAR(255), PRIMARY KEY(COMPLAINT_EVENT_ID, ORG_ID))");
+        statement.execute("CREATE TABLE DPDP_CONSENT_STATUS_AUDIT (AUDIT_ID VARCHAR(36) PRIMARY KEY, ORG_ID VARCHAR(255), ACTION_BY VARCHAR(255))");
+        statement.execute("CREATE TABLE DPDP_CONSENT_HISTORY (HISTORY_ID VARCHAR(36) PRIMARY KEY, ORG_ID VARCHAR(255), SNAPSHOT CLOB, ACTION_BY VARCHAR(255))");
+        statement.execute("CREATE TABLE TOPIC (TOPIC_ID VARCHAR(64) PRIMARY KEY, ORG_ID VARCHAR(128), NAME VARCHAR(225))");
+        statement.execute("CREATE TABLE EVENT (EVENT_ID VARCHAR(64) PRIMARY KEY, ORG_ID VARCHAR(128), TOPIC_ID VARCHAR(64), PAYLOAD CLOB)");
+    }
+
+    private void seed(Statement statement) throws Exception {
+        statement.execute("INSERT INTO COMPLAINT VALUES ('c1','example.com','" + SOURCE + "','alice','r1','cat','LOW','OPEN','d',1,1,1)");
+        statement.execute("INSERT INTO COMPLAINT VALUES ('c2','other.com','" + SOURCE + "','alice','r2','cat','LOW','OPEN','d',1,1,1)");
+        statement.execute("INSERT INTO COMPLAINT_EVENT VALUES ('ce1','example.com','c1','" + SOURCE + "','alice')");
+        statement.execute("INSERT INTO DPDP_CONSENT_STATUS_AUDIT VALUES ('a1','example.com','alice')");
+        statement.execute("INSERT INTO DPDP_CONSENT_HISTORY VALUES ('h1','example.com','{\"piiPrincipalId\":\"" + SOURCE + "\",\"authorizations\":[{\"userId\":\"" + SOURCE + "\"}]}','alice')");
+        statement.execute("INSERT INTO TOPIC VALUES ('t1','example.com','user.data.change')");
+        statement.execute("INSERT INTO TOPIC VALUES ('t2','other.com','user.data.change')");
+        statement.execute("INSERT INTO EVENT VALUES ('e1','example.com','t1','{\"data\":{\"userId\":\"" + SOURCE + "\"},\"note\":\"keep " + SOURCE + "\"}')");
+        statement.execute("INSERT INTO EVENT VALUES ('e2','other.com','t2','{\"data\":{\"userId\":\"" + SOURCE + "\"}}')");
+    }
+}

--- a/tools/dpdp-anonymization-tool/pom.xml
+++ b/tools/dpdp-anonymization-tool/pom.xml
@@ -1,0 +1,113 @@
+<?xml version="1.0" encoding="UTF-8"?><!--
+ ~ Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ ~
+ ~ WSO2 LLC. licenses this file to you under the Apache License,
+ ~ Version 2.0 (the "License"); you may not use this file except
+ ~ in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~     http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing,
+ ~ software distributed under the License is distributed on an
+ ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ ~ KIND, either express or implied. See the License for the
+ ~ specific language governing permissions and limitations
+ ~ under the License.
+ -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.wso2.dpdp</groupId>
+    <artifactId>dpdp-anonymization-tool-parent</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+    <packaging>pom</packaging>
+
+    <name>WSO2 DPDP Anonymization Tool</name>
+    <description>Offline, tenant-scoped pseudonymization tool for WSO2 DPDP data.</description>
+
+    <modules>
+        <module>components/dpdp-anonymization-core</module>
+        <module>components/dpdp-anonymization-cli</module>
+        <module>components/dpdp-anonymization-distribution</module>
+        <module>integration-tests</module>
+    </modules>
+
+    <properties>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <jackson.version>2.17.3</jackson.version>
+        <commons.cli.version>1.6.0</commons.cli.version>
+        <slf4j.version>1.7.36</slf4j.version>
+        <junit.version>5.10.5</junit.version>
+        <h2.version>2.2.224</h2.version>
+        <mysql.version>8.0.33</mysql.version>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-databind</artifactId>
+                <version>${jackson.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>commons-cli</groupId>
+                <artifactId>commons-cli</artifactId>
+                <version>${commons.cli.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>slf4j-api</artifactId>
+                <version>${slf4j.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>slf4j-simple</artifactId>
+                <version>${slf4j.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.junit.jupiter</groupId>
+                <artifactId>junit-jupiter</artifactId>
+                <version>${junit.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.h2database</groupId>
+                <artifactId>h2</artifactId>
+                <version>${h2.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.mysql</groupId>
+                <artifactId>mysql-connector-j</artifactId>
+                <version>${mysql.version}</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <version>3.11.0</version>
+                    <configuration>
+                        <source>${maven.compiler.source}</source>
+                        <target>${maven.compiler.target}</target>
+                    </configuration>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <version>3.2.5</version>
+                    <configuration>
+                        <useModulePath>false</useModulePath>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+    </build>
+</project>


### PR DESCRIPTION
 ## Purpose

  Introduce a standalone, offline DPDP anonymization tool for tenant-scoped pseudonymization of user identifiers stored in `WSO2DPDP_DB`.

  The tool is located under `tools/dpdp-anonymization-tool` and remains separate from the DPDP Accelerator runtime and its default Maven reactor.

  ## Key changes

  - Add a Java 8-compatible multi-module Maven project containing:
    - Core anonymization processor.
    - Command-line interface.
    - ZIP distribution packaging.
    - Unit and H2 integration tests.
  - Add Unix and Windows launch scripts.
  - Add configuration for JDBC connectivity and Event payload rules.
  - Generate masked success and failure reports.
  - Add operator documentation covering configuration, execution, security, and recovery.

  ## Anonymization scope

  The tool pseudonymizes tenant-scoped identity values in:

  - `COMPLAINT.USER_ID`
  - Correlated `COMPLAINT.USER_NAME`
  - `COMPLAINT_EVENT.ACTOR_USER_ID`
  - Correlated `COMPLAINT_EVENT.ACTOR_USER_NAME`
  - `DPDP_CONSENT_STATUS_AUDIT.ACTION_BY`
  - `DPDP_CONSENT_HISTORY.ACTION_BY`
  - `DPDP_CONSENT_HISTORY.SNAPSHOT.piiPrincipalId`
  - `DPDP_CONSENT_HISTORY.SNAPSHOT.authorizations[*].userId`
  - Allowlisted user-ID paths inside `EVENT.PAYLOAD`

  Event payload rules are selected using a tenant-safe join between `EVENT` and `TOPIC`. Only explicitly configured JSON paths are inspected; the
  tool does not recursively replace arbitrary matching strings.

  The default Event rules cover:

  - `user.data.change` → `/userId`
  - `user.account.delete` → `/userId`

  ## Safety controls

  - Require an explicit tenant domain and apply it as `ORG_ID` to every database operation.
  - Require canonical and different source/replacement UUIDs.
  - Default to dry-run mode.
  - Require `--execute` before committing changes.
  - Process covered changes in one JDBC transaction.
  - Roll back the complete operation on SQL, JSON, validation, or verification failures.
  - Validate replacement UUID collisions before updating.
  - Reject ambiguous username mappings associated with another non-null user ID.
  - Support explicitly supplied trusted username aliases for legacy username-backed records.
  - Verify that covered source values are removed before commit.
  - Report a target-only state as ambiguous rather than assuming a previous successful execution.
  - Mask source and replacement identifiers in generated reports.
  - Apply row locking and repeatable-read transaction isolation.
  - Require Event payload paths to resolve to textual scalar values.

  ## Command usage

  Dry-run:

  ```bash
  ./bin/dpdp-anonymize \
    --tenant-domain example.com \
    --user-id 18b7c17d-ef74-48c5-a0c8-a1df9b21ff87 \
    --pseudonym 216d6aac-7e84-4484-a71e-c52f89b3cb1d
  ```
  Execute after reviewing the dry-run report:

```bash
  ./bin/dpdp-anonymize \
    --tenant-domain example.com \
    --user-id 18b7c17d-ef74-48c5-a0c8-a1df9b21ff87 \
    --pseudonym 216d6aac-7e84-4484-a71e-c52f89b3cb1d \
    --execute
  ```

  Verified username aliases can be supplied using repeatable --username options.

  ## Result states

  The processor reports:

  - DRY_RUN
  - COMMITTED
  - NO_TENANT_DATA
  - NO_MATCH
  - TARGET_PRESENT_SOURCE_ABSENT
  - FAILED

  ## Distribution

  The build produces:

  ```bash
  tools/dpdp-anonymization-tool/
    components/dpdp-anonymization-distribution/target/
    dpdp-anonymization-tool-1.0.0-SNAPSHOT.zip
  ```

  The distribution contains the launch scripts, configuration, documentation, and a shaded executable JAR with the required dependencies and JDBC drivers.

  ## Testing

  Run the tool build independently:

  env JAVA_HOME="$(/usr/libexec/java_home -v 1.8)" \
  mvn -f tools/dpdp-anonymization-tool/pom.xml clean verify

  Current coverage includes:

  - Canonical UUID validation.
  - Source/replacement equality rejection.
  - Exact JSON scalar replacement.
  - JSON Pointer and array wildcard handling.
  - Non-string JSON target rejection.
  - CLI help and required-argument behavior.
  - Dry-run transaction rollback.
  - Tenant-isolated execution.
  - Structured-column and JSON updates.
  - Repeated-run target/source state handling.
  - Ambiguous username protection.
  - Malformed JSON rollback.
  - Tenant-without-DPDP-data detection.

  ## Operational requirements

  Before execution:

  1. Stop WSO2 IS and every writer to WSO2DPDP_DB.
  2. Take and verify a restorable database backup.
  3. Run without --execute.
  4. Review the generated dry-run report.
  5. Run with --execute only after verifying the tenant, source UUID, replacement UUID, aliases, and Event rules.

  ## Limitations

  - This provides configured-field pseudonymization, not complete data erasure.
  - Attachments, comments, complaint descriptions, arbitrary unconfigured JSON, operational identifiers, and other databases are outside scope.
  - PostgreSQL and SQLite are not currently supported.
  - H2 integration coverage is included.
  - MySQL JDBC support is packaged, but execution against a representative MySQL environment should be validated before production use.
  - The tool is intentionally not included in the accelerator’s default Maven reactor or WSO2 IS distribution.