### PR TITLE
Fix the approve button visibility after even after approval when ther…

### DIFF
--- a/dpdp-accelerator/react-apps/consent-portal/frontend/src/__tests__/CurrentUserApi.test.ts
+++ b/dpdp-accelerator/react-apps/consent-portal/frontend/src/__tests__/CurrentUserApi.test.ts
@@ -51,7 +51,7 @@ describe('current-user API', () => {
     })
 
     await expect(fetchCurrentUser()).resolves.toEqual({
-      userId: 'user-1',
+      userId: 'admin@acme.com',
       organizationId: 'acme.com',
       hideSelfConsentsForAdmins: true,
       scopes: ['openid', IS_SCOPES.LOGIN, IS_SCOPES.CONSENT_VIEW],

--- a/dpdp-accelerator/react-apps/consent-portal/frontend/src/features/auth/api/currentUserApi.ts
+++ b/dpdp-accelerator/react-apps/consent-portal/frontend/src/features/auth/api/currentUserApi.ts
@@ -53,7 +53,9 @@ export async function fetchCurrentUser(): Promise<CurrentUser> {
     throw new Error('no authenticated session')
   }
 
-  const userId = (user.sub ?? user.username ?? '').trim()
+  // Consent subjects and authorizations use the Identity Server username. The OIDC subject is
+  // commonly an internal UUID and does not match those consent identifiers.
+  const userId = (user.username ?? user.sub ?? '').trim()
   if (!userId) {
     throw new Error('the authenticated session has no subject')
   }


### PR DESCRIPTION
## Issue

The consent portal used the OIDC sub claim as the logged-in user ID. This value is a UUID, while consent subjectId and authorization.userId values use the username/email.

Because the identifiers did not match, the portal could not detect that a user had already approved a consent. When the overall consent remained PENDING because other authorizations were incomplete, the Approve button remained visible. This Fixes #85 

## Fix

- Updated the current-user mapping to prefer the OIDC username claim and fall back to sub only when the username is unavailable.
- Updated the related unit test to verify the new behavior.

## Validation

  - Full frontend test suite passed: 42 test files, 298 tests
  - TypeScript compilation passed
  - git diff --check passed