### PR TITLE
Stop the master-build E2E path from testing the source distribution

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -195,26 +195,64 @@ jobs:
         env:
           MAVEN_OPTS: -Xmx4g
 
+      # product-is builds two archives into this directory: the runtime distribution and
+      # a source distribution, wso2is-<version>-src.zip. Both match `wso2is-*.zip`, and
+      # `find` lists them in filesystem order rather than sorted - so taking the first
+      # match staged one or the other essentially at random. A run that drew the source
+      # zip unpacked a source tree, pointed IS_HOME at it and failed several steps later
+      # in merge.sh with "not a valid Carbon product path", which reads like a packaging
+      # bug rather than the wrong input. Exclude the source archive and sort, so the
+      # choice is both correct and reproducible.
       - name: Stage the built distribution zip
         if: env.IS_SOURCE == 'master'
         run: |
-          zip_path=$(find /tmp/product-is/modules/distribution/target -maxdepth 1 -name "wso2is-*.zip" | head -1)
-          if [ -z "${zip_path}" ]; then
-            echo "::error::No wso2is-*.zip under modules/distribution/target - did the module path change?"
+          zips=$(find /tmp/product-is/modules/distribution/target -maxdepth 1 \
+            -name "wso2is-*.zip" ! -name "*-src.zip" | sort)
+          count=$(echo "${zips}" | grep -c . || true)
+          if [ "${count}" -eq 0 ]; then
+            echo "::error::No runtime wso2is-*.zip under modules/distribution/target" \
+                 "(source distributions are excluded) - did the module path change?"
+            ls -1 /tmp/product-is/modules/distribution/target/*.zip 2>/dev/null || true
             exit 1
           fi
+          if [ "${count}" -gt 1 ]; then
+            echo "::error::Expected one runtime distribution zip, found ${count} - refusing" \
+                 "to guess which to test:"
+            echo "${zips}" >&2
+            exit 1
+          fi
+          zip_path="${zips}"
           mkdir -p ~/is-pack
           cp "${zip_path}" ~/is-pack/wso2is.zip
-          echo "Built $(basename "${zip_path}")"
+          echo "Staged $(basename "${zip_path}")"
 
       - name: Unpack IS
         run: unzip -q ~/is-pack/wso2is.zip -d "${GITHUB_WORKSPACE}"
 
       - name: Resolve IS_HOME
         run: |
-          dir=$(find "${GITHUB_WORKSPACE}" -maxdepth 1 -type d -name "wso2is-*")
-          if [ -z "${dir}" ]; then
-            echo "::error::No wso2is-* directory found after unpacking"
+          # An unpacked source distribution matches this glob as readily as the runtime
+          # pack, and an unquoted multi-line result would have silently produced an
+          # unusable IS_HOME, so exclude it and insist on exactly one match.
+          dirs=$(find "${GITHUB_WORKSPACE}" -maxdepth 1 -type d -name "wso2is-*" ! -name "*-src" | sort)
+          count=$(echo "${dirs}" | grep -c . || true)
+          if [ "${count}" -eq 0 ]; then
+            echo "::error::No runtime wso2is-* directory after unpacking. A source" \
+                 "distribution alone does not count - check which zip was staged."
+            ls -1d "${GITHUB_WORKSPACE}"/wso2is-* 2>/dev/null || true
+            exit 1
+          fi
+          if [ "${count}" -gt 1 ]; then
+            echo "::error::Expected one unpacked product directory, found ${count}:"
+            echo "${dirs}" >&2
+            exit 1
+          fi
+          # Assert it really is a runtime pack. Without this the first symptom of a wrong
+          # pack is merge.sh's "not a valid Carbon product path" much further down.
+          dir="${dirs}"
+          if [ ! -f "${dir}/bin/wso2server.sh" ]; then
+            echo "::error::${dir} has no bin/wso2server.sh, so it is not a runtime" \
+                 "Identity Server pack."
             exit 1
           fi
           echo "IS_HOME=${dir}" >> "$GITHUB_ENV"


### PR DESCRIPTION
## Why

`PR E2E` failed on Dependabot PR #97 ([run](https://github.com/wso2/dpdp-accelerator/actions/runs/33729813676)) at the *Apply the accelerator* step:

```
Resolved IS_HOME=/home/runner/work/dpdp-accelerator/dpdp-accelerator/wso2is-7.4.0-SNAPSHOT-src
ERROR: .../wso2is-7.4.0-SNAPSHOT-src is not a valid Carbon product path.
```

`merge.sh` was right to refuse: it had been handed an unpacked **source** distribution rather than a runtime pack.

`product-is` builds two archives into `modules/distribution/target`:

- `wso2is-<version>.zip` — the runtime distribution
- `wso2is-<version>-src.zip` — a source distribution

Both match the `wso2is-*.zip` glob the staging step used, and `find` returns entries in filesystem order rather than sorted, so `| head -1` staged one or the other essentially at random. `Resolve IS_HOME` then compounded it, because an unpacked `wso2is-<version>-src` directory matches `wso2is-*` just as readily.

The failure therefore surfaced six steps downstream of its cause, as a message that reads like a packaging bug rather than the wrong input having been fed in.

**This is intermittent, not new.** The flaw has been latent since the master-build path was added; identical code passed on 1 September and failed on 3 September. It is also not confined to PR CI — `release-builder.yml`'s E2E gate passes `is_source: master` too, so a release could have failed the same way.

## What changed

Both globs exclude the source artefact and sort, so the selection is correct *and* reproducible:

```sh
zips=$(find … -maxdepth 1 -name "wso2is-*.zip" ! -name "*-src.zip" | sort)
```

Three behaviours beyond the one-line fix:

- **Neither step guesses any more.** If more than one candidate survives the exclusion, the step fails and lists them. Silently picking from an ambiguous set is what caused this.
- **`Resolve IS_HOME` asserts `bin/wso2server.sh` exists.** A wrong pack now fails at the point it is chosen, naming the real problem, instead of at `merge.sh`.
- **The zero-match messages say what was excluded** and list what is actually present, so "nothing found" cannot be confused with "found only a source distribution".

## Verified

Reproduced against the exact directory contents from the failing run (`wso2is-7.4.0-SNAPSHOT.zip` alongside `wso2is-7.4.0-SNAPSHOT-src.zip`): the old logic selects the source zip, the new logic selects the runtime zip.

Also exercised, each behaving correctly: only a source zip present → error; two runtime zips → refuses to choose; only a source directory unpacked → error; a correctly-named directory with no runtime → error; nothing unpacked → error; and the **release path** (`wso2is-7.3.0`, which ships no `-src`) still resolves as before.

`actionlint` clean, and `shellcheck` clean on both steps extracted standalone.

## Not changed

The `head -1` at `e2e.yml:297` globs this repository's own assembly, which produces exactly one zip, in a `target/` the job has just run `mvn clean install` over. There is no second artefact for it to confuse, so it is left alone rather than given a speculative guard.
