### PR TITLE
Remove View & Reply for acknowledgement complaint email

### DIFF
--- a/dpdp-accelerator/components/org.wso2.dpdp.accelerator.complaint.mgt.service/src/main/java/org/wso2/dpdp/accelerator/complaint/mgt/service/notification/EmailNotificationClient.java
+++ b/dpdp-accelerator/components/org.wso2.dpdp.accelerator.complaint.mgt.service/src/main/java/org/wso2/dpdp/accelerator/complaint/mgt/service/notification/EmailNotificationClient.java
@@ -89,6 +89,7 @@ public class EmailNotificationClient implements NotificationClient {
     private static final String PLACEHOLDER_HEADLINE_HTML = "headline-html";
     private static final String PLACEHOLDER_FOOTER_TEXT = "footer-text";
     private static final String PLACEHOLDER_ACTION_BADGE_HTML = "action-badge-html";
+    private static final String PLACEHOLDER_ACTION_BUTTON_HTML = "action-button-html";
     private static final String PLACEHOLDER_LOGO_URL = "logo-url";
 
     private static final String EMAIL_CLAIM = "http://wso2.org/claims/emailaddress";
@@ -273,6 +274,10 @@ public class EmailNotificationClient implements NotificationClient {
                     "You're receiving this because you filed this complaint. We'll email you when there's "
                             + "an update.");
             properties.put(PLACEHOLDER_ACTION_BADGE_HTML, ACKNOWLEDGEMENT_BADGE_HTML);
+            // Deliberately empty, and deliberately still set: IS leaves an unmatched placeholder
+            // in the template as literal text, so omitting the key ships "{{action-button-html}}"
+            // in the mail body. See buildActionButton for why this type has no button.
+            properties.put(PLACEHOLDER_ACTION_BUTTON_HTML, "");
 
             eventService.handleEvent(new Event(IdentityEventConstants.Event.TRIGGER_NOTIFICATION, properties));
         } catch (Throwable t) {
@@ -506,6 +511,7 @@ public class EmailNotificationClient implements NotificationClient {
         placeholders.put(PLACEHOLDER_HEADLINE_HTML, headlineHtml);
         placeholders.put(PLACEHOLDER_FOOTER_TEXT, footerText);
         placeholders.put(PLACEHOLDER_ACTION_BADGE_HTML, actionBadgeHtml);
+        placeholders.put(PLACEHOLDER_ACTION_BUTTON_HTML, buildActionButton(actionUrl));
         placeholders.put(PLACEHOLDER_LOGO_URL, IdentityUtil.getServerURL(LOGO_PATH, true, false));
         return placeholders;
     }
@@ -529,6 +535,29 @@ public class EmailNotificationClient implements NotificationClient {
         return "<span style=\"display:inline-block;background-color:" + background + ";color:" + color
                 + ";font-size:11px;font-weight:700;letter-spacing:0.04em;text-transform:uppercase;"
                 + "padding:4px 10px;border-radius:999px;\">" + text + "</span>";
+    }
+
+    /**
+     * The call to action is per-notification-type rather than part of the shared shell, because it
+     * tells the recipient to act - true for the officer's "new complaint" mail and for either
+     * side's "new reply" mail, but not for the acknowledgement, which confirms receipt of the
+     * citizen's own complaint and quotes their own description back at them. A "Review & Reply"
+     * button there asks them to reply to themselves. The shell's footer link is on
+     * {@code action-url} regardless, so an acknowledgement with no button still offers a way in.
+     * <p>
+     * The URL is interpolated here rather than left as an {@code action-url} placeholder inside
+     * this markup: IS's notification handler substitutes the template in a single pass, so a
+     * placeholder occurring within another placeholder's *value* is never expanded and would ship
+     * as literal text in the href.
+     */
+    private static String buildActionButton(String actionUrl) {
+        return "<table role=\"presentation\" cellpadding=\"0\" cellspacing=\"0\" align=\"center\" "
+                + "style=\"margin:0 auto;\"><tr>"
+                + "<td style=\"border-radius:24px;background-color:#f97316;\">"
+                + "<a href=\"" + actionUrl + "\" style=\"display:inline-block;padding:12px 32px;"
+                + "font-size:14px;font-weight:700;color:#ffffff;text-decoration:none;"
+                + "border-radius:24px;\">Review &amp; Reply</a>"
+                + "</td></tr></table>";
     }
 
     private static String htmlEscape(String value) {

--- a/dpdp-accelerator/components/org.wso2.dpdp.accelerator.identity.extensions/src/main/resources/notification/complaint-email-body.html
+++ b/dpdp-accelerator/components/org.wso2.dpdp.accelerator.identity.extensions/src/main/resources/notification/complaint-email-body.html
@@ -37,7 +37,7 @@
           </td>
         </tr>
 
-        <!-- Body: badge, headline, detail card, quoted message, action button -->
+        <!-- Body: badge, headline, detail card, quoted message, action button (per-type, may be empty) -->
         <tr>
           <td style="padding:28px;">
             {{action-badge-html}}
@@ -85,13 +85,7 @@
               </tr>
             </table>
 
-            <table role="presentation" cellpadding="0" cellspacing="0" align="center" style="margin:0 auto;">
-              <tr>
-                <td style="border-radius:24px;background-color:#f97316;">
-                  <a href="{{action-url}}" style="display:inline-block;padding:12px 32px;font-size:14px;font-weight:700;color:#ffffff;text-decoration:none;border-radius:24px;">Review &amp; Reply</a>
-                </td>
-              </tr>
-            </table>
+            {{action-button-html}}
           </td>
         </tr>
 


### PR DESCRIPTION
# Purpose

The three complaint notification emails share a single HTML shell (`complaint-email-body.html`), registered for all three template types by `EmailTemplateProvisioningUtil`, with only the subject line differing per type. That shell carried an unconditional **Review & Reply** call-to-action button.

On two of the three types, the button is correct:

* **ComplaintCreated** goes to the Grievance Officer ("filed a new complaint").
* **ComplaintCommentAdded** goes to whichever party did not write the comment ("replied to complaint").

Both recipients genuinely need to act.

On the third, it is wrong. **ComplaintAcknowledged** is sent to the data principal who has just filed the complaint, and `sendAcknowledgement` populates `message-excerpt` with that citizen's own description. The mail therefore quoted the recipient's own words back to them beneath a button instructing them to review and reply — to themselves.

The headline on that type was already correctly passive (`Your complaint {ref} has been received`); the button was the only remaining element implying the recipient owed an action.

## Resolves

Fixes issue - https://github.com/wso2/dpdp-accelerator/issues/159

# Goals

* Remove the **Review & Reply** call-to-action from the complaint acknowledgement mail only.
* Leave the officer ("new complaint filed") and reply ("new reply on complaint") mails byte-identical, since the button is appropriate and load-bearing there.
* Avoid duplicating the shared HTML shell into per-type template files, which would fork the layout and guarantee future drift between the three mails.
* Keep the acknowledgement recipient with a route into the portal, so removing the button does not turn the mail into a dead end.

# Approach

The call-to-action becomes a per-type placeholder, following the pattern the shell already establishes for `{{action-badge-html}}` and `{{headline-html}}` — both of which are HTML fragments computed per notification type in Java rather than hardcoded in the template.

### `complaint-email-body.html`

The seven-line button table is replaced with `{{action-button-html}}`.

The `{{action-url}}` placeholder stays in the file: the footer's quieter **Open in Consent Portal** link uses it, which is what keeps the buttonless acknowledgement navigable.

### `EmailNotificationClient`

* Adds `PLACEHOLDER_ACTION_BUTTON_HTML`.
* Adds a private `buildActionButton(actionUrl)` returning the original markup verbatim.
* `buildTemplatePlaceholders` (created/comment paths) sets it to `buildActionButton(actionUrl)`.
* `sendAcknowledgement` sets it to an empty string.

### Non-obvious constraints

Two non-obvious constraints are documented in comments at the point they apply, because both fail silently and only in a real sent email:

1. **The empty value is set, not omitted.**

   IS's notification handler (`NotificationUtil#extractPlaceHolders`) leaves an unmatched `{{placeholder}}` in the body as literal text rather than dropping it.

   Therefore, omitting the key on the acknowledgement path would ship a visible `{{action-button-html}}` to citizens.

2. **The `href` is interpolated in Java.**

   The URL is not left as `{{action-url}}` inside the button markup.

   Placeholder substitution is a single pass, so a placeholder appearing inside another placeholder's value is never expanded and would render as literal text in the link target.

### UI impact

No portal UI is affected. The change is confined to outbound email bodies, so there is no screenshot to attach.

The rendered difference is the absence of one orange button on one of three mail types.

# User Stories

* As a **Data Principal**, when I file a complaint I receive a confirmation that tells me it was received and does not ask me to act on my own submission.
* As a **Grievance Officer**, I continue to get a direct **Review & Reply** link into the officer view of a newly filed complaint.
* As either party in a complaint thread, I continue to get a direct **Review & Reply** link when the other side replies.

# Release Note

The complaint acknowledgement email sent to a data principal on filing a complaint no longer shows a **Review & Reply** button, which incorrectly asked the recipient to respond to their own complaint.

The officer notification and reply notification emails are unchanged.

# Documentation

**N/A** — no documented behaviour changes.

The email templates are not described field-by-field in the product documentation, and `docs/localization-guide.md` covers localizing admin-created Purposes/Elements, not notification template markup.

The template remains operator-editable via the Console exactly as before.

# Training

**N/A** — no impact on training content.

# Certification

**N/A** — no impact on certification exams.

The change removes a UI element from one notification email; it introduces no new configuration, API, or concept a certification question could target.

# Marketing

**N/A**

# Automation Tests

## Unit Tests

```text
mvn verify -pl dpdp-accelerator/components/org.wso2.dpdp.accelerator.complaint.mgt.service
```

* **153 tests**
* **0 failures**
* **0 errors**
* **0 skipped**
* JaCoCo `INSTRUCTION/COVEREDRATIO` check passed.
* Module coverage: **87.3%** (2841/3255 instructions), against the module's `0.8` minimum.
* `EmailNotificationClient` coverage: **80.7%** (1156/1433 instructions).

No existing test asserted the call-to-action markup, so none needed updating. The four tests referencing `action-badge-html` are unaffected.

Every `{{placeholder}}` in the shell was cross-checked as being populated by both send paths, specifically to prevent the literal-text failure mode described in the approach.

## Integration Tests

None added.

The complaint notification path is not covered by the Playwright suite in `dpdp-integration-test-suite`, which drives the portal UI and has no SMTP capture.

The end-to-end rendering of the acknowledgement email — specifically that the button is gone and no literal `{{action-button-html}}` appears — has not been verified against a live server with a real SMTP sender.

That is the one check worth doing before merge, and it requires a deployed IS with `[output_adapter.email]` configured.
