### PR TITLE
Reordered the consent portal menu items

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,4 @@ docs/build/
 # Env
 .env
 .env.local
+/docs/pnpm-lock.yaml

--- a/.gitignore
+++ b/.gitignore
@@ -47,4 +47,3 @@ docs/build/
 # Env
 .env
 .env.local
-/docs/pnpm-lock.yaml

--- a/dpdp-accelerator/react-apps/consent-portal/frontend/src/components/layout/sidebar/AppSidebar.tsx
+++ b/dpdp-accelerator/react-apps/consent-portal/frontend/src/components/layout/sidebar/AppSidebar.tsx
@@ -214,10 +214,10 @@ function AppSidebar({ collapsed }: AppSidebarProps): React.JSX.Element {
   const visibleItems = [
     ...dashboardItems,
     ...consentItems,
-    ...eventItems,
-    ...catalogItems,
     ...complaintItems,
     ...administrationItems,
+    ...catalogItems,
+    ...eventItems,
   ]
 
   const activeItem = mapPathToMenuId(location.pathname, location.search)
@@ -270,18 +270,6 @@ function AppSidebar({ collapsed }: AppSidebarProps): React.JSX.Element {
           </Sidebar.Category>
         ) : null}
 
-        {eventItems.length > 0 ? (
-          <Sidebar.Category>
-            <Sidebar.CategoryLabel>{t('sidebar.events')}</Sidebar.CategoryLabel>
-            {eventItems.map((item) => (
-              <Sidebar.Item key={item.id} id={item.id}>
-                <Sidebar.ItemIcon>{item.icon}</Sidebar.ItemIcon>
-                <Sidebar.ItemLabel>{t(item.labelKey)}</Sidebar.ItemLabel>
-              </Sidebar.Item>
-            ))}
-          </Sidebar.Category>
-        ) : null}
-
         {administrationItems.length > 0 ? (
           <Sidebar.Category>
             <Sidebar.CategoryLabel>{t('sidebar.administration')}</Sidebar.CategoryLabel>
@@ -298,6 +286,18 @@ function AppSidebar({ collapsed }: AppSidebarProps): React.JSX.Element {
           <Sidebar.Category>
             <Sidebar.CategoryLabel>{t('sidebar.catalog')}</Sidebar.CategoryLabel>
             {catalogItems.map((item) => (
+              <Sidebar.Item key={item.id} id={item.id}>
+                <Sidebar.ItemIcon>{item.icon}</Sidebar.ItemIcon>
+                <Sidebar.ItemLabel>{t(item.labelKey)}</Sidebar.ItemLabel>
+              </Sidebar.Item>
+            ))}
+          </Sidebar.Category>
+        ) : null}
+
+        {eventItems.length > 0 ? (
+          <Sidebar.Category>
+            <Sidebar.CategoryLabel>{t('sidebar.events')}</Sidebar.CategoryLabel>
+            {eventItems.map((item) => (
               <Sidebar.Item key={item.id} id={item.id}>
                 <Sidebar.ItemIcon>{item.icon}</Sidebar.ItemIcon>
                 <Sidebar.ItemLabel>{t(item.labelKey)}</Sidebar.ItemLabel>


### PR DESCRIPTION
### Description

Moved the Event-related menu section to the bottom of the Consent Portal sidebar while preserving all existing menu items and authorization behavior. Fixes #169.

Validation completed: AppSidebar.test.tsx - 6 tests passed

<img width="252" height="607" alt="Image" src="https://github.com/user-attachments/assets/b41abce5-11ae-4cf8-8230-1834d4f8f628" />
