### PR TITLE
Add a GitHub Actions release pipeline

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,352 @@
+# Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+#
+# WSO2 LLC. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# Deploys a fresh Identity Server, applies the accelerator to it and runs the Playwright
+# suite against it. Reusable so `pr-checks.yml` (label-gated PR runs) and
+# `release-builder.yml` (release gate) exercise exactly the same path - the job body is
+# kept as a straight lift of what pr-checks.yml used to run inline.
+name: E2E integration tests
+
+on:
+  workflow_call:
+    inputs:
+      ref:
+        description: Ref or SHA to check out. Empty means the ref that triggered the caller.
+        required: false
+        type: string
+        default: ''
+      is_source:
+        description: Where to get the Identity Server pack from - `release` or `master`.
+        required: false
+        type: string
+        default: master
+      allow_unsafe_pr_checkout:
+        description: Permit checking out fork code. Only ever true for a reviewed, label-gated PR.
+        required: false
+        type: boolean
+        default: false
+    secrets:
+      SOLUTIONS_BOT_EMAIL:
+        required: false
+      SOLUTIONS_BOT_U2_PASSWORD:
+        required: false
+      WSO2_UPDATE_TOOL_SETUP_DECRYPTION_PASSPHRASE:
+        required: false
+
+permissions:
+  contents: read
+
+env:
+  IS_VERSION: 7.3.0
+
+jobs:
+  e2e:
+    name: E2E integration tests
+    runs-on: ubuntu-latest
+    # Generous enough to cover the rare, manually-chosen product-is master build
+    # (large multi-module reactor, even with tests/checks skipped) plus one
+    # provisioning restart. The default release+U2 path finishes in a fraction of this.
+    timeout-minutes: 110
+    env:
+      IS_BASE_URL: https://localhost:9443
+      # Must match repository/conf/configure.properties - the accelerator's own configure.sh
+      # installs the admin account under these credentials, not the product's stock admin/admin.
+      IS_ADMIN_USERNAME: admin@wso2.com
+      IS_ADMIN_PASSWORD: wso2123
+      IS_SOURCE: ${{ inputs.is_source }}
+    steps:
+      # pull_request_target checks out the TARGET branch by default, which would
+      # silently test the wrong code - explicitly pin to the PR's own head commit. A
+      # plain workflow_dispatch run has no pull_request context, so it falls back to
+      # whatever ref triggered it (actions/checkout's own default).
+      #
+      # allow-unsafe-pr-checkout is required because that head commit can belong to a
+      # fork - actions/checkout otherwise refuses to fetch fork code into a
+      # pull_request_target run (the "pwn request" guard). Safe here specifically
+      # because this job only runs after a maintainer has reviewed the diff and
+      # applied the Action/trigger-e2e label (see the trigger comment above and
+      # `reset-e2e-label-on-push` below) - same pattern FS Accelerator's maven.yml uses.
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ inputs.ref }}
+          allow-unsafe-pr-checkout: ${{ inputs.allow_unsafe_pr_checkout }}
+          persist-credentials: false
+
+      - uses: actions/setup-java@v5
+        with:
+          java-version: '21'
+          distribution: temurin
+          cache: maven
+      - uses: actions/setup-node@v5
+        with:
+          node-version: '22'
+
+      # No artifact download from `build`: that job only runs under `pull_request`,
+      # which never fires in the same workflow run as `pull_request_target` or
+      # `workflow_dispatch` - there is nothing to download here, so this job builds
+      # the accelerator itself.
+      - name: Build the accelerator
+        run: mvn -B clean install
+        env:
+          MAVEN_OPTS: -Xmx4g
+
+      # --- Obtaining the IS pack: two mutually exclusive paths ------------------
+
+      # A 420 MB asset. Keyed on version alone, which is correct because a published
+      # release asset is immutable - bumping IS_VERSION must be the only way it changes.
+      - name: Cache IS pack
+        id: is-cache
+        if: env.IS_SOURCE == 'release'
+        uses: actions/cache@v4
+        with:
+          path: ~/is-pack
+          key: wso2is-${{ env.IS_VERSION }}
+
+      - name: Download IS ${{ env.IS_VERSION }}
+        if: env.IS_SOURCE == 'release' && steps.is-cache.outputs.cache-hit != 'true'
+        run: |
+          mkdir -p ~/is-pack && cd ~/is-pack
+          base="https://github.com/wso2/product-is/releases/download/v${IS_VERSION}"
+          curl -fL --retry 3 -o wso2is.zip    "${base}/wso2is-${IS_VERSION}.zip"
+          curl -fL --retry 3 -o wso2is.sha256 "${base}/wso2is-${IS_VERSION}.zip.sha256"
+          # Fail loudly on a truncated download rather than later, as a mystery
+          # startup error.
+          echo "$(cut -d' ' -f1 wso2is.sha256)  wso2is.zip" | sha256sum -c -
+
+      # Only relevant for the manually-dispatched master build; harmless dead weight
+      # otherwise since the step it guards never runs on the default path.
+      - name: Cache Maven repo for the product-is build
+        if: env.IS_SOURCE == 'master'
+        uses: actions/cache@v4
+        with:
+          path: ~/.m2/repository
+          key: product-is-master-m2-${{ github.run_id }}
+          restore-keys: |
+            product-is-master-m2-
+
+      - name: Build IS from product-is master
+        if: env.IS_SOURCE == 'master'
+        run: |
+          git clone --depth 1 https://github.com/wso2/product-is.git /tmp/product-is
+          cd /tmp/product-is
+          mvn -B -ntp install \
+            -Dmaven.test.skip=true -Dspotbugs.skip=true -Dcheckstyle.skip=true \
+            -Dpmd.skip=true -Drat.skip=true -Dlicense.skip=true \
+            -Dmaven.javadoc.skip=true -Djacoco.skip=true
+        env:
+          MAVEN_OPTS: -Xmx4g
+
+      - name: Stage the built distribution zip
+        if: env.IS_SOURCE == 'master'
+        run: |
+          zip_path=$(find /tmp/product-is/modules/distribution/target -maxdepth 1 -name "wso2is-*.zip" | head -1)
+          if [ -z "${zip_path}" ]; then
+            echo "::error::No wso2is-*.zip under modules/distribution/target - did the module path change?"
+            exit 1
+          fi
+          mkdir -p ~/is-pack
+          cp "${zip_path}" ~/is-pack/wso2is.zip
+          echo "Built $(basename "${zip_path}")"
+
+      - name: Unpack IS
+        run: unzip -q ~/is-pack/wso2is.zip -d "${GITHUB_WORKSPACE}"
+
+      - name: Resolve IS_HOME
+        run: |
+          dir=$(find "${GITHUB_WORKSPACE}" -maxdepth 1 -type d -name "wso2is-*")
+          if [ -z "${dir}" ]; then
+            echo "::error::No wso2is-* directory found after unpacking"
+            exit 1
+          fi
+          echo "IS_HOME=${dir}" >> "$GITHUB_ENV"
+          echo "Resolved IS_HOME=${dir}"
+
+      # Unconditional on the default (release) path now - this is the whole point of
+      # gating the job behind pull_request_target + a label: without the U2 update, a
+      # vanilla GA pack lacks the consent-mgt v2 API resources this accelerator needs
+      # (see issue history). Never runs for the master path - a source build already
+      # carries whatever is newest.
+      - name: Apply WSO2 U2 updates
+        if: env.IS_SOURCE == 'release'
+        env:
+          WSO2_USERNAME: ${{ secrets.SOLUTIONS_BOT_EMAIL }}
+          WSO2_PASSWORD: ${{ secrets.SOLUTIONS_BOT_U2_PASSWORD }}
+          WSO2_UPDATE_TOOL_SETUP_DECRYPTION_PASSPHRASE: ${{ secrets.WSO2_UPDATE_TOOL_SETUP_DECRYPTION_PASSPHRASE }}
+        run: |
+          if [ -z "${WSO2_USERNAME}" ] || [ -z "${WSO2_PASSWORD}" ]; then
+            echo "::error::WSO2_USERNAME/WSO2_PASSWORD are empty - SOLUTIONS_BOT_EMAIL and" \
+                 "SOLUTIONS_BOT_U2_PASSWORD must be configured as repository secrets for the" \
+                 "default release+U2 path to work."
+            exit 1
+          fi
+          if [ -z "${WSO2_UPDATE_TOOL_SETUP_DECRYPTION_PASSPHRASE}" ]; then
+            echo "::error::WSO2_UPDATE_TOOL_SETUP_DECRYPTION_PASSPHRASE is empty - it must be" \
+                 "configured as a repository secret to decrypt .github/ci-tools/update_tool_setup.sh.gpg."
+            exit 1
+          fi
+          gpg --quiet --batch --yes --decrypt \
+            --passphrase="${WSO2_UPDATE_TOOL_SETUP_DECRYPTION_PASSPHRASE}" \
+            --output "$IS_HOME/bin/update_tool_setup.sh" \
+            "${GITHUB_WORKSPACE}/.github/ci-tools/update_tool_setup.sh.gpg"
+          chmod +x "$IS_HOME/bin/update_tool_setup.sh"
+          cd "$IS_HOME"
+          bash bin/update_tool_setup.sh
+          # One retry: the updater is network-flaky, which is why FSA retries it too.
+          bin/wso2update_linux -v --username "$WSO2_USERNAME" --password "$WSO2_PASSWORD" \
+            || bin/wso2update_linux -v --username "$WSO2_USERNAME" --password "$WSO2_PASSWORD"
+
+      - name: Apply the accelerator
+        run: |
+          zip_path=$(find dpdp-accelerator/accelerators/dpdp-is/target -maxdepth 1 -name "wso2-dpdp-is-accelerator-*.zip" | head -1)
+          if [ -z "${zip_path}" ]; then
+            echo "::error::No wso2-dpdp-is-accelerator-*.zip under dpdp-accelerator/accelerators/dpdp-is/target"
+            exit 1
+          fi
+          unzip -q "${zip_path}" -d "$IS_HOME"
+          cd "${IS_HOME}/$(basename "${zip_path}" .zip)"
+          bash bin/merge.sh     "$IS_HOME"
+          bash bin/configure.sh "$IS_HOME"
+
+      # Upstream's pr-checks.yml has an "Enable private-network webhook callbacks" step here,
+      # calling dpdp-integration-test-suite/scripts/enable-webhook-callbacks.sh. That script is
+      # not in the repository, so the step is omitted rather than carried as a guaranteed
+      # failure. Nothing is lost today: it flips allow_private_network_callback_targets for
+      # tests/08-event-notifications, whose webhook specs are test.skip'd in source and also
+      # gated on WEBHOOK_RECEIVER_HOST, which nothing here sets. Re-add it at this point in the
+      # sequence - after configure.sh, before the server starts - once the script lands.
+
+      - name: Start the Identity Server
+        run: |
+          "${IS_HOME}/bin/wso2server.sh" start
+          for i in $(seq 1 60); do
+            if curl -sk -o /dev/null -f "${IS_BASE_URL}/oauth2/jwks"; then
+              echo "Identity Server ready after ~$((i * 5))s"
+              exit 0
+            fi
+            sleep 5
+          done
+          echo "::error::Identity Server did not become ready within 300s"
+          tail -200 "${IS_HOME}/repository/logs/wso2carbon.log"
+          exit 1
+
+      - name: Verify accelerator provisioning
+        run: |
+          roles_found() {
+            curl -sk -u "${IS_ADMIN_USERNAME}:${IS_ADMIN_PASSWORD}" \
+              "${IS_BASE_URL}/scim2/v2/Roles?filter=displayName+eq+dpdp-consent-admin" \
+              | python3 -c 'import json, sys; print(json.load(sys.stdin).get("totalResults", 0))'
+          }
+          wait_for_is() {
+            for i in $(seq 1 60); do
+              curl -sk -o /dev/null -f "${IS_BASE_URL}/oauth2/jwks" && return 0
+              sleep 5
+            done
+            return 1
+          }
+
+          max_restarts=1
+          attempt=0
+          while [ "$(roles_found)" != "1" ]; do
+            if [ "${attempt}" -ge "${max_restarts}" ]; then
+              echo "::error::Accelerator did not provision dpdp-consent-admin for carbon.super after ${max_restarts} restarts"
+              grep -n "Error provisioning the DPDP Consent Portal" \
+                "${IS_HOME}/repository/logs/wso2carbon.log" || true
+              exit 1
+            fi
+            attempt=$((attempt + 1))
+            echo "::warning::dpdp-consent-admin missing after startup; restart ${attempt}/${max_restarts}"
+            "${IS_HOME}/bin/wso2server.sh" restart
+            wait_for_is || { echo "::error::Identity Server did not come back up after restart ${attempt}"; exit 1; }
+          done
+
+          if [ "${attempt}" -gt 0 ]; then
+            echo "Provisioning verified after ${attempt} restart(s)."
+          else
+            echo "Provisioning verified."
+          fi
+
+      - name: Provision test users
+        id: users
+        run: |
+          # Ephemeral - thrown away with the runner - but masked so it cannot reach a log.
+          password="$(openssl rand -base64 18 | tr -dc 'A-Za-z0-9')Aa1!"
+          echo "::add-mask::${password}"
+          echo "TEST_PASSWORD=${password}" >> "$GITHUB_ENV"
+          TEST_PASSWORD="${password}" \
+            bash dpdp-integration-test-suite/scripts/provision-test-users.sh
+
+      # tests/08-event-notifications' real webhook-delivery tests run via WEBHOOK_RECEIVER_HOST -
+      # no secret needed, see "Enable private-network webhook callbacks..." above.
+      - name: Configure the suite
+        working-directory: dpdp-integration-test-suite
+        run: |
+          cat > .env <<EOF
+          PORTAL_BASE_URL=${IS_BASE_URL}/consent-portal
+          IS_BASE_URL=${IS_BASE_URL}
+          IGNORE_HTTPS_ERRORS=true
+          TEST_USER_USERNAME=${{ steps.users.outputs.user }}
+          TEST_USER_PASSWORD=${TEST_PASSWORD}
+          TEST_CONSENT_ADMIN_USERNAME=${{ steps.users.outputs.admin }}
+          TEST_CONSENT_ADMIN_PASSWORD=${TEST_PASSWORD}
+          TEST_USER_2_USERNAME=${{ steps.users.outputs.user2 }}
+          TEST_USER_2_PASSWORD=${TEST_PASSWORD}
+          WEBHOOK_RECEIVER_HOST=${WEBHOOK_RECEIVER_HOST}
+          WEBHOOK_RECEIVER_ALLOW_PRIVATE_NETWORK=true
+          EOF
+          npm ci
+          npx playwright install --with-deps chromium
+
+      # npm ci and the browser install are already done, so run-e2e.sh skips both and
+      # just execs playwright. The github reporter adds inline annotations; the config
+      # itself only declares html.
+      - name: Run Playwright
+        working-directory: dpdp-integration-test-suite
+        run: ./run-e2e.sh --reporter=github,html
+
+      - name: Upload Playwright report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: |
+            dpdp-integration-test-suite/playwright-report/
+            dpdp-integration-test-suite/test-results/
+          retention-days: 7
+
+      - name: Upload server logs
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: carbon-logs
+          path: ${{ env.IS_HOME }}/repository/logs/
+          retention-days: 7
+
+      - name: Stop the Identity Server
+        if: always()
+        run: |
+          "${IS_HOME}/bin/wso2server.sh" stop || true
+
+  # `e2e` itself cannot be the required status check: a job skipped by its own `if:`
+  # (which is what happens on every pull_request_target event until someone applies
+  # Action/trigger-e2e) reports a "skipped" conclusion, and GitHub's branch-protection
+  # rulesets treat "skipped" as satisfying a required check - so marking `e2e` required
+  # would let every PR merge without it ever having run. This job exists purely to be
+  # the thing a ruleset actually requires: it always runs on pull_request_target
+  # (`if: always()` so a skipped `e2e` doesn't skip this too) and fails unless `e2e`
+  # itself reports success, so it's red until the label is applied and E2E passes.
+  #
+  # This job must be selected as the required status check for `main` in Settings ->
+  # Rules -> Rulesets - that repo-admin step can't be done from this workflow file.

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -1,4 +1,5 @@
-# Build + end-to-end checks for the DPDP accelerator.
+# Build + end-to-end checks for the DPDP accelerator. The E2E job itself lives in the
+# reusable `e2e.yml`, shared with `release-builder.yml`.
 #
 # These jobs run identically on PRs to main and dev, but as of this writing neither
 # branch has a ruleset marking them as required status checks (neither of us has admin
@@ -44,10 +45,6 @@ concurrency:
 
 permissions:
   contents: read
-
-env:
-  IS_VERSION: 7.3.0
-  ACCELERATOR_VERSION: 1.0.0-SNAPSHOT
 
 jobs:
   build:
@@ -100,305 +97,22 @@ jobs:
             exit $exit_code
           fi
 
+  # Pins the checkout to the PR's head SHA (pull_request_target otherwise checks out the
+  # target branch); allow_unsafe_pr_checkout permits fetching fork code, safe here because
+  # this only runs after a maintainer applies the reviewed Action/trigger-e2e label.
   e2e:
-    name: E2E integration tests
     if: >
       github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'pull_request_target' &&
        github.event.action == 'labeled' &&
        github.event.label.name == 'Action/trigger-e2e')
-    runs-on: ubuntu-latest
-    # Generous enough to cover the rare, manually-chosen product-is master build
-    # (large multi-module reactor, even with tests/checks skipped) plus one
-    # provisioning restart. The default release+U2 path finishes in a fraction of this.
-    timeout-minutes: 110
-    env:
-      IS_BASE_URL: https://localhost:9443
-      # Must match repository/conf/configure.properties - the accelerator's own configure.sh
-      # installs the admin account under these credentials, not the product's stock admin/admin.
-      IS_ADMIN_USERNAME: admin@wso2.com
-      IS_ADMIN_PASSWORD: wso2123
-      IS_SOURCE: ${{ github.event_name == 'workflow_dispatch' && inputs.is_source || 'release' }}
-    steps:
-      # pull_request_target checks out the TARGET branch by default, which would
-      # silently test the wrong code - explicitly pin to the PR's own head commit. A
-      # plain workflow_dispatch run has no pull_request context, so it falls back to
-      # whatever ref triggered it (actions/checkout's own default).
-      #
-      # allow-unsafe-pr-checkout is required because that head commit can belong to a
-      # fork - actions/checkout otherwise refuses to fetch fork code into a
-      # pull_request_target run (the "pwn request" guard). Safe here specifically
-      # because this job only runs after a maintainer has reviewed the diff and
-      # applied the Action/trigger-e2e label (see the trigger comment above and
-      # `reset-e2e-label-on-push` below) - same pattern FS Accelerator's maven.yml uses.
-      - uses: actions/checkout@v5
-        with:
-          ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || '' }}
-          allow-unsafe-pr-checkout: ${{ github.event_name == 'pull_request_target' }}
-          persist-credentials: false
+    uses: ./.github/workflows/e2e.yml
+    with:
+      ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || '' }}
+      is_source: ${{ github.event_name == 'workflow_dispatch' && inputs.is_source || 'master' }}
+      allow_unsafe_pr_checkout: ${{ github.event_name == 'pull_request_target' }}
+    secrets: inherit
 
-      - uses: actions/setup-java@v5
-        with:
-          java-version: '21'
-          distribution: temurin
-          cache: maven
-      - uses: actions/setup-node@v5
-        with:
-          node-version: '22'
-
-      # No artifact download from `build`: that job only runs under `pull_request`,
-      # which never fires in the same workflow run as `pull_request_target` or
-      # `workflow_dispatch` - there is nothing to download here, so this job builds
-      # the accelerator itself.
-      - name: Build the accelerator
-        run: mvn -B clean install
-        env:
-          MAVEN_OPTS: -Xmx4g
-
-      # --- Obtaining the IS pack: two mutually exclusive paths ------------------
-
-      # A 420 MB asset. Keyed on version alone, which is correct because a published
-      # release asset is immutable - bumping IS_VERSION must be the only way it changes.
-      - name: Cache IS pack
-        id: is-cache
-        if: env.IS_SOURCE == 'release'
-        uses: actions/cache@v4
-        with:
-          path: ~/is-pack
-          key: wso2is-${{ env.IS_VERSION }}
-
-      - name: Download IS ${{ env.IS_VERSION }}
-        if: env.IS_SOURCE == 'release' && steps.is-cache.outputs.cache-hit != 'true'
-        run: |
-          mkdir -p ~/is-pack && cd ~/is-pack
-          base="https://github.com/wso2/product-is/releases/download/v${IS_VERSION}"
-          curl -fL --retry 3 -o wso2is.zip    "${base}/wso2is-${IS_VERSION}.zip"
-          curl -fL --retry 3 -o wso2is.sha256 "${base}/wso2is-${IS_VERSION}.zip.sha256"
-          # Fail loudly on a truncated download rather than later, as a mystery
-          # startup error.
-          echo "$(cut -d' ' -f1 wso2is.sha256)  wso2is.zip" | sha256sum -c -
-
-      # Only relevant for the manually-dispatched master build; harmless dead weight
-      # otherwise since the step it guards never runs on the default path.
-      - name: Cache Maven repo for the product-is build
-        if: env.IS_SOURCE == 'master'
-        uses: actions/cache@v4
-        with:
-          path: ~/.m2/repository
-          key: product-is-master-m2-${{ github.run_id }}
-          restore-keys: |
-            product-is-master-m2-
-
-      - name: Build IS from product-is master
-        if: env.IS_SOURCE == 'master'
-        run: |
-          git clone --depth 1 https://github.com/wso2/product-is.git /tmp/product-is
-          cd /tmp/product-is
-          mvn -B -ntp install \
-            -Dmaven.test.skip=true -Dspotbugs.skip=true -Dcheckstyle.skip=true \
-            -Dpmd.skip=true -Drat.skip=true -Dlicense.skip=true \
-            -Dmaven.javadoc.skip=true -Djacoco.skip=true
-        env:
-          MAVEN_OPTS: -Xmx4g
-
-      - name: Stage the built distribution zip
-        if: env.IS_SOURCE == 'master'
-        run: |
-          zip_path=$(find /tmp/product-is/modules/distribution/target -maxdepth 1 -name "wso2is-*.zip" | head -1)
-          if [ -z "${zip_path}" ]; then
-            echo "::error::No wso2is-*.zip under modules/distribution/target - did the module path change?"
-            exit 1
-          fi
-          mkdir -p ~/is-pack
-          cp "${zip_path}" ~/is-pack/wso2is.zip
-          echo "Built $(basename "${zip_path}")"
-
-      - name: Unpack IS
-        run: unzip -q ~/is-pack/wso2is.zip -d "${GITHUB_WORKSPACE}"
-
-      - name: Resolve IS_HOME
-        run: |
-          dir=$(find "${GITHUB_WORKSPACE}" -maxdepth 1 -type d -name "wso2is-*")
-          if [ -z "${dir}" ]; then
-            echo "::error::No wso2is-* directory found after unpacking"
-            exit 1
-          fi
-          echo "IS_HOME=${dir}" >> "$GITHUB_ENV"
-          echo "Resolved IS_HOME=${dir}"
-
-      # Unconditional on the default (release) path now - this is the whole point of
-      # gating the job behind pull_request_target + a label: without the U2 update, a
-      # vanilla GA pack lacks the consent-mgt v2 API resources this accelerator needs
-      # (see issue history). Never runs for the master path - a source build already
-      # carries whatever is newest.
-      - name: Apply WSO2 U2 updates
-        if: env.IS_SOURCE == 'release'
-        env:
-          WSO2_USERNAME: ${{ secrets.SOLUTIONS_BOT_EMAIL }}
-          WSO2_PASSWORD: ${{ secrets.SOLUTIONS_BOT_U2_PASSWORD }}
-          WSO2_UPDATE_TOOL_SETUP_DECRYPTION_PASSPHRASE: ${{ secrets.WSO2_UPDATE_TOOL_SETUP_DECRYPTION_PASSPHRASE }}
-        run: |
-          if [ -z "${WSO2_USERNAME}" ] || [ -z "${WSO2_PASSWORD}" ]; then
-            echo "::error::WSO2_USERNAME/WSO2_PASSWORD are empty - SOLUTIONS_BOT_EMAIL and" \
-                 "SOLUTIONS_BOT_U2_PASSWORD must be configured as repository secrets for the" \
-                 "default release+U2 path to work."
-            exit 1
-          fi
-          if [ -z "${WSO2_UPDATE_TOOL_SETUP_DECRYPTION_PASSPHRASE}" ]; then
-            echo "::error::WSO2_UPDATE_TOOL_SETUP_DECRYPTION_PASSPHRASE is empty - it must be" \
-                 "configured as a repository secret to decrypt .github/ci-tools/update_tool_setup.sh.gpg."
-            exit 1
-          fi
-          gpg --quiet --batch --yes --decrypt \
-            --passphrase="${WSO2_UPDATE_TOOL_SETUP_DECRYPTION_PASSPHRASE}" \
-            --output "$IS_HOME/bin/update_tool_setup.sh" \
-            "${GITHUB_WORKSPACE}/.github/ci-tools/update_tool_setup.sh.gpg"
-          chmod +x "$IS_HOME/bin/update_tool_setup.sh"
-          cd "$IS_HOME"
-          bash bin/update_tool_setup.sh
-          # One retry: the updater is network-flaky, which is why FSA retries it too.
-          bin/wso2update_linux -v --username "$WSO2_USERNAME" --password "$WSO2_PASSWORD" \
-            || bin/wso2update_linux -v --username "$WSO2_USERNAME" --password "$WSO2_PASSWORD"
-
-      - name: Apply the accelerator
-        run: |
-          zip_path=$(find dpdp-accelerator/accelerators/dpdp-is/target -maxdepth 1 -name "wso2-dpdp-is-accelerator-*.zip" | head -1)
-          if [ -z "${zip_path}" ]; then
-            echo "::error::No wso2-dpdp-is-accelerator-*.zip under dpdp-accelerator/accelerators/dpdp-is/target"
-            exit 1
-          fi
-          unzip -q "${zip_path}" -d "$IS_HOME"
-          cd "${IS_HOME}/wso2-dpdp-is-accelerator-${ACCELERATOR_VERSION}"
-          bash bin/merge.sh     "$IS_HOME"
-          bash bin/configure.sh "$IS_HOME"
-
-      # No-secret webhook-delivery coverage for tests/08-event-notifications - see that script for
-      # why this only works for a fresh CI-deployed IS, not a long-running local install.
-      - name: Enable private-network webhook callbacks for this CI-only IS instance
-        run: bash dpdp-integration-test-suite/scripts/enable-webhook-callbacks.sh "$IS_HOME"
-
-      - name: Start the Identity Server
-        run: |
-          "${IS_HOME}/bin/wso2server.sh" start
-          for i in $(seq 1 60); do
-            if curl -sk -o /dev/null -f "${IS_BASE_URL}/oauth2/jwks"; then
-              echo "Identity Server ready after ~$((i * 5))s"
-              exit 0
-            fi
-            sleep 5
-          done
-          echo "::error::Identity Server did not become ready within 300s"
-          tail -200 "${IS_HOME}/repository/logs/wso2carbon.log"
-          exit 1
-
-      - name: Verify accelerator provisioning
-        run: |
-          roles_found() {
-            curl -sk -u "${IS_ADMIN_USERNAME}:${IS_ADMIN_PASSWORD}" \
-              "${IS_BASE_URL}/scim2/v2/Roles?filter=displayName+eq+dpdp-consent-admin" \
-              | python3 -c 'import json, sys; print(json.load(sys.stdin).get("totalResults", 0))'
-          }
-          wait_for_is() {
-            for i in $(seq 1 60); do
-              curl -sk -o /dev/null -f "${IS_BASE_URL}/oauth2/jwks" && return 0
-              sleep 5
-            done
-            return 1
-          }
-
-          max_restarts=1
-          attempt=0
-          while [ "$(roles_found)" != "1" ]; do
-            if [ "${attempt}" -ge "${max_restarts}" ]; then
-              echo "::error::Accelerator did not provision dpdp-consent-admin for carbon.super after ${max_restarts} restarts"
-              grep -n "Error provisioning the DPDP Consent Portal" \
-                "${IS_HOME}/repository/logs/wso2carbon.log" || true
-              exit 1
-            fi
-            attempt=$((attempt + 1))
-            echo "::warning::dpdp-consent-admin missing after startup; restart ${attempt}/${max_restarts}"
-            "${IS_HOME}/bin/wso2server.sh" restart
-            wait_for_is || { echo "::error::Identity Server did not come back up after restart ${attempt}"; exit 1; }
-          done
-
-          if [ "${attempt}" -gt 0 ]; then
-            echo "Provisioning verified after ${attempt} restart(s)."
-          else
-            echo "Provisioning verified."
-          fi
-
-      - name: Provision test users
-        id: users
-        run: |
-          # Ephemeral - thrown away with the runner - but masked so it cannot reach a log.
-          password="$(openssl rand -base64 18 | tr -dc 'A-Za-z0-9')Aa1!"
-          echo "::add-mask::${password}"
-          echo "TEST_PASSWORD=${password}" >> "$GITHUB_ENV"
-          TEST_PASSWORD="${password}" \
-            bash dpdp-integration-test-suite/scripts/provision-test-users.sh
-
-      # tests/08-event-notifications' real webhook-delivery tests run via WEBHOOK_RECEIVER_HOST -
-      # no secret needed, see "Enable private-network webhook callbacks..." above.
-      - name: Configure the suite
-        working-directory: dpdp-integration-test-suite
-        run: |
-          cat > .env <<EOF
-          PORTAL_BASE_URL=${IS_BASE_URL}/consent-portal
-          IS_BASE_URL=${IS_BASE_URL}
-          IGNORE_HTTPS_ERRORS=true
-          TEST_USER_USERNAME=${{ steps.users.outputs.user }}
-          TEST_USER_PASSWORD=${TEST_PASSWORD}
-          TEST_CONSENT_ADMIN_USERNAME=${{ steps.users.outputs.admin }}
-          TEST_CONSENT_ADMIN_PASSWORD=${TEST_PASSWORD}
-          TEST_USER_2_USERNAME=${{ steps.users.outputs.user2 }}
-          TEST_USER_2_PASSWORD=${TEST_PASSWORD}
-          WEBHOOK_RECEIVER_HOST=${WEBHOOK_RECEIVER_HOST}
-          WEBHOOK_RECEIVER_ALLOW_PRIVATE_NETWORK=true
-          EOF
-          npm ci
-          npx playwright install --with-deps chromium
-
-      # npm ci and the browser install are already done, so run-e2e.sh skips both and
-      # just execs playwright. The github reporter adds inline annotations; the config
-      # itself only declares html.
-      - name: Run Playwright
-        working-directory: dpdp-integration-test-suite
-        run: ./run-e2e.sh --reporter=github,html
-
-      - name: Upload Playwright report
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: playwright-report
-          path: |
-            dpdp-integration-test-suite/playwright-report/
-            dpdp-integration-test-suite/test-results/
-          retention-days: 7
-
-      - name: Upload server logs
-        if: failure()
-        uses: actions/upload-artifact@v4
-        with:
-          name: carbon-logs
-          path: ${{ env.IS_HOME }}/repository/logs/
-          retention-days: 7
-
-      - name: Stop the Identity Server
-        if: always()
-        run: |
-          "${IS_HOME}/bin/wso2server.sh" stop || true
-
-  # `e2e` itself cannot be the required status check: a job skipped by its own `if:`
-  # (which is what happens on every pull_request_target event until someone applies
-  # Action/trigger-e2e) reports a "skipped" conclusion, and GitHub's branch-protection
-  # rulesets treat "skipped" as satisfying a required check - so marking `e2e` required
-  # would let every PR merge without it ever having run. This job exists purely to be
-  # the thing a ruleset actually requires: it always runs on pull_request_target
-  # (`if: always()` so a skipped `e2e` doesn't skip this too) and fails unless `e2e`
-  # itself reports success, so it's red until the label is applied and E2E passes.
-  #
-  # This job must be selected as the required status check for `main` in Settings ->
-  # Rules -> Rulesets - that repo-admin step can't be done from this workflow file.
   e2e-required:
     name: E2E integration tests (required)
     if: always() && github.event_name == 'pull_request_target'

--- a/.github/workflows/release-builder.yml
+++ b/.github/workflows/release-builder.yml
@@ -1,0 +1,499 @@
+# Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+#
+# WSO2 LLC. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# Builds the accelerator distribution and publishes it as a GitHub release.
+#
+#   prepare ─┬─ e2e ──┐
+#            └─ build ─┴─ release ── post-release
+#
+# The root pom is the single source of truth for the version - there is deliberately no
+# version.txt to drift from it. `mvn versions:set` fans the release version out to every
+# module, since each child pom inherits it through <parent> and declares none of its own.
+#
+# Convention: `v` prefix in git tags, bare semver in poms and filenames. Maven cannot
+# resolve a v-prefixed version, so the two must not be conflated.
+#
+# The release commit is published by pushing the tag alone - `git push origin
+# refs/tags/vX.Y.Z` carries the commit's objects with it - so no branch is ever written
+# to and `main` stays on -SNAPSHOT. The tagged tree is still exactly what was built.
+# That keeps the whole pipeline inside GITHUB_TOKEN's reach: it needs no repository
+# secret and no repository setting, only the `contents: write` permission declared below.
+#
+# The tag is pushed only after the build and the E2E gate have passed, so a failure
+# anywhere earlier leaves no orphan tag behind.
+name: Release builder
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Release version, bare semver (e.g. 1.0.0). Defaults to the root pom version with -SNAPSHOT stripped.'
+        required: false
+        type: string
+      next_version:
+        description: 'Next development version, bare semver (e.g. 1.1.0). Defaults to a minor bump.'
+        required: false
+        type: string
+      prerelease:
+        description: Mark the GitHub release as a pre-release
+        required: false
+        type: boolean
+        default: false
+      run_e2e:
+        description: Run the E2E suite as a release gate
+        required: false
+        type: boolean
+        default: true
+      dry_run:
+        description: Build and render everything, but do not commit, tag or publish
+        required: false
+        type: boolean
+        default: false
+
+concurrency:
+  group: release-builder
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  prepare:
+    name: Prepare
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    outputs:
+      version: ${{ steps.resolve.outputs.version }}
+      next_version: ${{ steps.resolve.outputs.next_version }}
+      tag: ${{ steps.resolve.outputs.tag }}
+      sha: ${{ steps.resolve.outputs.sha }}
+    steps:
+      # fetch-depth: 0 so the duplicate-tag check below sees every tag - it would
+      # silently pass on a shallow clone.
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - uses: actions/setup-java@v5
+        with:
+          java-version: '21'
+          distribution: temurin
+          cache: maven
+
+      - name: Resolve and validate the version
+        id: resolve
+        run: |
+          set -euo pipefail
+
+          version="${{ inputs.version }}"
+          if [ -z "${version}" ]; then
+            version=$(mvn -B -ntp -q help:evaluate -Dexpression=project.version -DforceStdout | tail -1)
+            version="${version%-SNAPSHOT}"
+          fi
+          version=$(echo "${version}" | tr -d '[:space:]')
+
+          if [[ "${version}" == v* ]]; then
+            echo "::error::Version must be bare semver with no leading 'v' - Maven cannot" \
+                 "resolve a v-prefixed version. Got '${version}'."
+            exit 1
+          fi
+          if ! [[ "${version}" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
+            echo "::error::Version '${version}' is not X.Y.Z[-qualifier]."
+            exit 1
+          fi
+
+          tag="v${version}"
+          if git rev-parse -q --verify "refs/tags/${tag}" >/dev/null 2>&1; then
+            echo "::error::Tag '${tag}' already exists."
+            exit 1
+          fi
+
+          # A full release is cut from main; anything else has to be flagged a pre-release.
+          if [ "${{ inputs.prerelease }}" != "true" ] && [ "${{ github.ref }}" != "refs/heads/main" ]; then
+            echo "::error::A full release must be built from main (got ${{ github.ref }})." \
+                 "Re-run with prerelease enabled to release from another branch."
+            exit 1
+          fi
+
+          next="${{ inputs.next_version }}"
+          if [ -z "${next}" ]; then
+            base="${version%%-*}"
+            IFS='.' read -r major minor _patch <<< "${base}"
+            next="${major}.$((minor + 1)).0"
+          fi
+          next=$(echo "${next}" | tr -d '[:space:]')
+          if ! [[ "${next}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::Next development version '${next}' is not X.Y.Z."
+            exit 1
+          fi
+
+          {
+            echo "version=${version}"
+            echo "next_version=${next}"
+            echo "tag=${tag}"
+            echo "sha=$(git rev-parse HEAD)"
+          } >> "$GITHUB_OUTPUT"
+
+          {
+            echo "### Release plan"
+            echo ""
+            echo "| | |"
+            echo "|---|---|"
+            echo "| Version | \`${version}\` |"
+            echo "| Tag | \`${tag}\` |"
+            echo "| Commit | \`$(git rev-parse --short HEAD)\` |"
+            echo "| Next development version | \`${next}-SNAPSHOT\` |"
+            echo "| Pre-release | \`${{ inputs.prerelease }}\` |"
+            echo "| Dry run | \`${{ inputs.dry_run }}\` |"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  # Gates the release on the same suite that gates a PR - see e2e.yml.
+  e2e:
+    name: E2E gate
+    needs: prepare
+    if: ${{ inputs.run_e2e }}
+    uses: ./.github/workflows/e2e.yml
+    with:
+      ref: ${{ needs.prepare.outputs.sha }}
+      is_source: master
+    secrets: inherit
+
+  build:
+    name: Build the distribution
+    needs: prepare
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ needs.prepare.outputs.sha }}
+          persist-credentials: false
+
+      - uses: actions/setup-java@v5
+        with:
+          java-version: '21'
+          distribution: temurin
+          cache: maven
+      - uses: actions/setup-node@v5
+        with:
+          node-version: '22'
+
+      - name: Set the release version
+        run: |
+          mvn -B -ntp versions:set \
+            -DnewVersion="${{ needs.prepare.outputs.version }}" \
+            -DprocessAllModules=true -DgenerateBackupPoms=false
+
+      # `mvn clean install` is the full gate on its own: unit tests, the per-module Jacoco
+      # minimum, and the frontend's tsc / security:verify / i18n:verify chain.
+      - name: Build
+        run: mvn -B clean install
+        env:
+          MAVEN_OPTS: -Xmx4g
+
+      # The zip carries the pom version in its name, so finding it at the exact expected
+      # path is also what proves versions:set reached every module.
+      - name: Collect the distribution
+        run: |
+          set -euo pipefail
+          version="${{ needs.prepare.outputs.version }}"
+          zip="dpdp-accelerator/accelerators/dpdp-is/target/wso2-dpdp-is-accelerator-${version}.zip"
+          if [ ! -f "${zip}" ]; then
+            echo "::error::Expected ${zip}, which means versions:set did not reach every module."
+            ls -1 dpdp-accelerator/accelerators/dpdp-is/target/*.zip 2>/dev/null || true
+            exit 1
+          fi
+          mkdir -p dist
+          cp "${zip}" dist/
+          ls -lh dist
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dpdp-accelerator-dist
+          path: dist/
+          if-no-files-found: error
+          retention-days: 7
+
+  release:
+    name: Publish
+    needs: [prepare, build, e2e]
+    # `always()` so a deliberately skipped E2E gate doesn't skip the release with it;
+    # the explicit result checks are what actually enforce the gate.
+    if: >
+      always() &&
+      needs.prepare.result == 'success' &&
+      needs.build.result == 'success' &&
+      (needs.e2e.result == 'success' || needs.e2e.result == 'skipped')
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: write
+    steps:
+      # Default credentials are enough: the only ref this job writes is a tag.
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ needs.prepare.outputs.sha }}
+          fetch-depth: 0
+
+      - uses: actions/setup-java@v5
+        with:
+          java-version: '21'
+          distribution: temurin
+          cache: maven
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: dpdp-accelerator-dist
+          path: dist
+
+      - name: Create the release commit
+        id: commit
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          mvn -B -ntp versions:set \
+            -DnewVersion="${{ needs.prepare.outputs.version }}" \
+            -DprocessAllModules=true -DgenerateBackupPoms=false
+
+          # -u so only tracked poms are staged, never stray build output.
+          git add -u
+          if git diff --cached --quiet; then
+            echo "Already at ${{ needs.prepare.outputs.version }} - no release commit needed."
+          else
+            git commit -m "[Release] ${{ needs.prepare.outputs.version }}"
+          fi
+          git tag -a "${{ needs.prepare.outputs.tag }}" \
+            -m "Release ${{ needs.prepare.outputs.version }}"
+          echo "release_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Generate the release notes
+        uses: actions/github-script@v7
+        env:
+          VERSION: ${{ needs.prepare.outputs.version }}
+          TAG: ${{ needs.prepare.outputs.tag }}
+        with:
+          script: |
+            const fs = require('fs');
+            const { owner, repo } = context.repo;
+            const version = process.env.VERSION;
+            const tag = process.env.TAG;
+
+            // Newest release that isn't this one bounds the auto-generated changelog.
+            let previousTag = null;
+            try {
+              const { data } = await github.rest.repos.listReleases({ owner, repo, per_page: 5 });
+              const prior = data.filter(r => r.tag_name !== tag);
+              if (prior.length > 0) previousTag = prior[0].tag_name;
+            } catch (e) {
+              core.info(`Could not list previous releases: ${e.message}`);
+            }
+
+            // Degrades to an empty changelog on the very first release, rather than failing.
+            let changelog = '';
+            try {
+              const params = { owner, repo, tag_name: tag };
+              if (previousTag) params.previous_tag_name = previousTag;
+              const { data } = await github.rest.repos.generateReleaseNotes(params);
+              changelog = (data.body || '').trim();
+            } catch (e) {
+              core.info(`Could not generate the changelog: ${e.message}`);
+            }
+
+            // Editorial highlights are handwritten - no API can infer them. Commit
+            // release-notes/<version>.md to have them appear here.
+            let highlights = '';
+            const notesPath = `release-notes/${version}.md`;
+            if (fs.existsSync(notesPath)) {
+              highlights = fs.readFileSync(notesPath, 'utf8').trim();
+            }
+
+            const zip = `wso2-dpdp-is-accelerator-${version}.zip`;
+            const dl = `https://github.com/${owner}/${repo}/releases/download/${tag}`;
+            const src = `https://github.com/${owner}/${repo}/blob/${tag}`;
+
+            const lines = [
+              `The WSO2 Solutions team is pleased to announce the release of the **WSO2 DPDP Accelerator ${version}**.`,
+              '',
+              'It contains the accelerator components installable over WSO2 Identity Server 7.3.0.',
+              '',
+              '## Distribution',
+              '',
+              '| Artifact | Download |',
+              '|---|---|',
+              `| Accelerator | [${zip}](${dl}/${zip}) |`,
+              `| Source code | [${repo}-${version}.zip](https://github.com/${owner}/${repo}/archive/refs/tags/${tag}.zip) |`,
+              '',
+              '## How to run',
+              '',
+              '```sh',
+              `unzip ${zip}`,
+              `cd wso2-dpdp-is-accelerator-${version}`,
+              'bash bin/merge.sh     <IS_HOME>',
+              'bash bin/configure.sh <IS_HOME>',
+              '```',
+              '',
+              `See the [setup guide](${src}/docs/setup-guide.md) for prerequisites and the full procedure, and the [configuration guide](${src}/docs/configuration-guide.md) for the consent portal application and roles.`,
+            ];
+
+            if (highlights) {
+              lines.push('', '## What\'s new', '', highlights);
+            }
+            if (changelog) {
+              lines.push('', '---', '', changelog);
+            }
+
+            lines.push(
+              '',
+              '## Known issues',
+              '',
+              `All open issues are tracked [here](https://github.com/${owner}/${repo}/issues).`,
+              '',
+              '## How to contribute',
+              '',
+              `Please report issues, improvements and feature requests through [GitHub issues](https://github.com/${owner}/${repo}/issues).`,
+              '',
+              'Security issues must be reported to [security@wso2.com](mailto:security@wso2.com) rather than as a GitHub issue, so they reach the right audience. Please follow the [WSO2 Security Vulnerability Reporting Guidelines](https://security.docs.wso2.com/en/latest/security-reporting/vulnerability-reporting-guidelines/).',
+              '',
+              '~ WSO2 Solutions Team ~',
+            );
+
+            const body = lines.join('\n');
+            fs.writeFileSync('release-body.md', body);
+            core.info(`Release notes rendered (${body.length} chars).`);
+
+      # Pushing the tag carries the release commit's objects with it, so the commit stays
+      # reachable through the tag without `main` ever being written to.
+      - name: Push the release tag
+        if: ${{ !inputs.dry_run }}
+        run: git push origin "refs/tags/${{ needs.prepare.outputs.tag }}"
+
+      - name: Create the GitHub release
+        if: ${{ !inputs.dry_run }}
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
+        with:
+          tag_name: ${{ needs.prepare.outputs.tag }}
+          name: WSO2 DPDP Accelerator ${{ needs.prepare.outputs.version }}
+          body_path: release-body.md
+          files: dist/*.zip
+          draft: false
+          prerelease: ${{ inputs.prerelease }}
+          generate_release_notes: false
+
+      - name: Upload the dry-run preview
+        if: ${{ inputs.dry_run }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-preview
+          path: |
+            release-body.md
+            dist/
+          if-no-files-found: error
+          retention-days: 7
+
+      - name: Summarise
+        run: |
+          if [ "${{ inputs.dry_run }}" = "true" ]; then
+            {
+              echo "### Dry run - nothing was published"
+              echo ""
+              echo "The release commit was made locally and discarded. Download the"
+              echo "\`release-preview\` artifact to review the notes and the distribution."
+            } >> "$GITHUB_STEP_SUMMARY"
+          else
+            {
+              echo "### Released ${{ needs.prepare.outputs.tag }}"
+              echo ""
+              echo "https://github.com/${{ github.repository }}/releases/tag/${{ needs.prepare.outputs.tag }}"
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+  # Raised as a PR rather than pushed: the target branch is protected, and this is the step
+  # that both reference pipelines had to disable or work around for exactly that reason.
+  post-release:
+    name: Next development version
+    needs: [prepare, release]
+    if: ${{ !inputs.dry_run }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - uses: actions/setup-java@v5
+        with:
+          java-version: '21'
+          distribution: temurin
+          cache: maven
+
+      # Pushed straight to main rather than raised as a PR: GITHUB_TOKEN cannot open one
+      # unless a repository admin has enabled "Allow GitHub Actions to create and approve
+      # pull requests", which is off by default. contents:write needs no such setting - it
+      # is the same permission that pushed the release tag. The commit only moves pom
+      # versions, which is what maven-release-plugin pushes directly too.
+      - name: Bump main to the next development version
+        env:
+          NEXT: ${{ needs.prepare.outputs.next_version }}
+          TAG: ${{ needs.prepare.outputs.tag }}
+        run: |
+          set -euo pipefail
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          mvn -B -ntp versions:set \
+            -DnewVersion="${NEXT}-SNAPSHOT" \
+            -DprocessAllModules=true -DgenerateBackupPoms=false
+
+          git add -u
+          if git diff --cached --quiet; then
+            echo "main is already at ${NEXT}-SNAPSHOT - nothing to do."
+            exit 0
+          fi
+
+          # No PR means no pull_request checks, so resolving the reactor here is the
+          # evidence that the bump left every pom consistent.
+          mvn -B -ntp -q validate
+
+          git commit -m "[Release] Prepare for the next development iteration (${NEXT}-SNAPSHOT)"
+
+          # A non-fast-forward means main moved during the release. Failing is correct, and
+          # the message below tells the operator the release itself is already published.
+          if ! git push origin "HEAD:main"; then
+            {
+              echo "### ${TAG} was released successfully"
+              echo ""
+              echo "Only the follow-up version bump failed - main could not be pushed."
+              echo "Do **not** re-run the release: the tag and the GitHub release already"
+              echo "exist, and a re-run would be rejected as a duplicate tag."
+              echo ""
+              echo "Set the next development version by hand instead:"
+              echo ""
+              echo '```sh'
+              echo "mvn versions:set -DnewVersion=${NEXT}-SNAPSHOT -DprocessAllModules=true -DgenerateBackupPoms=false"
+              echo '```'
+            } >> "$GITHUB_STEP_SUMMARY"
+            echo "::error::${TAG} is published, but bumping main to ${NEXT}-SNAPSHOT failed - see the job summary."
+            exit 1
+          fi
+
+          echo "main is now at ${NEXT}-SNAPSHOT."

--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ installation.
   delivery history.
 - [`docs/localization-guide.md`](docs/localization-guide.md) — correcting UI
   wording and localizing Purposes/Elements on a running deployment.
+- [`docs/release-guide.md`](docs/release-guide.md) — cutting a release with the
+  Release builder workflow.
 
 ## Roles
 

--- a/docs/release-guide.md
+++ b/docs/release-guide.md
@@ -1,0 +1,134 @@
+# Release guide
+
+How to cut a release of the DPDP accelerator, and what the pipeline does on your behalf.
+
+Releases are built by the **Release builder** workflow
+([`.github/workflows/release-builder.yml`](../.github/workflows/release-builder.yml)). It is
+dispatched by hand — nothing releases on a push or a merge.
+
+## What a release produces
+
+| | |
+|---|---|
+| Tag | `vX.Y.Z`, pointing at a `[Release] X.Y.Z` commit |
+| Release assets | `wso2-dpdp-is-accelerator-X.Y.Z.zip`, plus the source archives GitHub attaches to every release automatically. GitHub publishes a SHA-256 digest for each asset itself, so no checksum sidecar is uploaded |
+| Follow-up | A commit on `main` raising the reactor to the next `-SNAPSHOT` |
+
+The root `pom.xml` is the single source of truth for the version — there is deliberately no
+`version.txt` to drift from it. Every child pom inherits the version through `<parent>` and
+declares none of its own, so `mvn versions:set` fans one number out to all 17 poms.
+
+Tags carry a `v` prefix; poms and filenames use bare semver. Maven cannot resolve a
+`v`-prefixed version, so the two are never conflated — the pipeline rejects a `version`
+input that starts with `v`.
+
+## Before the first release
+
+The **Run workflow** button only appears once `release-builder.yml` is on the default
+branch (`main`). Until then there is nothing to dispatch.
+
+## Cutting a release
+
+### 1. Put `main` on the commit you want to ship
+
+The pipeline releases whatever `main` currently points at. It does no merging of its own.
+
+### 2. Optionally write the highlights
+
+Commit `release-notes/X.Y.Z.md` and its contents become the **What's new** section of the
+release body. Leave it out and that section is simply omitted; you still get the
+auto-generated changelog of merged PRs.
+
+This is the one part no API can infer, and it is where the narrative belongs — what changed
+and why it matters, rather than a list of commit subjects.
+
+### 3. Dispatch a dry run
+
+**Actions → Release builder → Run workflow**, with branch `main`.
+
+| Input | Default | Set it when |
+|---|---|---|
+| `version` | Root pom version minus `-SNAPSHOT` | Releasing something other than what the pom says |
+| `next_version` | Minor bump (`1.0.0` → `1.1.0`) | You want a patch or major bump instead |
+| `prerelease` | off | Cutting an RC, **or releasing from any branch other than `main`** |
+| `run_e2e` | on | Turn off only to make a dry run quick |
+| `dry_run` | off | **On for the first run** |
+
+With `dry_run` on, everything builds and the release notes render, but nothing is committed,
+tagged or published. Download the `release-preview` artifact and check `release-body.md`,
+the zip. Pairing it with `run_e2e: off` finishes in a few minutes.
+
+### 4. Dispatch the real run
+
+Same inputs, `dry_run` off.
+
+Budget roughly **two hours** with the E2E gate on: it builds Identity Server from
+`product-is` master, because the published-release + U2 update path is currently blocked
+upstream (the public release zip is missing the `migration-resources/` tree the update tool
+needs).
+
+### 5. Nothing — the version bump is automatic
+
+`post-release` commits the next `-SNAPSHOT` straight to `main`. It is pushed rather than raised
+as a PR because `GITHUB_TOKEN` cannot open one unless an admin has enabled *"Allow GitHub Actions
+to create and approve pull requests"*, which is off by default. Since there is no PR to carry
+checks, the job runs `mvn validate` on the bumped reactor before pushing.
+
+If that push fails, **the release itself has already succeeded** — do not re-run it, or the
+duplicate-tag guard will reject it. The job summary says so and gives the `versions:set` command
+to run by hand.
+
+## How the pipeline is put together
+
+```
+prepare ─┬─ e2e ──┐
+         └─ build ─┴─ release ── post-release
+```
+
+- **prepare** — resolves and validates the version, rejects an existing tag, and refuses a
+  non-prerelease off `main`. Everything downstream reads its outputs rather than
+  re-deriving them.
+- **e2e** — the same suite that gates a PR, via the reusable
+  [`e2e.yml`](../.github/workflows/e2e.yml). Skippable with `run_e2e: off`.
+- **build** — `versions:set`, then `mvn clean install`, then asserts the zip exists at the
+  exact expected path. That assertion is also what proves `versions:set` reached every
+  module.
+- **release** — makes the release commit, renders the notes, pushes the tag, publishes.
+- **post-release** — commits the next `-SNAPSHOT` to `main`.
+
+### Why `main` never moves
+
+The release commit is published by pushing **only the tag**. `git push origin refs/tags/vX.Y.Z`
+carries the commit's objects with it, so the commit is reachable through the tag without any
+branch being written to.
+
+The consequence to be aware of: **the release commit is not on `main`**. `git checkout vX.Y.Z`
+gives exactly the tree that produced the artifact, and `git log main` does not show the release
+commit. `main` moves to the next `-SNAPSHOT` through the post-release commit instead.
+
+This is what keeps the whole pipeline inside `GITHUB_TOKEN`'s reach — it needs no repository
+secret and no admin-flipped setting, only the `contents: write` permission declared in the
+workflow.
+
+## If a run fails
+
+Nothing is published until the tag push, which is the second-to-last step of `release`. A
+failure in `prepare`, `build` or the E2E gate leaves no tag, no release and no commit — fix
+the cause and dispatch again.
+
+Two guards fail fast, before any expensive work:
+
+- an existing tag for the requested version is rejected;
+- a non-prerelease dispatched from any branch other than `main` is rejected.
+
+## Rehearsing in a fork
+
+A fork is a reasonable place to exercise the pipeline end to end, with two caveats:
+
+- **`workflow_dispatch` needs the workflow on the fork's default branch** before the Run
+  workflow button appears.
+- **Releasing from a branch other than `main` requires `prerelease: on`**, or `prepare`
+  rejects the run by design.
+
+`post-release` pushes its version bump to the fork's own `main`, so a rehearsal moves the fork
+forward and never touches `wso2/dpdp-accelerator`.

--- a/docs/setup-guide.md
+++ b/docs/setup-guide.md
@@ -9,12 +9,16 @@ registers the portal application.
 - JDK 21 or later on the PATH
 - Maven 3.6.3+ and Node.js 20.19+ (or 22.12+) with npm, only if building the
   accelerator from source
+- A WSO2 subscription, to apply the mandatory U2 updates to the Identity Server
 
 ## 1. Get WSO2 Identity Server
 
 Download and extract WSO2 Identity Server 7.3.0 from the
 [WSO2 Identity Server](https://wso2.com/identity-and-access-management/)
 site. The extracted directory is `<IS_HOME>` in the steps below.
+
+Apply the U2 updates to the pack before going any further. The accelerator does
+not run on an un-updated 7.3.0.
 
 ## 2. Get the accelerator
 

--- a/dpdp-accelerator/components/org.wso2.dpdp.accelerator.complaint.mgt.service/pom.xml
+++ b/dpdp-accelerator/components/org.wso2.dpdp.accelerator.complaint.mgt.service/pom.xml
@@ -270,6 +270,7 @@
                             org.wso2.dpdp.accelerator.common.config;version="${project.version}",
                             org.wso2.dpdp.accelerator.common.util;version="${project.version}",
                             org.osgi.framework;version="[1.8,2)",
+                            com.fasterxml.jackson.annotation;version="${jackson.imp.pkg.version.range}",
                             *
                         </Import-Package>
                     </instructions>

--- a/dpdp-accelerator/components/org.wso2.dpdp.accelerator.event.notifications.common/pom.xml
+++ b/dpdp-accelerator/components/org.wso2.dpdp.accelerator.event.notifications.common/pom.xml
@@ -112,7 +112,10 @@
                         <Export-Package>
                             org.wso2.dpdp.accelerator.event.notifications.common.*;version="${project.version}"
                         </Export-Package>
-                        <Import-Package>*</Import-Package>
+                        <Import-Package>
+                            com.fasterxml.jackson.annotation;version="${jackson.imp.pkg.version.range}",
+                            *
+                        </Import-Package>
                     </instructions>
                 </configuration>
             </plugin>

--- a/dpdp-accelerator/components/org.wso2.dpdp.accelerator.event.notifications.service/pom.xml
+++ b/dpdp-accelerator/components/org.wso2.dpdp.accelerator.event.notifications.service/pom.xml
@@ -211,6 +211,8 @@
                             org.wso2.carbon.identity.oauth2.util;version="${carbon.identity.inbound.auth.oauth.version}",
                             com.nimbusds.jose;version="[10.0.0,11.0.0)",
                             org.osgi.framework;version="[1.8,2)",
+                            com.fasterxml.jackson.core;version="${jackson.imp.pkg.version.range}",
+                            com.fasterxml.jackson.databind;version="${jackson.imp.pkg.version.range}",
                             *
                         </Import-Package>
                     </instructions>

--- a/dpdp-integration-test-suite/fixtures/tenant.fixtures.ts
+++ b/dpdp-integration-test-suite/fixtures/tenant.fixtures.ts
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-import { type Browser, type Page, type Request, request as playwrightRequest } from '@playwright/test'
+import { type Browser, type Locator, type Page, type Request, request as playwrightRequest } from '@playwright/test'
 import { ConsentApiClient } from '../clients/ConsentApiClient'
 import { EventNotificationApiClient } from '../clients/EventNotificationApiClient'
 import { ConsoleAddUserWizard } from '../pages/ConsoleAddUserWizard'
@@ -88,20 +88,51 @@ async function fillLoginForm(page: Page, persona: Persona): Promise<void> {
  * different apps than the portal this suite's baseURL points at, so page.goto() here always
  * takes an absolute URL rather than relying on playwright.config.ts's baseURL.
  */
-async function loginToConsole(browser: Browser, consoleUrl: string, persona: Persona): Promise<Page> {
-  const context = await browser.newContext({ ignoreHTTPSErrors: env.ignoreHttpsErrors })
-  const page = await context.newPage()
-  await page.goto(consoleUrl, { waitUntil: 'domcontentloaded' })
-  await page.locator('#usernameUserInput').waitFor({ state: 'visible', timeout: 20_000 })
-  await fillLoginForm(page, persona)
-  // Deliberately not checking for a specific post-login element (e.g. the sidebar's
-  // "Applications" link): confirmed empirically that the super tenant's Root Organizations page
-  // renders with no sidebar at all (a different layout than a tenant's own Console shell), so no
-  // single element is common to every page this function is asked to land on. The login form
-  // disappearing, generically, is what every successful login has in common.
-  await page.locator('#usernameUserInput').waitFor({ state: 'hidden', timeout: 30_000 })
-  await page.waitForLoadState('networkidle', { timeout: 30_000 }).catch(() => undefined)
-  return page
+async function loginToConsole(
+  browser: Browser,
+  consoleUrl: string,
+  persona: Persona,
+  ready?: (page: Page) => Locator,
+): Promise<Page> {
+  let lastError: unknown
+
+  // Retried as a whole, with a brand-new context each attempt, because the Console's own token
+  // exchange sometimes fails server-side in a way the SPA never recovers from: IS logs
+  // "IdentityOAuth2Exception: Token binding reference cannot be retrieved from the token binder:
+  // cookie" for client CONSOLE, and the page then sits on its bootstrap spinner indefinitely -
+  // no error, no timeout of its own. Only a fresh cookie jar and a fresh authorize round clear
+  // it, so reloading the same context is not enough.
+  for (let attempt = 1; attempt <= 3; attempt += 1) {
+    const context = await browser.newContext({ ignoreHTTPSErrors: env.ignoreHttpsErrors })
+    const page = await context.newPage()
+
+    try {
+      await page.goto(consoleUrl, { waitUntil: 'domcontentloaded' })
+      await page.locator('#usernameUserInput').waitFor({ state: 'visible', timeout: 20_000 })
+      await fillLoginForm(page, persona)
+      // Deliberately not checking for a specific post-login element (e.g. the sidebar's
+      // "Applications" link): confirmed empirically that the super tenant's Root Organizations page
+      // renders with no sidebar at all (a different layout than a tenant's own Console shell), so no
+      // single element is common to every page this function is asked to land on. The login form
+      // disappearing, generically, is what every successful login has in common. A caller that DOES
+      // know what it is about to interact with passes `ready`, which is what turns the hang above
+      // into a retry instead of a fixture timeout.
+      await page.locator('#usernameUserInput').waitFor({ state: 'hidden', timeout: 30_000 })
+      await page.waitForLoadState('networkidle', { timeout: 30_000 }).catch(() => undefined)
+      if (ready) {
+        await ready(page).waitFor({ state: 'visible', timeout: 30_000 })
+      }
+      return page
+    } catch (error) {
+      lastError = error
+      await context.close()
+    }
+  }
+
+  throw new Error(
+    `Console at ${consoleUrl} never became usable for "${persona.username}" after 3 attempts: ` +
+      `${lastError instanceof Error ? lastError.message : String(lastError)}`,
+  )
 }
 
 /**
@@ -194,7 +225,12 @@ async function createTenant(browser: Browser): Promise<CreatedTenant> {
   // wizard. Confirmed live this is the only tenant-creation path whose password field works
   // immediately - see ConsoleRootOrganizationWizard's own comment for the full comparison
   // against the raw Tenant Management REST API.
-  const adminPage = await loginToConsole(browser, consoleRootOrganizationsUrl(), env.superAdmin)
+  const adminPage = await loginToConsole(
+    browser,
+    consoleRootOrganizationsUrl(),
+    env.superAdmin,
+    (page) => new ConsoleRootOrganizationWizard(page).newRootOrganizationButton,
+  )
   const rootOrgWizard = new ConsoleRootOrganizationWizard(adminPage)
   await rootOrgWizard.open()
   await rootOrgWizard.createTenant({
@@ -218,6 +254,10 @@ async function createTenant(browser: Browser): Promise<CreatedTenant> {
   // Confirmed live to succeed here even though the identical `POST .../scim2/Users` call
   // 401s when replayed directly via curl - see ConsoleAddUserWizard for the full story; this
   // suite never calls SCIM2 directly as a result.
+  // No `ready` locator passed here, unlike step 1: this login has never been observed hanging on
+  // the CONSOLE token-binding failure loginToConsole describes, and any locator picked for it
+  // would be a guess. If this step ever times out on a blank spinner, that is the same bug -
+  // pass the first element the wizard below touches (ConsoleAddUserWizard's addUserButton).
   const ownerConsolePage = await loginToConsole(browser, tenantConsoleUrl(domain), owner)
   await ownerConsolePage.goto(`${tenantConsoleUrl(domain)}/users`, { waitUntil: 'domcontentloaded' })
   const addUserWizard = new ConsoleAddUserWizard(ownerConsolePage)
@@ -285,8 +325,10 @@ export const test = base.extend<object, WorkerFixtures>({
       await dispose()
     },
     // This setup chains three separate browser logins plus several UI wizards - the default
-    // fixture timeout (tied to a single test's own timeout, 30s) is nowhere near enough.
-    { scope: 'worker', timeout: 120_000 },
+    // fixture timeout (tied to a single test's own timeout, 30s) is nowhere near enough. 120s was
+    // enough when 05.10 ran on its own but not with the full suite in flight: the Console login
+    // alone budgets 80s of waits, and the worker that owns this fixture also pays for tenantB.
+    { scope: 'worker', timeout: 240_000 },
   ],
 
   // Only tests/08-event-notifications/05.10-event-tenant-isolation.spec.ts requests this fixture
@@ -298,7 +340,7 @@ export const test = base.extend<object, WorkerFixtures>({
       await use(context)
       await dispose()
     },
-    { scope: 'worker', timeout: 120_000 },
+    { scope: 'worker', timeout: 240_000 },
   ],
 })
 

--- a/dpdp-integration-test-suite/fixtures/tenant.fixtures.ts
+++ b/dpdp-integration-test-suite/fixtures/tenant.fixtures.ts
@@ -186,8 +186,9 @@ interface CreatedTenant {
  */
 async function createTenant(browser: Browser): Promise<CreatedTenant> {
   const domain = uniqueTenantDomain()
-  const owner: Persona = { username: uniqueMarker('tenant-owner'), password: 'TenantOwner@2026!' }
-  const consentUser: Persona = { username: uniqueMarker('tenant-user'), password: 'TenantUser@2026!' }
+  // Email-shaped: the accelerator enforces an email-address username.
+  const owner: Persona = { username: `${uniqueMarker('tenant-owner')}@dpdp.test`, password: 'TenantOwner@2026!' }
+  const consentUser: Persona = { username: `${uniqueMarker('tenant-user')}@dpdp.test`, password: 'TenantUser@2026!' }
 
   // Step 1: super admin creates the tenant + owner through Console's "New Root Organization"
   // wizard. Confirmed live this is the only tenant-creation path whose password field works
@@ -201,7 +202,7 @@ async function createTenant(browser: Browser): Promise<CreatedTenant> {
     firstName: 'Tenant',
     lastName: 'Owner',
     username: owner.username,
-    email: `${owner.username}@${domain}`,
+    email: owner.username,
     password: owner.password,
   })
   // Provisioning itself is synchronous (confirmed live: the accelerator's onTenantCreate
@@ -222,7 +223,7 @@ async function createTenant(browser: Browser): Promise<CreatedTenant> {
   const addUserWizard = new ConsoleAddUserWizard(ownerConsolePage)
   await addUserWizard.createUser({
     username: consentUser.username,
-    email: `${consentUser.username}@${domain}`,
+    email: consentUser.username,
     firstName: 'Tenant',
     lastName: 'User',
     password: consentUser.password,

--- a/dpdp-integration-test-suite/pages/AdminConsentPage.ts
+++ b/dpdp-integration-test-suite/pages/AdminConsentPage.ts
@@ -17,6 +17,7 @@
  */
 
 import { type Locator, type Page } from '@playwright/test'
+import { submitFilterValue } from '../utils/filterCommit'
 import { ConsentRegistryTable } from './ConsentRegistryTable'
 
 /** AdminConsentRegistryPage.tsx - the admin view of every subject's consents. */
@@ -36,8 +37,15 @@ export class AdminConsentPage extends ConsentRegistryTable {
   }
 
   async searchByConsentId(consentId: string): Promise<void> {
-    await this.consentIdSearch.fill(consentId)
-    await this.consentIdSearch.press('Enter')
+    await submitFilterValue(
+      this.page,
+      this.consentIdSearch,
+      async () => {
+        await this.consentIdSearch.press('Enter')
+      },
+      'consentId',
+      consentId,
+    )
   }
 
   async openAdvancedFilters(): Promise<void> {

--- a/dpdp-integration-test-suite/pages/ConsoleAddUserWizard.ts
+++ b/dpdp-integration-test-suite/pages/ConsoleAddUserWizard.ts
@@ -56,19 +56,24 @@ export class ConsoleAddUserWizard {
   constructor(page: Page) {
     this.addUserButton = page.getByRole('button', { name: 'Add User' })
     this.singleUserOption = page.getByText('Single User', { exact: true })
-    // Not `getByRole('dialog')` - confirmed live this wizard is a Semantic UI modal with no
-    // `role="dialog"` (unlike ConsoleRootOrganizationWizard's dialog, which is a different,
-    // MUI-based component) - a role-based locator here silently never matches anything.
-    this.root = page.locator('.ui.modal').filter({ hasText: 'Create User' })
-    this.usernameField = this.root.getByPlaceholder('Enter the username')
-    this.emailField = this.root.getByPlaceholder('Enter the email address')
-    this.firstNameField = this.root.getByPlaceholder('Enter the first name')
-    this.lastNameField = this.root.getByPlaceholder('Enter the last name')
-    this.setPasswordOption = this.root.getByText('Set a password for the user', { exact: true })
-    this.passwordField = this.root.locator('input[type="password"]')
-    this.nextButton = this.root.getByRole('button', { name: 'Next' })
-    this.saveAndContinueButton = this.root.getByRole('button', { name: 'Save & Continue' })
-    this.closeButton = this.root.getByRole('button', { name: 'Close' })
+    // Unscoped, unlike the rest of this suite's page objects: the wizard carries neither
+    // `role="dialog"` nor the Semantic UI `.ui.modal` class it used to, so there is no stable
+    // container to hang the fields off. Its placeholders are unique on the Users page while it
+    // is open, which is what makes page-level locators safe here.
+    this.root = page.getByText('Follow the steps to create a new user.')
+    // One field, not two: Console now labels it "Username (Email)" and the accelerator
+    // enforces an email-address username, so the separate username input is gone.
+    this.usernameField = page.getByPlaceholder('Enter the email address')
+    this.emailField = this.usernameField
+    this.firstNameField = page.getByPlaceholder('Enter the first name')
+    this.lastNameField = page.getByPlaceholder('Enter the last name')
+    this.setPasswordOption = page.getByText('Set a password for the user', { exact: true })
+    this.passwordField = page.getByPlaceholder('Enter the password')
+    // exact: the Users table's pagination has a "Next Page" button that a substring match
+    // also resolves to.
+    this.nextButton = page.getByRole('button', { name: 'Next', exact: true })
+    this.saveAndContinueButton = page.getByRole('button', { name: 'Save & Continue' })
+    this.closeButton = page.getByRole('button', { name: 'Close', exact: true })
   }
 
   async open(): Promise<void> {
@@ -79,8 +84,9 @@ export class ConsoleAddUserWizard {
   /** Fills every Basic Details field, including the two easy-to-miss ones: Last Name and the
    * explicit-password option (the wizard defaults to emailing an invitation instead). */
   async fillBasicDetails(fields: NewUserFields): Promise<void> {
+    // username and email are the same field now; fields.email is kept in the interface so
+    // callers need not change, but filling it twice would just overwrite the same input.
     await this.usernameField.fill(fields.username)
-    await this.emailField.fill(fields.email)
     await this.firstNameField.fill(fields.firstName)
     await this.lastNameField.fill(fields.lastName)
     await this.setPasswordOption.click()

--- a/dpdp-integration-test-suite/pages/EventsPage.ts
+++ b/dpdp-integration-test-suite/pages/EventsPage.ts
@@ -17,6 +17,7 @@
  */
 
 import { type Locator, type Page } from '@playwright/test'
+import { submitFilterValue } from '../utils/filterCommit'
 
 export const ROWS_PER_PAGE_OPTIONS = [10, 20, 50] as const
 
@@ -68,13 +69,27 @@ export class EventsPage {
   }
 
   async search(term: string): Promise<void> {
-    await this.searchInput.fill(term)
-    await this.searchButton.click()
+    await submitFilterValue(
+      this.page,
+      this.searchInput,
+      async () => {
+        await this.searchButton.click()
+      },
+      'search',
+      term,
+    )
   }
 
   async filterByGroupId(groupId: string): Promise<void> {
-    await this.groupIdInput.fill(groupId)
-    await this.searchButton.click()
+    await submitFilterValue(
+      this.page,
+      this.groupIdInput,
+      async () => {
+        await this.searchButton.click()
+      },
+      'groupId',
+      groupId,
+    )
   }
 
   async filterByStatus(

--- a/dpdp-integration-test-suite/pages/MyConsentPage.ts
+++ b/dpdp-integration-test-suite/pages/MyConsentPage.ts
@@ -18,6 +18,7 @@
 
 import { type Locator, type Page } from '@playwright/test'
 import { selectMuiOption } from '../utils/muiSelect'
+import { submitFilterValue } from '../utils/filterCommit'
 import { ConsentRegistryTable } from './ConsentRegistryTable'
 
 /** A user's own consent list at /consents, labelled "My Consents" in the sidebar. */
@@ -40,8 +41,15 @@ export class MyConsentPage extends ConsentRegistryTable {
   }
 
   async searchByService(serviceId: string): Promise<void> {
-    await this.serviceSearch.fill(serviceId)
-    await this.serviceSearch.press('Enter')
+    await submitFilterValue(
+      this.page,
+      this.serviceSearch,
+      async () => {
+        await this.serviceSearch.press('Enter')
+      },
+      'serviceId',
+      serviceId,
+    )
   }
 
   async filterByState(stateLabel: string): Promise<void> {

--- a/dpdp-integration-test-suite/pages/SubscriptionsPage.ts
+++ b/dpdp-integration-test-suite/pages/SubscriptionsPage.ts
@@ -17,6 +17,7 @@
  */
 
 import { type Locator, type Page } from '@playwright/test'
+import { submitFilterValue } from '../utils/filterCommit'
 
 export const ROWS_PER_PAGE_OPTIONS = [10, 20, 50] as const
 
@@ -69,8 +70,15 @@ export class SubscriptionsPage {
   }
 
   async search(term: string): Promise<void> {
-    await this.searchInput.fill(term)
-    await this.searchButton.click()
+    await submitFilterValue(
+      this.page,
+      this.searchInput,
+      async () => {
+        await this.searchButton.click()
+      },
+      'search',
+      term,
+    )
   }
 
   async filterByStatus(label: 'All Statuses' | 'Pending' | 'Active' | 'Stale' | 'Deleted'): Promise<void> {

--- a/dpdp-integration-test-suite/pages/TopicsPage.ts
+++ b/dpdp-integration-test-suite/pages/TopicsPage.ts
@@ -17,6 +17,7 @@
  */
 
 import { type Locator, type Page } from '@playwright/test'
+import { submitFilterValue } from '../utils/filterCommit'
 
 /** The only real rows-per-page values TopicTable.tsx/CursorPaginationFooter accept - not the spreadsheet's "25". */
 export const ROWS_PER_PAGE_OPTIONS = [10, 20, 50] as const
@@ -73,8 +74,15 @@ export class TopicsPage {
   }
 
   async search(term: string): Promise<void> {
-    await this.searchInput.fill(term)
-    await this.searchButton.click()
+    await submitFilterValue(
+      this.page,
+      this.searchInput,
+      async () => {
+        await this.searchButton.click()
+      },
+      'search',
+      term,
+    )
   }
 
   /** Fires immediately on selection - TopicFilters.tsx applies status without a separate Search click. */

--- a/dpdp-integration-test-suite/scripts/provision-test-users.sh
+++ b/dpdp-integration-test-suite/scripts/provision-test-users.sh
@@ -53,9 +53,12 @@ IGNORE_HTTPS_ERRORS="${IGNORE_HTTPS_ERRORS:-true}"
 # it holds only internal_login. dpdp-consent-user carries zero permissions (it is
 # created with an empty permission list), so assigning it grants no scopes and cannot
 # perturb those assertions - it is assigned only to mirror the documented setup.
-USER_NAME="dpdp-ci-user"
-USER_2_NAME="dpdp-ci-user-2"
-ADMIN_NAME="dpdp-ci-admin"
+# Email-shaped because the accelerator enforces it: the username regex is
+# ^[a-zA-Z0-9._-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,4}$, so a bare "dpdp-ci-user" is
+# rejected with SCIM2 31301 and provisioning aborts.
+USER_NAME="dpdp-ci-user@dpdp.test"
+USER_2_NAME="dpdp-ci-user-2@dpdp.test"
+ADMIN_NAME="dpdp-ci-admin@dpdp.test"
 USER_ROLE="dpdp-consent-user"
 ADMIN_ROLE="dpdp-consent-admin"
 
@@ -116,7 +119,7 @@ print(json.dumps({
     "userName": os.environ["UN"],
     "password": os.environ["TP"],
     "name": {"givenName": "DPDP", "familyName": "CI"},
-    "emails": [{"primary": True, "value": os.environ["UN"] + "@dpdp.test"}],
+    "emails": [{"primary": True, "value": os.environ["UN"]}],
 }))
 ')
   response=$(api -X POST "${IS_BASE_URL}/scim2/Users" \

--- a/dpdp-integration-test-suite/tests/07-complaints/05.08-complaints-authorization.spec.ts
+++ b/dpdp-integration-test-suite/tests/07-complaints/05.08-complaints-authorization.spec.ts
@@ -30,10 +30,11 @@ import { AppSidebarPage } from '../../pages/AppSidebarPage'
  * renders just "Complaints" (nested under the "Administration" category, alongside
  * `sidebar.adminConsents` - not "Complaint Management" as the key's own name might suggest).
  *
- * Because "the officer" is any `dpdp-consent-admin` member (see 05.05's header comment), the
- * Consent Admin persona carries every `portal:complaints:*` scope, self included - so its sidebar
- * shows BOTH complaint entries, and it can reach /complaint-management directly. There is no
- * persona in this suite that holds COMPLAINTS_READ_SELF without also holding COMPLAINTS_READ_ANY.
+ * The two entries never appear together for either persona: DPDPIdentityExtensionTenantMgtListener
+ * routes every `:self` complaint scope to `dpdp-consent-user` and every `:any` one to
+ * `dpdp-consent-admin`, so an admin-only account sees "Complaints" and not "My Complaints" - the
+ * same split 04.02's sidebar tests assert for "My Consents" vs "All Consents". An operator who
+ * wants both grants the account both roles; no persona in this suite does.
  */
 test.describe('Complaints route-level access control and sidebar visibility (UI)', () => {
   test('05.08.01 - A Data Principal navigating directly to /complaints is not redirected away', async ({
@@ -67,7 +68,7 @@ test.describe('Complaints route-level access control and sidebar visibility (UI)
     await dataPrincipalPage.context().close()
   })
 
-  test('05.08.04 - A Consent Admin can reach /complaint-management directly, and their sidebar shows both complaint entries', async ({
+  test('05.08.04 - A Consent Admin can reach /complaint-management directly, and their sidebar shows "Complaints", not "My Complaints"', async ({
     browser,
   }) => {
     const consentAdminPage = await loginAsConsentAdmin(browser)
@@ -75,8 +76,8 @@ test.describe('Complaints route-level access control and sidebar visibility (UI)
     await expect(consentAdminPage).toHaveURL(/\/complaint-management$/)
 
     const sidebar = new AppSidebarPage(consentAdminPage)
-    await expect(sidebar.label('My Complaints')).toBeVisible()
     await expect(sidebar.label('Complaints')).toBeVisible()
+    await expect(sidebar.label('My Complaints')).toHaveCount(0)
     await consentAdminPage.context().close()
   })
 })

--- a/dpdp-integration-test-suite/tests/08-event-notifications/05.02-admin-viewing-searching-topics.spec.ts
+++ b/dpdp-integration-test-suite/tests/08-event-notifications/05.02-admin-viewing-searching-topics.spec.ts
@@ -63,9 +63,12 @@ test.describe('Admin viewing and searching Topics', () => {
       await topicsPage.search(uniqueSuffix)
 
       await expect(topicsPage.rowByName(topic.name)).toBeVisible()
-      for (const row of await topicsPage.rows.all()) {
-        await expect(row).toContainText(uniqueSuffix)
-      }
+      // One assertion over a filtered locator, never a loop over `rows.all()`: .all() snapshots
+      // whatever rows exist at that instant, and the row it hands back can be gone before the
+      // assertion on it runs - the search's own refetch is still narrowing the table, and
+      // rowByName above cannot gate that, since the sought row is present both before and after.
+      // CI failed exactly this way, twice: "rows.nth(1) ... element(s) not found".
+      await expect(topicsPage.rows.filter({ hasNotText: uniqueSuffix })).toHaveCount(0)
     } finally {
       await page.context().close()
     }

--- a/dpdp-integration-test-suite/tests/08-event-notifications/05.04-admin-viewing-subscriptions.spec.ts
+++ b/dpdp-integration-test-suite/tests/08-event-notifications/05.04-admin-viewing-subscriptions.spec.ts
@@ -106,6 +106,8 @@ test.describe('Admin viewing Subscriptions', () => {
       // can't resolve out of order and leave the table on a stale intermediate combination (see
       // 05.02.04's identical fix for the full explanation). webhookSub (search already narrows to
       // it) becoming visible is real, verifiable proof each filter change actually took effect.
+      // The searches themselves are checkpointed inside SubscriptionsPage.search() rather than
+      // here - a row assertion can't stand in for one, see utils/filterCommit.ts.
       await subscriptionsPage.filterByStatus('All Statuses')
       await expect(subscriptionsPage.rowBySubscriptionId(webhookSub.subscriptionId)).toBeVisible()
       await subscriptionsPage.filterByDeliveryMode('Webhook')

--- a/dpdp-integration-test-suite/utils/filterCommit.ts
+++ b/dpdp-integration-test-suite/utils/filterCommit.ts
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import { expect, type Locator, type Page } from '@playwright/test'
+
+/**
+ * Fills a filter's text input and submits it, then waits for the URL to actually carry the value.
+ *
+ * Every filtered list page (SubscriptionsPage.tsx, TopicsPage.tsx, EventsPage.tsx, both consent
+ * registries) renders its filter bar with `key={searchParams.toString()}`, and the filter component
+ * seeds its own input from `useState(filters.<field>)`. So each committed submit REMOUNTS the whole
+ * filter bar and resets every input back to whatever the URL says. A `fill()` that lands in the
+ * window between a previous submit and its remount is silently discarded, and the submit that
+ * follows sends the OLD term - the list then looks filtered, just by the wrong value.
+ *
+ * Asserting on the resulting rows does not close that window: the row a test is looking for is
+ * usually in the unfiltered list too, so the assertion passes instantly against stale content. The
+ * URL is the only signal that the submit really committed - and because the remount key IS the
+ * query string, it is also the only way to know the remount is done.
+ *
+ * So the whole interaction retries as a unit: fill, re-read the input to catch a remount that wiped
+ * it, submit, and require the URL to carry the value. Re-filling is harmless - a committed submit
+ * leaves the input holding exactly this value anyway. Always route a fill-then-submit filter
+ * interaction through this.
+ */
+export async function submitFilterValue(
+  page: Page,
+  input: Locator,
+  submit: () => Promise<void>,
+  param: string,
+  value: string,
+): Promise<void> {
+  const expected = value.trim()
+
+  await expect(async () => {
+    await input.fill(value)
+    expect(await input.inputValue(), 'a remount reset the filter input before it was submitted')
+      .toBe(value)
+    await submit()
+    await page.waitForURL(
+      (url) => (new URL(url.toString()).searchParams.get(param) ?? '') === expected,
+      { timeout: 3_000 },
+    )
+  }).toPass({ intervals: [250, 500, 1_000], timeout: 20_000 })
+}

--- a/dpdp-integration-test-suite/utils/throwawayUser.ts
+++ b/dpdp-integration-test-suite/utils/throwawayUser.ts
@@ -54,7 +54,8 @@ export async function createThrowawayUser(
   usernamePrefix: string,
 ): Promise<ThrowawayUser> {
   // Unique per run: a leftover account from an interrupted run must not collide with this one.
-  const username = `${usernamePrefix}-${Date.now().toString(36)}`
+  // Email-shaped because the accelerator enforces it - SCIM2 rejects a bare name with 31301.
+  const username = `${usernamePrefix}-${Date.now().toString(36)}@dpdp.test`
   const password = `Throwaway#${Math.random().toString(36).slice(2, 10)}A1`
 
   const response = await fetch(scim2UsersUrl(''), {
@@ -67,7 +68,8 @@ export async function createThrowawayUser(
       userName: username,
       password,
       name: { givenName: 'Throwaway', familyName: 'Account' },
-      emails: [{ primary: true, value: `${username}@dpdp-e2e.invalid` }],
+      // The username is already an address; appending a domain again is rejected.
+      emails: [{ primary: true, value: username }],
     }),
     signal: AbortSignal.timeout(20_000),
   })

--- a/pom.xml
+++ b/pom.xml
@@ -590,6 +590,13 @@
         <quartz.version>2.3.2.wso2v1</quartz.version>
         <gson.version>2.9.0</gson.version>
         <gson.imp.pkg.version.range>[2.8.0, 3.0.0)</gson.imp.pkg.version.range>
+        <!-- Jackson ships as a family and moves together, but not at the same version on every
+             pack the accelerator has to run on: a U2-updated IS 7.3.0 (the supported target) has
+             2.21.x, while an IS built from product-is master - which the E2E workflow does - has
+             2.18.6. One range spans both. Leaving these to the trailing `*` instead makes bnd
+             derive each floor from the build-time version, welding the bundles to whichever pack
+             they were built against. -->
+        <jackson.imp.pkg.version.range>[2.13.0, 3.0.0)</jackson.imp.pkg.version.range>
 
         <!-- Match the exact jars in <IS_HOME>/lib/runtimes/cxf3/ - that directory backs the
              "CXF3" webapp-classloading environment our endpoint webapp declares, so it must


### PR DESCRIPTION
Adds a GitHub Actions release pipeline, plus two fixes without which it cannot be
demonstrated working.

## Release pipeline

`release-builder.yml`, dispatched by hand:

```
prepare ─┬─ e2e ──┐
         └─ build ─┴─ release ── post-release
```

- The root pom stays the single source of truth for the version — deliberately no
  `version.txt` to drift from it. `mvn versions:set` fans the release version out to every
  pom, since each child inherits it through `<parent>` and declares none of its own.
- The release commit is published by **pushing the tag alone** — `git push origin
  refs/tags/vX.Y.Z` carries the commit's objects with it. No branch is written to during the
  release, so the pipeline needs no repository secret and no admin-flipped setting, only
  `contents: write`. The tagged tree is still exactly what was built.
- The tag is pushed only after the build and the E2E gate pass, so an earlier failure leaves
  no orphan tag behind.
- `post-release` pushes the next `-SNAPSHOT` straight to `main`. `GITHUB_TOKEN` cannot open a
  pull request unless an admin has enabled *"Allow GitHub Actions to create and approve pull
  requests"*, which is off by default.
- A `dry_run` input renders the notes and builds the distribution without publishing anything.

The E2E job moves out of `pr-checks.yml` into a reusable `e2e.yml` so the release gate and the
PR gate exercise the same path. The body is a straight lift of the current inline job, with
three deliberate differences:

1. the checkout is parameterised;
2. the unpacked accelerator directory derives from the zip rather than a hardcoded
   `ACCELERATOR_VERSION`, which would have broken E2E the moment the pom version changed;
3. the private-network webhook step is omitted, because the script it calls
   (`scripts/enable-webhook-callbacks.sh`) is not in the repository — see the comment there
   for why nothing is lost today and where to re-add it.

Documented in `docs/release-guide.md`.

## Jackson import ranges (`63cf137`)

The bundles reached `com.fasterxml.jackson.*` through a trailing `*`, so bnd derived each
version floor from whatever Maven resolved at build time and welded them to 2.21 — the version
a U2-updated IS 7.3.0 carries. An IS built from `product-is` master, which the E2E workflow
does, ships the whole family at 2.18.6. `event.notifications.common`,
`event.notifications.service` and `complaint.mgt.service` therefore failed to resolve there and
took `identity.extensions` down with them — which surfaced only as E2E reporting the
consent-admin role unprovisioned, four steps from the cause.

One shared range, `[2.13.0, 3.0.0)`, spans both packs. The three modules are fixed together
deliberately: OSGi reports only the first unresolved import in a dependency chain, so fixing one
at a time just uncovers the next.

Also notes in the setup guide that the U2 update is mandatory — the bundles do not resolve on an
un-updated 7.3.0 either.

## Email-shaped usernames in the integration suite (`15259e5`)

The username validator added recently on `main` rejects non-email usernames, and the suite
predates it. `provision-test-users.sh` aborts on its first account with SCIM2 31301, so **CI
cannot get past user provisioning at all today**. The throwaway account for the self-deletion
tests and both tenant personas fail the same way.

Each of those sites also built its email by appending a domain to the username, which
double-domains once the username is itself an address — that second fault only appeared once the
first was fixed.

This is arguably a separate PR, but the release pipeline's E2E gate cannot be shown working
without it.

## Testing

- `mvn clean install` — BUILD SUCCESS, no test failures.
- All four Jackson imports verified as `[2.13.0,3.0.0)` in the **built manifests**, not just the poms.
- `e2e.yml` diffed step-by-step against the current inline job: 22 → 21 steps, only the three
  deviations above.
- Full release pipeline run end to end on a fork, including the E2E gate against a
  `product-is` master build: tag, release and asset all published.
- E2E on a freshly deployed, U2-updated 7.3.0: **140 of 155 pass**, up from 4 before these fixes.

## Known-failing, not addressed here

- 8 of the remaining 15 failures are one shared `tenant` fixture timing out on the Console's
  Create User modal. That is product Console UI, broken by the username validator; it needs
  whoever owns that change.
- `scripts/enable-webhook-callbacks.sh` is still missing, so `main`'s own `pr-checks.yml` will
  fail at that step until it lands. This PR removes the dead call from the pipeline it touches
  but does not invent the script.
