### PR TITLE
Stop Dependabot proposing dependency versions the Identity Server dictates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,17 +14,13 @@
 # specific language governing permissions and limitations
 # under the License.
 
-# Weekly, grouped updates. Grouping matters here because every PR raised costs a
-# full build - and, if a maintainer labels it, an E2E run - so one PR per
-# dependency would swamp the runners.
-#
-# Version updates need no repository setting; Dependabot alerts and security
-# updates are separate admin toggles, tracked in #80.
+# Grouped weekly, because every PR costs a full build and possibly an E2E run.
+# Only version updates are configured here; alerts and security updates are
+# separate features, enabled under Settings -> Code security.
 version: 2
 updates:
-  # Keeps the SHA pins in .github/workflows current: Dependabot rewrites the SHA
-  # and the trailing version comment together, which is the only maintainable way
-  # to run pinned actions.
+  # Dependabot rewrites a pinned SHA and its version comment together, which is what
+  # makes the SHA pins in .github/workflows maintainable.
   - package-ecosystem: github-actions
     directory: /
     schedule:
@@ -33,14 +29,29 @@ updates:
       actions:
         patterns: ['*']
 
-  # The root pom is the only place versions are declared, so this covers every
-  # module in the reactor. Majors are left out of the group deliberately - a major
-  # bump of an IS-facing dependency needs reviewing on its own.
+  # The root pom declares every version, so this covers the whole reactor. Majors are
+  # excluded from the group: an IS-facing major bump needs reviewing on its own.
   - package-ecosystem: maven
     directory: /
     schedule:
       interval: weekly
     open-pull-requests-limit: 5
+    # org.wso2 versions are fixed by the Identity Server the accelerator installs
+    # over, and several are reused as OSGi Import-Package requirements in
+    # components/*/pom.xml, where a bare version means "or higher". Raising
+    # securevault by one patch (1.2.0 -> 1.2.1) made every bundle demand a version the
+    # server does not export: nothing resolved and no roles were provisioned, while
+    # `mvn clean install` stayed green because the breakage is runtime-only. Limiting
+    # the group to minor and patch is no protection - that bump was a patch.
+    #
+    # CXF and axiom are runtime-supplied too, so they track the server rather than the
+    # newest release. Jackson, gson, commons-logging and the javax/osgi APIs are
+    # provided scope as well but keep updating: their import ranges live in separate
+    # *.imp.pkg.version.range properties, independent of the build version.
+    ignore:
+      - dependency-name: "org.wso2.*:*"
+      - dependency-name: "org.apache.cxf:*"
+      - dependency-name: "org.apache.ws.commons.axiom.wso2:*"
     groups:
       maven-minor-patch:
         update-types: [minor, patch]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -37,7 +37,9 @@ updates:
       interval: weekly
     open-pull-requests-limit: 5
     # org.wso2 versions are fixed by the Identity Server the accelerator installs
-    # over, and several are reused as OSGi Import-Package requirements in
+    # over - the reactor's own parent pom, org.wso2:wso2, included, hence the pattern
+    # having no dot after org.wso2 - and several are reused as Import-Package
+    # requirements in
     # components/*/pom.xml, where a bare version means "or higher". Raising
     # securevault by one patch (1.2.0 -> 1.2.1) made every bundle demand a version the
     # server does not export: nothing resolved and no roles were provisioned, while
@@ -49,7 +51,7 @@ updates:
     # provided scope as well but keep updating: their import ranges live in separate
     # *.imp.pkg.version.range properties, independent of the build version.
     ignore:
-      - dependency-name: "org.wso2.*:*"
+      - dependency-name: "org.wso2*:*"
       - dependency-name: "org.apache.cxf:*"
       - dependency-name: "org.apache.ws.commons.axiom.wso2:*"
     groups:


### PR DESCRIPTION
## Why

A grouped Maven update (#98) raised 37 dependencies, one of them `securevault.version` from 1.2.0 to 1.2.1. The E2E suite failed with no `dpdp-consent-admin` role provisioned, and the server log gave the reason:

```
Could not resolve module: org.wso2.dpdp.accelerator.common [584]
  Unresolved requirement: Import-Package: org.wso2.securevault; version="1.2.1"
```

That property is not only a dependency version. `components/org.wso2.dpdp.accelerator.common/pom.xml` reuses it verbatim as an OSGi requirement:

```xml
org.wso2.securevault;version="${securevault.version}",
org.wso2.securevault.commons;version="${securevault.version}",
```

A bare OSGi version means *"or higher"*. The Identity Server exports 1.2.0, so nothing could satisfy `>= 1.2.1`: `common` never resolved, the six bundles importing `org.wso2.dpdp.accelerator.common.config` failed with it, the tenant listener in `identity.extensions` never ran, and the role it provisions was never created.

Two properties of this failure are worth drawing out:

- **`mvn clean install` was green throughout.** Compilation is happy with either version. The breakage exists only at runtime, against a server the build never sees, so E2E was the only thing that could have caught it.
- **It was a *patch* bump.** The group is already restricted to minor and patch updates, and that restriction is exactly why this looked safe. There is no severity threshold that would have prevented it.

It is also not a one-off. Twenty version properties are used inside `Import-Package` across the bundles, and that single update moved at least twelve of them. OSGi reports only the first unsatisfied requirement, so fixing securevault alone would most likely have surfaced the next one.

## What changed

Nothing under `org.wso2` is this project's choice - it is fixed by the distribution the accelerator is installed over - so those are ignored outright:

```yaml
    ignore:
      - dependency-name: "org.wso2.*:*"
      - dependency-name: "org.apache.cxf:*"
      - dependency-name: "org.apache.ws.commons.axiom.wso2:*"
```

CXF and axiom are there for a weaker but related reason: both are supplied by the runtime rather than shipped, so their versions have to match what the server carries. CXF comes from `$IS_HOME/lib/runtimes/cxf3` because the internal webapps deliberately do not bundle it, and axiom is a WSO2 repackage the server provides. Neither can fail resolution the way securevault did - axiom is imported as `version="0"`, and the webapps are not OSGi bundles - but compiling against a newer API than the runtime provides fails just as late.

The file's existing comments were also condensed while in here; they had grown to 48 lines against 37 lines of configuration.

## Deliberately still updating

Jackson, gson, commons-logging and the `javax`/`osgi` APIs are `provided` scope too, so "provided scope" would have been the tidier rule - but it is the wrong one. Their `Import-Package` ranges live in separate properties:

```xml
<jackson.imp.pkg.version.range>[2.13.0, 3.0.0)</jackson.imp.pkg.version.range>
```

so the build version and the runtime contract move independently, and bumping one cannot affect resolution. Those updates are worth keeping - `jackson-databind` in particular is where security fixes arrive.

## Verified

Matched the three patterns against every dependency coordinate in the root pom: **all 14 runtime-pinned bumps from that update are suppressed** (securevault, the eleven `carbon.*`, consent-mgt, orbit nimbus), and **28 genuinely updatable dependencies still are**. The YAML parses, and all four ecosystems and both group definitions are unchanged.

## Follow-up, not in this PR

This stops Dependabot proposing the bumps; it does not fix the underlying inconsistency, which is that some imports pin an explicit range while others reuse the build version. Giving `securevault` and the `carbon.*` imports their own `*.imp.pkg.version.range` properties would follow the convention the file already uses elsewhere, and make the runtime contract explicit rather than an accident of the build version. Worth its own change.
