### PR TITLE
Stop Dependabot proposing dependencies that never reach a server

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -54,6 +54,24 @@ updates:
       - dependency-name: "org.wso2*:*"
       - dependency-name: "org.apache.cxf:*"
       - dependency-name: "org.apache.ws.commons.axiom.wso2:*"
+      # None of these ship: the built zip carries ten jars - our eight bundles, quartz
+      # and swagger-annotations - with Jackson, gson and commons-logging coming from
+      # lib/runtimes/cxf3 and the javax/osgi APIs from the framework. Raising them only
+      # changes what we compile against, risking a call the installed server does not
+      # have. A Jackson CVE is fixed by updating the server, not this pom.
+      - dependency-name: "com.fasterxml.jackson.core:*"
+      - dependency-name: "com.fasterxml.jackson.jaxrs:*"
+      - dependency-name: "com.google.code.gson:*"
+      - dependency-name: "commons-logging:*"
+      - dependency-name: "javax.servlet:*"
+      - dependency-name: "javax.ws.rs:*"
+      - dependency-name: "javax.validation:*"
+      - dependency-name: "org.osgi:*"
+      # Majors only - this plugin writes the OSGi manifests. bnd 6 began emitting
+      # Import-Package entries for java.* packages outside java.base (java.net.http,
+      # java.sql), which Equinox does not export, so every bundle failed to resolve.
+      - dependency-name: "org.apache.felix:maven-bundle-plugin"
+        update-types: ["version-update:semver-major"]
     groups:
       maven-minor-patch:
         update-types: [minor, patch]


### PR DESCRIPTION
## Why

Following the securevault breakage, this audits every managed Maven dependency for whether bumping it can actually be validated — and, more fundamentally, whether it reaches a server at all.

Unpacking the built accelerator answers that directly. It ships **ten jars**:

```
org.wso2.dpdp.accelerator.*-1.0.0-SNAPSHOT.jar   (our eight bundles)
quartz-2.3.2.wso2v1.jar                          (already ignored by org.wso2*)
swagger-annotations-1.6.14.jar
```

And every internal webapp's `WEB-INF/lib` holds `swagger-annotations` and nothing else — `webapp-classloading.xml` places them in the `CXF3,Carbon` environment, so CXF, JAX-RS and Jackson come from `lib/runtimes/cxf3`, while the OSGi bundles import theirs from the framework.

So of 62 managed dependencies, exactly **two** third-party jars are installed, and one of those is already ignored.

## What changed

Added to `ignore`: Jackson (`core`, `jaxrs`), gson, commons-logging, the `javax` APIs (servlet, ws.rs, validation) and the `osgi` APIs. None of them ship. Raising them changes only what we compile against, which buys nothing at runtime and risks compiling against a method the installed server does not have — a failure that appears at runtime, long after a green build.

This **corrects a claim in the previous change**, which kept Jackson updating on the grounds that "jackson-databind is where security fixes land". That reasoning was wrong for this project: the jar is never installed, so a Jackson CVE is fixed by updating the Identity Server, not by bumping this pom. The update was pure risk with no benefit.

`maven-bundle-plugin` is restricted to non-major updates rather than ignored outright. It writes the OSGi manifests, and bnd 6 began emitting `Import-Package` entries for `java.*` packages outside `java.base` — `java.net.http` and `java.sql` — which Equinox does not export, so every bundle failed to resolve (#100). That is currently held off only by a Dependabot comment-command preference, which is invisible in the repository and scoped to `6.x`; stating it here is reviewable and covers `7.x`.

## Result

| | before | after |
| --- | --- | --- |
| managed dependencies | 62 | 62 |
| proposable by Dependabot | 27 | **15** |

The 15 are exactly what ships or what is test-only: `swagger-annotations`, plus the test tooling (h2, mysql-connector-j, postgresql, sqlite, testcontainers, junit, mockito, testng, jersey, slf4j).

## Test-scope updates stay on, deliberately

Test dependencies cannot reach a server, and a bad one turns CI red — which is the point. That includes `mysql-connector-j`: it is `test` scope, and `DatabaseDialectConcurrencyIntegrationTest` exercises it against a real `mysql:8.0.36` container via Testcontainers, alongside PostgreSQL. Those container tests do run in CI — the Build job reports `Skipped: 0`, and the test raises `SkipException` when Docker is absent, so a skip would show. The driver is not shipped either; operators supply their own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N5BHH7V3eMp8RYgXP79TCL
