### PR TITLE
Fixed the All Consents page PENDING filter behavior

### DIFF
--- a/dpdp-accelerator/react-apps/consent-portal/frontend/src/__tests__/AppSidebar.test.tsx
+++ b/dpdp-accelerator/react-apps/consent-portal/frontend/src/__tests__/AppSidebar.test.tsx
@@ -75,7 +75,7 @@ describe('AppSidebar', () => {
 
     fireEvent.click(screen.getByText('My Pending Consents'))
 
-    expect(screen.getByText('/consents?state=PENDING')).toBeInTheDocument()
+    expect(screen.getByText('/consents?view=pending&state=PENDING')).toBeInTheDocument()
 
     fireEvent.click(screen.getByText('Dashboard'))
 

--- a/dpdp-accelerator/react-apps/consent-portal/frontend/src/__tests__/ConsentRegistryPage.test.tsx
+++ b/dpdp-accelerator/react-apps/consent-portal/frontend/src/__tests__/ConsentRegistryPage.test.tsx
@@ -244,10 +244,10 @@ describe('ConsentRegistryPage', () => {
     })
   })
 
-  it('shows the pending title and breadcrumb when filtered to pending consents', async () => {
+  it('shows the dedicated pending title and breadcrumb for the pending view', async () => {
     mockConsentSearch([])
 
-    renderConsentRegistryPage(createQueryClient(), '/consents?state=PENDING')
+    renderConsentRegistryPage(createQueryClient(), '/consents?view=pending&state=PENDING')
 
     expect(await screen.findByRole('heading', { name: 'My Pending Consents' })).toBeInTheDocument()
     const breadcrumbs = screen.getByRole('navigation', { name: 'Breadcrumb' })
@@ -257,20 +257,36 @@ describe('ConsentRegistryPage', () => {
     )
   })
 
-  it('locks state and relation to the pending queue - narrowing either means leaving this view', async () => {
+  it('keeps state and relation filters enabled when pending is selected from My Consents', async () => {
     mockConsentSearch([])
 
     renderConsentRegistryPage(createQueryClient(), '/consents?state=PENDING&relation=AUTHORIZER')
 
+    await screen.findByRole('heading', { name: 'My Consents' })
+    expect(screen.getByRole('combobox', { name: 'State' })).not.toHaveAttribute('aria-disabled')
+    expect(screen.getByRole('combobox', { name: 'Relation' })).not.toHaveAttribute('aria-disabled')
+    expect(screen.getByRole('combobox', { name: 'Relation' })).toHaveTextContent('Managed by Me')
+    expect(consentsApi.fetchMyConsents.mock.calls[0]?.[0]).toMatchObject({
+      state: 'PENDING',
+      relation: 'AUTHORIZER',
+    })
+  })
+
+  it('keeps the dedicated pending view filters locked and relation-wide', async () => {
+    mockConsentSearch([])
+
+    renderConsentRegistryPage(createQueryClient(), '/consents?view=pending&state=PENDING')
+
     await screen.findByRole('heading', { name: 'My Pending Consents' })
     expect(screen.getByRole('combobox', { name: 'State' })).toHaveAttribute('aria-disabled', 'true')
-    expect(screen.getByRole('combobox', { name: 'Relation' })).toHaveTextContent('All')
     expect(screen.getByRole('combobox', { name: 'Relation' })).toHaveAttribute(
       'aria-disabled',
       'true',
     )
-    // Relation is forced to ANY server-side too, not just visually locked.
-    expect(consentsApi.fetchMyConsents.mock.calls[0]?.[0]).toMatchObject({ relation: 'ANY' })
+    expect(consentsApi.fetchMyConsents.mock.calls[0]?.[0]).toMatchObject({
+      state: 'PENDING',
+      relation: 'ANY',
+    })
   })
 
   it('ignores the removed CREATED status in the URL', async () => {

--- a/dpdp-accelerator/react-apps/consent-portal/frontend/src/__tests__/MainLayout.test.tsx
+++ b/dpdp-accelerator/react-apps/consent-portal/frontend/src/__tests__/MainLayout.test.tsx
@@ -152,8 +152,8 @@ describe('MainLayout', () => {
     expect(within(breadcrumbs).getByText('My Consents')).toHaveAttribute('aria-current', 'page')
   })
 
-  it('shows My Pending Consents for the self-service registry filtered to pending', () => {
-    renderHeaderBreadcrumbs('/consents?state=PENDING')
+  it('shows My Pending Consents for the dedicated pending view', () => {
+    renderHeaderBreadcrumbs('/consents?view=pending&state=PENDING')
 
     const breadcrumbs = screen.getByRole('navigation', { name: 'Breadcrumb' })
     expect(within(breadcrumbs).getByText('My Pending Consents')).toHaveAttribute(

--- a/dpdp-accelerator/react-apps/consent-portal/frontend/src/components/layout/main-layout/HeaderBreadcrumbs.tsx
+++ b/dpdp-accelerator/react-apps/consent-portal/frontend/src/components/layout/main-layout/HeaderBreadcrumbs.tsx
@@ -181,7 +181,7 @@ function buildBreadcrumbItems(
   }
 
   if (pathname.startsWith('/consents')) {
-    const isPending = new URLSearchParams(search).get('state') === 'PENDING'
+    const isPending = new URLSearchParams(search).get('view') === 'pending'
 
     return [
       {

--- a/dpdp-accelerator/react-apps/consent-portal/frontend/src/components/layout/sidebar/AppSidebar.tsx
+++ b/dpdp-accelerator/react-apps/consent-portal/frontend/src/components/layout/sidebar/AppSidebar.tsx
@@ -68,7 +68,7 @@ const CONSENT_ITEMS: SidebarItem[] = [
   {
     id: 'pending-consents',
     labelKey: 'sidebar.pendingConsents',
-    path: '/consents?state=PENDING',
+    path: '/consents?view=pending&state=PENDING',
     icon: <Clock3 size={18} />,
     requiredScope: REQUIRED_SCOPES.CONSENTS_READ_SELF,
   },
@@ -152,9 +152,7 @@ function mapPathToMenuId(pathname: string, search: string): string {
   }
 
   if (pathname.startsWith('/consents')) {
-    const state = new URLSearchParams(search).get('state')
-
-    if (state === 'PENDING') {
+    if (new URLSearchParams(search).get('view') === 'pending') {
       return 'pending-consents'
     }
 

--- a/dpdp-accelerator/react-apps/consent-portal/frontend/src/features/dashboard/DashboardPage.tsx
+++ b/dpdp-accelerator/react-apps/consent-portal/frontend/src/features/dashboard/DashboardPage.tsx
@@ -261,7 +261,7 @@ function DashboardPage(): React.JSX.Element {
             {data.pendingCount > 0 ? (
               <Button
                 component={RouterLink}
-                to="/consents?state=PENDING"
+                to="/consents?view=pending&state=PENDING"
                 size="small"
                 endIcon={<ArrowRight size={15} />}
                 sx={{ mt: 1 }}

--- a/dpdp-accelerator/react-apps/consent-portal/frontend/src/features/my-consents/ConsentRegistryPage.tsx
+++ b/dpdp-accelerator/react-apps/consent-portal/frontend/src/features/my-consents/ConsentRegistryPage.tsx
@@ -55,19 +55,19 @@ function isConsentRelation(value: string): value is ConsentRelation {
 const DEFAULT_PAGE = 0
 const DEFAULT_ROWS_PER_PAGE = 10
 
-function getFiltersFromSearchParams(searchParams: URLSearchParams): ConsentRegistryFiltersModel {
+function getFiltersFromSearchParams(
+  searchParams: URLSearchParams,
+  isPendingView: boolean,
+): ConsentRegistryFiltersModel {
   const stateParam = searchParams.get('state') ?? ''
   const relationParam = searchParams.get('relation') ?? ''
   const state = isConsentState(stateParam) ? (stateParam as ConsentState) : DEFAULT_FILTERS.state
   const urlRelation = isConsentRelation(relationParam) ? relationParam : DEFAULT_FILTERS.relation
-  // The Pending queue is every relation at once - relation narrowing (and
-  // switching away from Pending) happens by leaving this view, not inside it.
-  const relation = state === 'PENDING' ? 'ANY' : urlRelation
 
   return {
     state,
     serviceId: searchParams.get('serviceId') ?? DEFAULT_FILTERS.serviceId,
-    relation,
+    relation: isPendingView ? 'ANY' : urlRelation,
     createdAfter: searchParams.get('createdAfter') ?? DEFAULT_FILTERS.createdAfter,
     createdBefore: searchParams.get('createdBefore') ?? DEFAULT_FILTERS.createdBefore,
   }
@@ -93,8 +93,13 @@ function toSearchParams(
   filters: ConsentRegistryFiltersModel,
   page = DEFAULT_PAGE,
   rowsPerPage = DEFAULT_ROWS_PER_PAGE,
+  isPendingView = false,
 ): URLSearchParams {
   const params = new URLSearchParams()
+
+  if (isPendingView) {
+    params.set('view', 'pending')
+  }
 
   if (filters.state !== DEFAULT_FILTERS.state) {
     params.set('state', filters.state)
@@ -132,7 +137,11 @@ function ConsentRegistryPage(): React.JSX.Element {
   const [searchParams, setSearchParams] = useSearchParams()
   const [approvalConsentID, setApprovalConsentID] = useState<string>()
   const [revocationConsentID, setRevocationConsentID] = useState<string>()
-  const filters = useMemo(() => getFiltersFromSearchParams(searchParams), [searchParams])
+  const isPendingView = searchParams.get('view') === 'pending'
+  const filters = useMemo(
+    () => getFiltersFromSearchParams(searchParams, isPendingView),
+    [isPendingView, searchParams],
+  )
   const page = useMemo(() => getPageFromSearchParams(searchParams), [searchParams])
   const rowsPerPage = useMemo(() => getRowsPerPageFromSearchParams(searchParams), [searchParams])
   const consentListQuery = useConsentListQuery(filters, page, rowsPerPage)
@@ -147,7 +156,9 @@ function ConsentRegistryPage(): React.JSX.Element {
     nextPage = DEFAULT_PAGE,
     nextRowsPerPage = rowsPerPage,
   ): void => {
-    setSearchParams(toSearchParams(nextFilters, nextPage, nextRowsPerPage), { replace: true })
+    setSearchParams(toSearchParams(nextFilters, nextPage, nextRowsPerPage, isPendingView), {
+      replace: true,
+    })
   }
 
   return (
@@ -156,13 +167,14 @@ function ConsentRegistryPage(): React.JSX.Element {
         <Stack spacing={1}>
           <HeaderBreadcrumbs />
           <Typography variant="h4" fontWeight={700}>
-            {filters.state === 'PENDING' ? t('sidebar.pendingConsents') : t('sidebar.allConsents')}
+            {isPendingView ? t('sidebar.pendingConsents') : t('sidebar.allConsents')}
           </Typography>
         </Stack>
 
         <ConsentRegistryFilters
           key={searchParams.toString()}
           filters={filters}
+          isPendingView={isPendingView}
           onFilterChange={(nextFilters) => updateParams(nextFilters)}
           onClear={() => updateParams(DEFAULT_FILTERS)}
         />

--- a/dpdp-accelerator/react-apps/consent-portal/frontend/src/features/my-consents/components/ConsentRegistryFilters.tsx
+++ b/dpdp-accelerator/react-apps/consent-portal/frontend/src/features/my-consents/components/ConsentRegistryFilters.tsx
@@ -40,6 +40,7 @@ import { getConsentStateLabelKey } from '../utils/statusChip'
 
 interface ConsentRegistryFiltersProps {
   filters: ConsentRegistryFiltersModel
+  isPendingView: boolean
   onFilterChange: (nextFilters: ConsentRegistryFiltersModel) => void
   onClear: () => void
 }
@@ -58,6 +59,7 @@ function toDateOnly(date: Date | null): string {
 
 function ConsentRegistryFilters({
   filters,
+  isPendingView,
   onFilterChange,
   onClear,
 }: ConsentRegistryFiltersProps): React.JSX.Element {
@@ -94,7 +96,7 @@ function ConsentRegistryFilters({
 
         <FormControl
           size="small"
-          disabled={filters.state === 'PENDING'}
+          disabled={isPendingView}
           sx={{ width: { xs: '100%', sm: 220 }, height: MAIN_FILTER_HEIGHT, flexShrink: 0 }}
         >
           <InputLabel id="consent-state-label">{t('consentRegistry.filters.state')}</InputLabel>
@@ -123,7 +125,7 @@ function ConsentRegistryFilters({
 
         <FormControl
           size="small"
-          disabled={filters.state === 'PENDING'}
+          disabled={isPendingView}
           sx={{ width: { xs: '100%', sm: 200 }, height: MAIN_FILTER_HEIGHT, flexShrink: 0 }}
         >
           <InputLabel id="consent-relation-label">


### PR DESCRIPTION
### Issue

  The **PENDING** state was being used to identify the dedicated **My Pending Consents** view. As a result, selecting PENDING as a filter on the **My Consents** page incorrectly switched the page title, breadcrumb, navigation state, and filter behavior to the pending-consents view. This Fixes #123 

  ### Fix

  - Added a dedicated view=pending URL parameter for the pending-consents page.
  - Updated sidebar and dashboard links to use the new pending view parameter.
  - Limited locked filters and relation=ANY behavior to the dedicated pending view.
  - Preserved normal state and relation filtering on the “My Consents” page.
  - Updated page titles, breadcrumbs, and navigation selection logic.
  - Added and updated tests covering both pending-view and regular filtering behavior.

  ### Tests Performed

  - Full frontend test suite: 42 test files passed, 298 tests passed
  - Targeted tests: 31 tests passed
      - ConsentRegistryPage.test.tsx
      - AppSidebar.test.tsx
      - MainLayout.test.tsx
