### PR TITLE
Derive ComplaintStatus from the status array instead of duplicating it

### DIFF
--- a/dpdp-accelerator/react-apps/consent-portal/frontend/src/types/complaint.ts
+++ b/dpdp-accelerator/react-apps/consent-portal/frontend/src/types/complaint.ts
@@ -48,20 +48,15 @@ export const COMPLAINT_PRIORITIES: ComplaintPriorityAPI[] = ['CRITICAL', 'HIGH',
 // the DAO/service layer (DAOConstants, mysql.sql's CHK_COMPLAINT_STATUS) and this frontend both
 // predate that spec revision and consistently use WAITING_ON_CLIENT instead. Kept as-is rather
 // than renamed across the DB/enum layer for this pass - see the integration notes for this gap.
-export type ComplaintStatus =
-  | 'OPEN'
-  | 'IN_PROGRESS'
-  | 'WAITING_ON_CLIENT'
-  | 'AWAITING_INTERNAL_REVIEW'
-  | 'RESOLVED'
-
-export const COMPLAINT_STATUSES: ComplaintStatus[] = [
+export const COMPLAINT_STATUSES = [
   'OPEN',
   'IN_PROGRESS',
   'WAITING_ON_CLIENT',
   'AWAITING_INTERNAL_REVIEW',
   'RESOLVED',
-]
+] as const
+
+export type ComplaintStatus = (typeof COMPLAINT_STATUSES)[number]
 
 export type ComplaintActorRoleAPI = 'USER' | 'COMPLAINT_OFFICER' | 'SYSTEM'
 export type ComplaintActorRole = 'DataPrincipal' | 'ComplaintOfficer' | 'System'


### PR DESCRIPTION
## Why

`Frontend quality` fails on #103, the frontend-npm group bump, on one file:

```
[warn] src/types/complaint.ts
[warn] Code style issues found in the above file.
```

That bump raises Prettier from 3.8.1 to 3.9.6, and 3.9 changed how it formats union types — a union that fits inside `printWidth` is now collapsed rather than kept one member per line:

```ts
-export type ComplaintStatus =
-  | 'OPEN'
-  | 'IN_PROGRESS'
-  | 'WAITING_ON_CLIENT'
-  | 'AWAITING_INTERNAL_REVIEW'
-  | 'RESOLVED'
+export type ComplaintStatus =
+  'OPEN' | 'IN_PROGRESS' | 'WAITING_ON_CLIENT' | 'AWAITING_INTERNAL_REVIEW' | 'RESOLVED'
```

The two versions are **mutually incompatible on this file** — each rejects the other's output. Verified by running both against `main`'s copy with `main`'s `.prettierrc`:

| Prettier | Result on `main` as-is |
| --- | --- |
| 3.8.1 | clean |
| 3.9.6 | fails |

So simply reformatting the file in a separate PR would not work: that PR's own `Frontend quality` job runs `main`'s Prettier 3.8.1, which would reject 3.9-formatted output. The reformat can only ride along inside #103 itself.

## What this does instead

The file already listed those five values twice — once as the union, once as the array the complaint filter dropdowns iterate:

```ts
export type ComplaintStatus = 'OPEN' | 'IN_PROGRESS' | ...
export const COMPLAINT_STATUSES: ComplaintStatus[] = ['OPEN', 'IN_PROGRESS', ...]
```

Adding or renaming a status meant editing both, with nothing to catch it if only one changed. Deriving the union from the array removes the duplication:

```ts
export const COMPLAINT_STATUSES = [...] as const
export type ComplaintStatus = (typeof COMPLAINT_STATUSES)[number]
```

The resulting type is identical. `COMPLAINT_STATUSES` is only ever read — two `.map()` calls, in `ComplaintListFilters.tsx` and `ComplaintQueueFilters.tsx` — so becoming `readonly` costs nothing.

Because the multi-line union is gone, **neither Prettier version has an opinion about this file any more**, which is what lets this merge on its own and unblocks #103 without touching it.

## Verified

| Check | Result |
| --- | --- |
| `prettier@3.8.1 --check` (what `main` runs today) | clean |
| `prettier@3.9.6 --check` (what #103 upgrades to) | clean |
| `tsc -b` | exit 0 |
| `eslint src/types/complaint.ts` | exit 0 |
| Vitest, full suite | 297 passed |

## Sequencing

This is safe to merge on its own — it passes today's Prettier. Once it is on `main`, #103 needs a rebase and should then go green with no changes of its own.

Worth noting for later: this only removes the *current* collision. Any future Prettier minor can reformat something else, and Dependabot cannot fix that itself. If that churn becomes tiresome, pinning Prettier via a `dependabot.yml` ignore is the alternative — deliberate upgrades instead of surprise ones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N5BHH7V3eMp8RYgXP79TCL
