### PR TITLE
Rename accelerator distribution artifact to `wso2-dpdpiam-accelerator`

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -210,9 +210,9 @@ jobs:
 
       - name: Apply the accelerator
         run: |
-          zip_path=$(find dpdp-accelerator/accelerators/dpdp-is/target -maxdepth 1 -name "wso2-dpdp-is-accelerator-*.zip" | head -1)
+          zip_path=$(find dpdp-accelerator/accelerators/dpdp-is/target -maxdepth 1 -name "wso2-dpdpiam-accelerator-*.zip" | head -1)
           if [ -z "${zip_path}" ]; then
-            echo "::error::No wso2-dpdp-is-accelerator-*.zip under dpdp-accelerator/accelerators/dpdp-is/target"
+            echo "::error::No wso2-dpdpiam-accelerator-*.zip under dpdp-accelerator/accelerators/dpdp-is/target"
             exit 1
           fi
           unzip -q "${zip_path}" -d "$IS_HOME"

--- a/.github/workflows/release-builder.yml
+++ b/.github/workflows/release-builder.yml
@@ -211,7 +211,7 @@ jobs:
         run: |
           set -euo pipefail
           version="${{ needs.prepare.outputs.version }}"
-          zip="dpdp-accelerator/accelerators/dpdp-is/target/wso2-dpdp-is-accelerator-${version}.zip"
+          zip="dpdp-accelerator/accelerators/dpdp-is/target/wso2-dpdpiam-accelerator-${version}.zip"
           if [ ! -f "${zip}" ]; then
             echo "::error::Expected ${zip}, which means versions:set did not reach every module."
             ls -1 dpdp-accelerator/accelerators/dpdp-is/target/*.zip 2>/dev/null || true
@@ -323,7 +323,7 @@ jobs:
               highlights = fs.readFileSync(notesPath, 'utf8').trim();
             }
 
-            const zip = `wso2-dpdp-is-accelerator-${version}.zip`;
+            const zip = `wso2-dpdpiam-accelerator-${version}.zip`;
             const dl = `https://github.com/${owner}/${repo}/releases/download/${tag}`;
             const src = `https://github.com/${owner}/${repo}/blob/${tag}`;
 
@@ -343,7 +343,7 @@ jobs:
               '',
               '```sh',
               `unzip ${zip}`,
-              `cd wso2-dpdp-is-accelerator-${version}`,
+              `cd wso2-dpdpiam-accelerator-${version}`,
               'bash bin/merge.sh     <IS_HOME>',
               'bash bin/configure.sh <IS_HOME>',
               '```',

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,7 @@ parents to the root pom, matching the Financial Services accelerator layout), so
 `dpdp-accelerator/` silently skips the accelerator zip and only builds the portal. See
 [`README.md`](README.md) for more background on prerequisites.
 
-Output: `dpdp-accelerator/accelerators/dpdp-is/target/wso2-dpdp-is-accelerator-<version>.zip`
+Output: `dpdp-accelerator/accelerators/dpdp-is/target/wso2-dpdpiam-accelerator-<version>.zip`
 
 ### Tests
 
@@ -61,7 +61,7 @@ frontend/ (Vite SPA)
   └─ npm run build → frontend/dist (incl. generated index.jsp/home.jsp/auth.jsp)
       └─ consent-portal.war  (war plugin, webResources = frontend/dist, webXml = ./web.xml)
           └─ unzipped by accelerators/dpdp-is antrun `create-solution` into carbon-home/
-              └─ wso2-dpdp-is-accelerator-<version>.zip
+              └─ wso2-dpdpiam-accelerator-<version>.zip
                   ├─ bin/merge.sh <IS_HOME>      copies carbon-home/* over the product
                   └─ bin/configure.sh <IS_HOME>  installs deployment.toml, runs consent DB migration
 ```

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ mvn clean install
 ```
 
 This builds the consent portal (frontend + backend WAR) and packages
-`wso2-dpdp-is-accelerator-<version>.zip` under
+`wso2-dpdpiam-accelerator-<version>.zip` under
 `dpdp-accelerator/accelerators/dpdp-is/target/` — ready to unzip inside
 `<IS_HOME>`. See [`docs/setup-guide.md`](docs/setup-guide.md) for
 installation.

--- a/docs/release-guide.md
+++ b/docs/release-guide.md
@@ -11,7 +11,7 @@ dispatched by hand — nothing releases on a push or a merge.
 | | |
 |---|---|
 | Tag | `vX.Y.Z`, pointing at a `[Release] X.Y.Z` commit |
-| Release assets | `wso2-dpdp-is-accelerator-X.Y.Z.zip`, plus the source archives GitHub attaches to every release automatically. GitHub publishes a SHA-256 digest for each asset itself, so no checksum sidecar is uploaded |
+| Release assets | `wso2-dpdpiam-accelerator-X.Y.Z.zip`, plus the source archives GitHub attaches to every release automatically. GitHub publishes a SHA-256 digest for each asset itself, so no checksum sidecar is uploaded |
 | Follow-up | A commit on `main` raising the reactor to the next `-SNAPSHOT` |
 
 The root `pom.xml` is the single source of truth for the version — there is deliberately no

--- a/docs/setup-guide.md
+++ b/docs/setup-guide.md
@@ -22,7 +22,7 @@ not run on an un-updated 7.3.0.
 
 ## 2. Get the accelerator
 
-Either download a released `wso2-dpdp-is-accelerator-<version>.zip`, or build
+Either download a released `wso2-dpdpiam-accelerator-<version>.zip`, or build
 it from source:
 
 ```sh
@@ -30,7 +30,7 @@ mvn clean install
 ```
 
 Run from the repository root — this produces
-`dpdp-accelerator/accelerators/dpdp-is/target/wso2-dpdp-is-accelerator-<version>.zip`.
+`dpdp-accelerator/accelerators/dpdp-is/target/wso2-dpdpiam-accelerator-<version>.zip`.
 See the [repository README](../README.md#build) for details.
 
 ## 3. Extract the accelerator

--- a/dpdp-accelerator/accelerators/dpdp-is/pom.xml
+++ b/dpdp-accelerator/accelerators/dpdp-is/pom.xml
@@ -25,7 +25,7 @@
         <relativePath>../pom.xml</relativePath>
     </parent>
 
-    <artifactId>wso2-dpdp-is-accelerator</artifactId>
+    <artifactId>wso2-dpdpiam-accelerator</artifactId>
     <packaging>pom</packaging>
     <name>WSO2 DPDP Accelerator - Identity Server Accelerator</name>
 

--- a/dpdp-accelerator/accelerators/dpdp-is/src/assembly/bin.xml
+++ b/dpdp-accelerator/accelerators/dpdp-is/src/assembly/bin.xml
@@ -20,7 +20,7 @@
           xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 http://maven.apache.org/xsd/assembly-1.1.2.xsd">
     <id>dpdp.is.accelerator</id>
     <includeBaseDirectory>true</includeBaseDirectory>
-    <baseDirectory>wso2-dpdp-is-accelerator-${project.version}</baseDirectory>
+    <baseDirectory>wso2-dpdpiam-accelerator-${project.version}</baseDirectory>
 
     <formats>
         <format>zip</format>


### PR DESCRIPTION
## Summary

The built distribution zip was named `wso2-dpdp-is-accelerator-<version>.zip`, which doesn't
match the naming convention used by the WSO2 Financial Services / Open Banking accelerator this
project otherwise follows. Checked against `wso2/financial-services-accelerator`'s actual poms:

- Their IS-based module (`fs-is`) has artifactId `wso2-fsiam-accelerator`
- Their APIM-based module (`fs-apim`) has artifactId `wso2-fsam-accelerator`

The pattern is `wso2-<product><platform-acronym>-accelerator` — the platform is abbreviated
(`iam`, `am`), not spelled out, with no separating hyphen. Our `wso2-dpdp-is-accelerator` broke
that pattern on both counts (spelled-out `is`, extra hyphen). This renames it to
`wso2-dpdpiam-accelerator` to match.

## Changes

- `dpdp-accelerator/accelerators/dpdp-is/pom.xml` — module `artifactId`
- `dpdp-accelerator/accelerators/dpdp-is/src/assembly/bin.xml` — zip's internal `baseDirectory`
- `.github/workflows/e2e.yml`, `.github/workflows/release-builder.yml` — updated the zip filename
  CI looks for
- `README.md`, `CLAUDE.md`, `docs/setup-guide.md`, `docs/release-guide.md` — updated references

The module directory itself (`accelerators/dpdp-is/`) is unchanged — this only renames the build
output artifact, not the source layout, so no aggregation/module-path wiring elsewhere needed
touching.

## Test plan

- [x] `mvn clean package` on the module produces `wso2-dpdpiam-accelerator-1.0.0-SNAPSHOT.zip`
- [x] Verified the zip's internal top-level directory is also renamed
      (`wso2-dpdpiam-accelerator-1.0.0-SNAPSHOT/`)
- [ ] CI (`e2e.yml`, `release-builder.yml`) picks up the new filename on this PR