### PR TITLE
Separated event API models from service DTOs

### DIFF
--- a/dpdp-accelerator/internal-webapps/org.wso2.dpdp.accelerator.event.notifications.endpoint/README.md
+++ b/dpdp-accelerator/internal-webapps/org.wso2.dpdp.accelerator.event.notifications.endpoint/README.md
@@ -1,0 +1,55 @@
+# Event Notification REST models
+
+`src/main/resources/event-notifications.yaml` owns the public JSON contract.
+OpenAPI Generator produces endpoint-local models in `src/gen/java`.
+Keep these generated files under version control and do not edit them by hand.
+
+From the repository root, regenerate and verify this module with:
+
+```sh
+mvn -f dpdp-accelerator/internal-webapps/org.wso2.dpdp.accelerator.event.notifications.endpoint/pom.xml \
+  -Ddpdp.dto.codegen.skip=false verify
+```
+
+This command requires the current reactor dependencies to be installed locally.
+Normal builds compile the committed models with generation disabled. The generator
+version is pinned in the parent POM. Review the specification and generated-source
+diff together; a second regeneration must produce identical Java sources. Remove
+obsolete generated models explicitly when deleting or renaming schemas.
+
+## Mapping and compatibility
+
+`EventNotificationDtoMapper` converts generated create requests to service DTOs,
+and service results to generated response models, including pagination and nested
+delivery history. Handlers retain their service DTO interfaces. The service and DAO
+modules do not depend on generated endpoint models.
+
+The API keeps epoch-millisecond timestamps, string-valued event response payloads,
+null and empty collection behavior, status codes, and error envelopes. Response
+delivery settings expose a null shared secret. Legacy metadata accepted in create
+requests is documented as compatibility input; the existing handlers still derive
+tenant/group context and ignore caller-supplied metadata on creation.
+
+Generation maps URI properties to strings so the service remains responsible for
+URL validation. Automatic bean validation is disabled to retain existing service
+validation and error codes. Enum deserializers preserve the common enum parsers'
+case handling, whitespace handling, aliases, and exception causes.
+
+`src/main/openapi-templates/enumOuterClass.mustache` is the pinned generator's CXF
+enum template with support added for `x-class-extra-annotation`. This attaches
+the compatibility deserializers without editing generated enums. Review this
+template whenever upgrading the generator.
+
+Polling and completion requests remain raw strings through the endpoint and
+handler because their signatures depend on the original body. Their generated
+request models document the contract; they are not bound or reserialized before
+signature verification. Polling responses are mapped normally.
+
+## Verification
+
+The TestNG suite includes mapper JSON comparisons against the previous service DTO
+representation, nested fields, legacy request fields, enum aliases, error codes,
+secret suppression, and exact signed-body forwarding. Maven verification enforces
+the existing coverage threshold for handwritten code; generated DTOs are excluded.
+Inspect the resulting WAR for generated classes and runtime dependencies before
+performing a smoke test in Identity Server.

--- a/dpdp-accelerator/internal-webapps/org.wso2.dpdp.accelerator.event.notifications.endpoint/pom.xml
+++ b/dpdp-accelerator/internal-webapps/org.wso2.dpdp.accelerator.event.notifications.endpoint/pom.xml
@@ -40,6 +40,10 @@
 
     <dependencies>
         <dependency>
+            <groupId>io.swagger</groupId>
+            <artifactId>swagger-annotations</artifactId>
+        </dependency>
+        <dependency>
             <groupId>commons-logging</groupId>
             <artifactId>commons-logging</artifactId>
             <scope>provided</scope>
@@ -124,6 +128,49 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.openapitools</groupId>
+                <artifactId>openapi-generator-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals><goal>generate</goal></goals>
+                        <configuration>
+                            <skip>${dpdp.dto.codegen.skip}</skip>
+                            <inputSpec>${project.basedir}/src/main/resources/event-notifications.yaml</inputSpec>
+                            <generatorName>jaxrs-cxf</generatorName>
+                            <templateDirectory>${project.basedir}/src/main/openapi-templates</templateDirectory>
+                            <generateApis>false</generateApis>
+                            <generateApiTests>false</generateApiTests>
+                            <generateApiDocumentation>false</generateApiDocumentation>
+                            <generateModelTests>false</generateModelTests>
+                            <generateModelDocumentation>false</generateModelDocumentation>
+                            <generateSupportingFiles>false</generateSupportingFiles>
+                            <modelPackage>org.wso2.dpdp.accelerator.event.notifications.endpoint.dto</modelPackage>
+                            <typeMappings><typeMapping>URI=String</typeMapping></typeMappings>
+                            <configOptions>
+                                <sourceFolder>src/gen/java</sourceFolder>
+                                <useBeanValidation>false</useBeanValidation>
+                                <openApiNullable>false</openApiNullable>
+                                <containerDefaultToNull>true</containerDefaultToNull>
+                                <hideGenerationTimestamp>true</hideGenerationTimestamp>
+                            </configOptions>
+                            <output>${project.basedir}</output>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>add-generated-dto-source</id>
+                        <phase>generate-sources</phase>
+                        <goals><goal>add-source</goal></goals>
+                        <configuration><sources><source>src/gen/java</source></sources></configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>
                 <configuration>
@@ -154,6 +201,7 @@
                     <excludes>
                         <exclude>**/*Constants.class</exclude>
                         <exclude>**/*ErrorCodes.class</exclude>
+                        <exclude>**/endpoint/dto/**</exclude>
                     </excludes>
                 </configuration>
                 <executions>

--- a/dpdp-accelerator/internal-webapps/org.wso2.dpdp.accelerator.event.notifications.endpoint/src/gen/java/org/wso2/dpdp/accelerator/event/notifications/endpoint/dto/CompletionRequest.java
+++ b/dpdp-accelerator/internal-webapps/org.wso2.dpdp.accelerator.event.notifications.endpoint/src/gen/java/org/wso2/dpdp/accelerator/event/notifications/endpoint/dto/CompletionRequest.java
@@ -1,0 +1,122 @@
+package org.wso2.dpdp.accelerator.event.notifications.endpoint.dto;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import org.wso2.dpdp.accelerator.event.notifications.endpoint.dto.CompletionStatus;
+
+import io.swagger.annotations.ApiModelProperty;
+import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+
+public class CompletionRequest  {
+  
+  @ApiModelProperty(required = true, value = "")
+
+  private CompletionStatus completionStatus;
+
+ /**
+  * Absolute HTTPS URL without credentials or a fragment.
+  */
+  @ApiModelProperty(required = true, value = "Absolute HTTPS URL without credentials or a fragment.")
+
+  private String completionEvidence;
+
+  @ApiModelProperty(value = "")
+
+  private Long completedAt;
+ /**
+   * Get completionStatus
+   * @return completionStatus
+  **/
+  @JsonProperty("completionStatus")
+  public CompletionStatus getCompletionStatus() {
+    return completionStatus;
+  }
+
+  public void setCompletionStatus(CompletionStatus completionStatus) {
+    this.completionStatus = completionStatus;
+  }
+
+  public CompletionRequest completionStatus(CompletionStatus completionStatus) {
+    this.completionStatus = completionStatus;
+    return this;
+  }
+
+ /**
+   * Absolute HTTPS URL without credentials or a fragment.
+   * @return completionEvidence
+  **/
+  @JsonProperty("completionEvidence")
+  public String getCompletionEvidence() {
+    return completionEvidence;
+  }
+
+  public void setCompletionEvidence(String completionEvidence) {
+    this.completionEvidence = completionEvidence;
+  }
+
+  public CompletionRequest completionEvidence(String completionEvidence) {
+    this.completionEvidence = completionEvidence;
+    return this;
+  }
+
+ /**
+   * Get completedAt
+   * minimum: 0
+   * @return completedAt
+  **/
+  @JsonProperty("completedAt")
+  public Long getCompletedAt() {
+    return completedAt;
+  }
+
+  public void setCompletedAt(Long completedAt) {
+    this.completedAt = completedAt;
+  }
+
+  public CompletionRequest completedAt(Long completedAt) {
+    this.completedAt = completedAt;
+    return this;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    CompletionRequest completionRequest = (CompletionRequest) o;
+    return Objects.equals(this.completionStatus, completionRequest.completionStatus) &&
+        Objects.equals(this.completionEvidence, completionRequest.completionEvidence) &&
+        Objects.equals(this.completedAt, completionRequest.completedAt);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(completionStatus, completionEvidence, completedAt);
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("class CompletionRequest {\n");
+    
+    sb.append("    completionStatus: ").append(toIndentedString(completionStatus)).append("\n");
+    sb.append("    completionEvidence: ").append(toIndentedString(completionEvidence)).append("\n");
+    sb.append("    completedAt: ").append(toIndentedString(completedAt)).append("\n");
+    sb.append("}");
+    return sb.toString();
+  }
+
+  /**
+   * Convert the given object to string with each line indented by 4 spaces
+   * (except the first line).
+   */
+  private static String toIndentedString(Object o) {
+    return o == null ? "null" : o.toString().replace("\n", "\n    ");
+  }
+}
+

--- a/dpdp-accelerator/internal-webapps/org.wso2.dpdp.accelerator.event.notifications.endpoint/src/gen/java/org/wso2/dpdp/accelerator/event/notifications/endpoint/dto/CompletionStatus.java
+++ b/dpdp-accelerator/internal-webapps/org.wso2.dpdp.accelerator.event.notifications.endpoint/src/gen/java/org/wso2/dpdp/accelerator/event/notifications/endpoint/dto/CompletionStatus.java
@@ -1,0 +1,43 @@
+package org.wso2.dpdp.accelerator.event.notifications.endpoint.dto;
+
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+/**
+ * Gets or Sets CompletionStatus
+ */
+public enum CompletionStatus {
+  
+  COMPLETED("completed"),
+  
+  ACK("ack"),
+  
+  DISPUTED("disputed"),
+  
+  PARTIAL("partial");
+
+  private String value;
+
+  CompletionStatus(String value) {
+    this.value = value;
+  }
+
+  @Override
+  @JsonValue
+  public String toString() {
+    return String.valueOf(value);
+  }
+
+  @JsonCreator
+  public static CompletionStatus fromValue(String value) {
+    for (CompletionStatus b : CompletionStatus.values()) {
+      if (b.value.equals(value)) {
+        return b;
+      }
+    }
+    throw new IllegalArgumentException("Unexpected value '" + value + "'");
+  }
+
+}
+

--- a/dpdp-accelerator/internal-webapps/org.wso2.dpdp.accelerator.event.notifications.endpoint/src/gen/java/org/wso2/dpdp/accelerator/event/notifications/endpoint/dto/Delivery.java
+++ b/dpdp-accelerator/internal-webapps/org.wso2.dpdp.accelerator.event.notifications.endpoint/src/gen/java/org/wso2/dpdp/accelerator/event/notifications/endpoint/dto/Delivery.java
@@ -1,0 +1,238 @@
+package org.wso2.dpdp.accelerator.event.notifications.endpoint.dto;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import org.wso2.dpdp.accelerator.event.notifications.endpoint.dto.DeliveryMode;
+
+import io.swagger.annotations.ApiModelProperty;
+import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+
+public class Delivery  {
+  
+  @ApiModelProperty(required = true, value = "")
+
+  private String deliveryId;
+
+  @ApiModelProperty(required = true, value = "")
+
+  private String eventId;
+
+  @ApiModelProperty(value = "")
+
+  private String subscriptionId;
+
+  @ApiModelProperty(value = "")
+
+  private String groupId;
+
+  @ApiModelProperty(value = "")
+
+  private String topic;
+
+  @ApiModelProperty(required = true, value = "")
+
+  private String currentStatus;
+
+  @ApiModelProperty(required = true, value = "")
+
+  private DeliveryMode deliveryMode;
+
+  @ApiModelProperty(required = true, value = "")
+
+  private Long occurredAt;
+ /**
+   * Get deliveryId
+   * @return deliveryId
+  **/
+  @JsonProperty("deliveryId")
+  public String getDeliveryId() {
+    return deliveryId;
+  }
+
+  public void setDeliveryId(String deliveryId) {
+    this.deliveryId = deliveryId;
+  }
+
+  public Delivery deliveryId(String deliveryId) {
+    this.deliveryId = deliveryId;
+    return this;
+  }
+
+ /**
+   * Get eventId
+   * @return eventId
+  **/
+  @JsonProperty("eventId")
+  public String getEventId() {
+    return eventId;
+  }
+
+  public void setEventId(String eventId) {
+    this.eventId = eventId;
+  }
+
+  public Delivery eventId(String eventId) {
+    this.eventId = eventId;
+    return this;
+  }
+
+ /**
+   * Get subscriptionId
+   * @return subscriptionId
+  **/
+  @JsonProperty("subscriptionId")
+  public String getSubscriptionId() {
+    return subscriptionId;
+  }
+
+  public void setSubscriptionId(String subscriptionId) {
+    this.subscriptionId = subscriptionId;
+  }
+
+  public Delivery subscriptionId(String subscriptionId) {
+    this.subscriptionId = subscriptionId;
+    return this;
+  }
+
+ /**
+   * Get groupId
+   * @return groupId
+  **/
+  @JsonProperty("groupId")
+  public String getGroupId() {
+    return groupId;
+  }
+
+  public void setGroupId(String groupId) {
+    this.groupId = groupId;
+  }
+
+  public Delivery groupId(String groupId) {
+    this.groupId = groupId;
+    return this;
+  }
+
+ /**
+   * Get topic
+   * @return topic
+  **/
+  @JsonProperty("topic")
+  public String getTopic() {
+    return topic;
+  }
+
+  public void setTopic(String topic) {
+    this.topic = topic;
+  }
+
+  public Delivery topic(String topic) {
+    this.topic = topic;
+    return this;
+  }
+
+ /**
+   * Get currentStatus
+   * @return currentStatus
+  **/
+  @JsonProperty("currentStatus")
+  public String getCurrentStatus() {
+    return currentStatus;
+  }
+
+  public void setCurrentStatus(String currentStatus) {
+    this.currentStatus = currentStatus;
+  }
+
+  public Delivery currentStatus(String currentStatus) {
+    this.currentStatus = currentStatus;
+    return this;
+  }
+
+ /**
+   * Get deliveryMode
+   * @return deliveryMode
+  **/
+  @JsonProperty("deliveryMode")
+  public DeliveryMode getDeliveryMode() {
+    return deliveryMode;
+  }
+
+  public void setDeliveryMode(DeliveryMode deliveryMode) {
+    this.deliveryMode = deliveryMode;
+  }
+
+  public Delivery deliveryMode(DeliveryMode deliveryMode) {
+    this.deliveryMode = deliveryMode;
+    return this;
+  }
+
+ /**
+   * Get occurredAt
+   * @return occurredAt
+  **/
+  @JsonProperty("occurredAt")
+  public Long getOccurredAt() {
+    return occurredAt;
+  }
+
+  public void setOccurredAt(Long occurredAt) {
+    this.occurredAt = occurredAt;
+  }
+
+  public Delivery occurredAt(Long occurredAt) {
+    this.occurredAt = occurredAt;
+    return this;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    Delivery delivery = (Delivery) o;
+    return Objects.equals(this.deliveryId, delivery.deliveryId) &&
+        Objects.equals(this.eventId, delivery.eventId) &&
+        Objects.equals(this.subscriptionId, delivery.subscriptionId) &&
+        Objects.equals(this.groupId, delivery.groupId) &&
+        Objects.equals(this.topic, delivery.topic) &&
+        Objects.equals(this.currentStatus, delivery.currentStatus) &&
+        Objects.equals(this.deliveryMode, delivery.deliveryMode) &&
+        Objects.equals(this.occurredAt, delivery.occurredAt);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(deliveryId, eventId, subscriptionId, groupId, topic, currentStatus, deliveryMode, occurredAt);
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("class Delivery {\n");
+    
+    sb.append("    deliveryId: ").append(toIndentedString(deliveryId)).append("\n");
+    sb.append("    eventId: ").append(toIndentedString(eventId)).append("\n");
+    sb.append("    subscriptionId: ").append(toIndentedString(subscriptionId)).append("\n");
+    sb.append("    groupId: ").append(toIndentedString(groupId)).append("\n");
+    sb.append("    topic: ").append(toIndentedString(topic)).append("\n");
+    sb.append("    currentStatus: ").append(toIndentedString(currentStatus)).append("\n");
+    sb.append("    deliveryMode: ").append(toIndentedString(deliveryMode)).append("\n");
+    sb.append("    occurredAt: ").append(toIndentedString(occurredAt)).append("\n");
+    sb.append("}");
+    return sb.toString();
+  }
+
+  /**
+   * Convert the given object to string with each line indented by 4 spaces
+   * (except the first line).
+   */
+  private static String toIndentedString(Object o) {
+    return o == null ? "null" : o.toString().replace("\n", "\n    ");
+  }
+}
+

--- a/dpdp-accelerator/internal-webapps/org.wso2.dpdp.accelerator.event.notifications.endpoint/src/gen/java/org/wso2/dpdp/accelerator/event/notifications/endpoint/dto/DeliveryAttempt.java
+++ b/dpdp-accelerator/internal-webapps/org.wso2.dpdp.accelerator.event.notifications.endpoint/src/gen/java/org/wso2/dpdp/accelerator/event/notifications/endpoint/dto/DeliveryAttempt.java
@@ -1,0 +1,163 @@
+package org.wso2.dpdp.accelerator.event.notifications.endpoint.dto;
+
+
+import io.swagger.annotations.ApiModelProperty;
+import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+
+public class DeliveryAttempt  {
+  
+  @ApiModelProperty(required = true, value = "")
+
+  private Integer attempt;
+
+  @ApiModelProperty(required = true, value = "")
+
+  private String status;
+
+  @ApiModelProperty(required = true, value = "")
+
+  private Long timestamp;
+
+  @ApiModelProperty(value = "")
+
+  private Integer httpStatus;
+
+  @ApiModelProperty(value = "")
+
+  private String error;
+ /**
+   * Get attempt
+   * @return attempt
+  **/
+  @JsonProperty("attempt")
+  public Integer getAttempt() {
+    return attempt;
+  }
+
+  public void setAttempt(Integer attempt) {
+    this.attempt = attempt;
+  }
+
+  public DeliveryAttempt attempt(Integer attempt) {
+    this.attempt = attempt;
+    return this;
+  }
+
+ /**
+   * Get status
+   * @return status
+  **/
+  @JsonProperty("status")
+  public String getStatus() {
+    return status;
+  }
+
+  public void setStatus(String status) {
+    this.status = status;
+  }
+
+  public DeliveryAttempt status(String status) {
+    this.status = status;
+    return this;
+  }
+
+ /**
+   * Get timestamp
+   * @return timestamp
+  **/
+  @JsonProperty("timestamp")
+  public Long getTimestamp() {
+    return timestamp;
+  }
+
+  public void setTimestamp(Long timestamp) {
+    this.timestamp = timestamp;
+  }
+
+  public DeliveryAttempt timestamp(Long timestamp) {
+    this.timestamp = timestamp;
+    return this;
+  }
+
+ /**
+   * Get httpStatus
+   * @return httpStatus
+  **/
+  @JsonProperty("httpStatus")
+  public Integer getHttpStatus() {
+    return httpStatus;
+  }
+
+  public void setHttpStatus(Integer httpStatus) {
+    this.httpStatus = httpStatus;
+  }
+
+  public DeliveryAttempt httpStatus(Integer httpStatus) {
+    this.httpStatus = httpStatus;
+    return this;
+  }
+
+ /**
+   * Get error
+   * @return error
+  **/
+  @JsonProperty("error")
+  public String getError() {
+    return error;
+  }
+
+  public void setError(String error) {
+    this.error = error;
+  }
+
+  public DeliveryAttempt error(String error) {
+    this.error = error;
+    return this;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    DeliveryAttempt deliveryAttempt = (DeliveryAttempt) o;
+    return Objects.equals(this.attempt, deliveryAttempt.attempt) &&
+        Objects.equals(this.status, deliveryAttempt.status) &&
+        Objects.equals(this.timestamp, deliveryAttempt.timestamp) &&
+        Objects.equals(this.httpStatus, deliveryAttempt.httpStatus) &&
+        Objects.equals(this.error, deliveryAttempt.error);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(attempt, status, timestamp, httpStatus, error);
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("class DeliveryAttempt {\n");
+    
+    sb.append("    attempt: ").append(toIndentedString(attempt)).append("\n");
+    sb.append("    status: ").append(toIndentedString(status)).append("\n");
+    sb.append("    timestamp: ").append(toIndentedString(timestamp)).append("\n");
+    sb.append("    httpStatus: ").append(toIndentedString(httpStatus)).append("\n");
+    sb.append("    error: ").append(toIndentedString(error)).append("\n");
+    sb.append("}");
+    return sb.toString();
+  }
+
+  /**
+   * Convert the given object to string with each line indented by 4 spaces
+   * (except the first line).
+   */
+  private static String toIndentedString(Object o) {
+    return o == null ? "null" : o.toString().replace("\n", "\n    ");
+  }
+}
+

--- a/dpdp-accelerator/internal-webapps/org.wso2.dpdp.accelerator.event.notifications.endpoint/src/gen/java/org/wso2/dpdp/accelerator/event/notifications/endpoint/dto/DeliveryConfig.java
+++ b/dpdp-accelerator/internal-webapps/org.wso2.dpdp.accelerator.event.notifications.endpoint/src/gen/java/org/wso2/dpdp/accelerator/event/notifications/endpoint/dto/DeliveryConfig.java
@@ -1,0 +1,113 @@
+package org.wso2.dpdp.accelerator.event.notifications.endpoint.dto;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import org.wso2.dpdp.accelerator.event.notifications.endpoint.dto.DeliveryMode;
+
+import io.swagger.annotations.ApiModelProperty;
+import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+
+public class DeliveryConfig  {
+  
+  @ApiModelProperty(required = true, value = "")
+
+  private DeliveryMode mode;
+
+  @ApiModelProperty(value = "")
+
+  private String callbackUrl;
+
+ /**
+  * Always null in service responses.
+  */
+  @ApiModelProperty(value = "Always null in service responses.")
+
+  private String sharedSecret;
+ /**
+   * Get mode
+   * @return mode
+  **/
+  @JsonProperty("mode")
+  public DeliveryMode getMode() {
+    return mode;
+  }
+
+  public void setMode(DeliveryMode mode) {
+    this.mode = mode;
+  }
+
+  public DeliveryConfig mode(DeliveryMode mode) {
+    this.mode = mode;
+    return this;
+  }
+
+ /**
+   * Get callbackUrl
+   * @return callbackUrl
+  **/
+  @JsonProperty("callbackUrl")
+  public String getCallbackUrl() {
+    return callbackUrl;
+  }
+
+  public void setCallbackUrl(String callbackUrl) {
+    this.callbackUrl = callbackUrl;
+  }
+
+  public DeliveryConfig callbackUrl(String callbackUrl) {
+    this.callbackUrl = callbackUrl;
+    return this;
+  }
+
+ /**
+   * Always null in service responses.
+   * @return sharedSecret
+  **/
+  @JsonProperty("sharedSecret")
+  public String getSharedSecret() {
+    return sharedSecret;
+  }
+
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    DeliveryConfig deliveryConfig = (DeliveryConfig) o;
+    return Objects.equals(this.mode, deliveryConfig.mode) &&
+        Objects.equals(this.callbackUrl, deliveryConfig.callbackUrl) &&
+        Objects.equals(this.sharedSecret, deliveryConfig.sharedSecret);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(mode, callbackUrl, sharedSecret);
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("class DeliveryConfig {\n");
+    
+    sb.append("    mode: ").append(toIndentedString(mode)).append("\n");
+    sb.append("    callbackUrl: ").append(toIndentedString(callbackUrl)).append("\n");
+    sb.append("    sharedSecret: ").append(toIndentedString(sharedSecret)).append("\n");
+    sb.append("}");
+    return sb.toString();
+  }
+
+  /**
+   * Convert the given object to string with each line indented by 4 spaces
+   * (except the first line).
+   */
+  private static String toIndentedString(Object o) {
+    return o == null ? "null" : o.toString().replace("\n", "\n    ");
+  }
+}
+

--- a/dpdp-accelerator/internal-webapps/org.wso2.dpdp.accelerator.event.notifications.endpoint/src/gen/java/org/wso2/dpdp/accelerator/event/notifications/endpoint/dto/DeliveryConfigRequest.java
+++ b/dpdp-accelerator/internal-webapps/org.wso2.dpdp.accelerator.event.notifications.endpoint/src/gen/java/org/wso2/dpdp/accelerator/event/notifications/endpoint/dto/DeliveryConfigRequest.java
@@ -1,0 +1,121 @@
+package org.wso2.dpdp.accelerator.event.notifications.endpoint.dto;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import org.wso2.dpdp.accelerator.event.notifications.endpoint.dto.DeliveryMode;
+
+import io.swagger.annotations.ApiModelProperty;
+import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+
+public class DeliveryConfigRequest  {
+  
+  @ApiModelProperty(required = true, value = "")
+
+  private DeliveryMode mode;
+
+ /**
+  * Required for webhook and omitted for poll.
+  */
+  @ApiModelProperty(value = "Required for webhook and omitted for poll.")
+
+  private String callbackUrl;
+
+  @ApiModelProperty(required = true, value = "")
+
+  private String sharedSecret;
+ /**
+   * Get mode
+   * @return mode
+  **/
+  @JsonProperty("mode")
+  public DeliveryMode getMode() {
+    return mode;
+  }
+
+  public void setMode(DeliveryMode mode) {
+    this.mode = mode;
+  }
+
+  public DeliveryConfigRequest mode(DeliveryMode mode) {
+    this.mode = mode;
+    return this;
+  }
+
+ /**
+   * Required for webhook and omitted for poll.
+   * @return callbackUrl
+  **/
+  @JsonProperty("callbackUrl")
+  public String getCallbackUrl() {
+    return callbackUrl;
+  }
+
+  public void setCallbackUrl(String callbackUrl) {
+    this.callbackUrl = callbackUrl;
+  }
+
+  public DeliveryConfigRequest callbackUrl(String callbackUrl) {
+    this.callbackUrl = callbackUrl;
+    return this;
+  }
+
+ /**
+   * Get sharedSecret
+   * @return sharedSecret
+  **/
+  @JsonProperty("sharedSecret")
+  public String getSharedSecret() {
+    return sharedSecret;
+  }
+
+  public void setSharedSecret(String sharedSecret) {
+    this.sharedSecret = sharedSecret;
+  }
+
+  public DeliveryConfigRequest sharedSecret(String sharedSecret) {
+    this.sharedSecret = sharedSecret;
+    return this;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    DeliveryConfigRequest deliveryConfigRequest = (DeliveryConfigRequest) o;
+    return Objects.equals(this.mode, deliveryConfigRequest.mode) &&
+        Objects.equals(this.callbackUrl, deliveryConfigRequest.callbackUrl) &&
+        Objects.equals(this.sharedSecret, deliveryConfigRequest.sharedSecret);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(mode, callbackUrl, sharedSecret);
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("class DeliveryConfigRequest {\n");
+    
+    sb.append("    mode: ").append(toIndentedString(mode)).append("\n");
+    sb.append("    callbackUrl: ").append(toIndentedString(callbackUrl)).append("\n");
+    sb.append("    sharedSecret: ").append(toIndentedString(sharedSecret)).append("\n");
+    sb.append("}");
+    return sb.toString();
+  }
+
+  /**
+   * Convert the given object to string with each line indented by 4 spaces
+   * (except the first line).
+   */
+  private static String toIndentedString(Object o) {
+    return o == null ? "null" : o.toString().replace("\n", "\n    ");
+  }
+}
+

--- a/dpdp-accelerator/internal-webapps/org.wso2.dpdp.accelerator.event.notifications.endpoint/src/gen/java/org/wso2/dpdp/accelerator/event/notifications/endpoint/dto/DeliveryHistory.java
+++ b/dpdp-accelerator/internal-webapps/org.wso2.dpdp.accelerator.event.notifications.endpoint/src/gen/java/org/wso2/dpdp/accelerator/event/notifications/endpoint/dto/DeliveryHistory.java
@@ -1,0 +1,295 @@
+package org.wso2.dpdp.accelerator.event.notifications.endpoint.dto;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.wso2.dpdp.accelerator.event.notifications.endpoint.dto.DeliveryAttempt;
+import org.wso2.dpdp.accelerator.event.notifications.endpoint.dto.DeliveryMode;
+
+import io.swagger.annotations.ApiModelProperty;
+import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+
+public class DeliveryHistory  {
+  
+  @ApiModelProperty(required = true, value = "")
+
+  private String deliveryId;
+
+  @ApiModelProperty(required = true, value = "")
+
+  private String eventId;
+
+  @ApiModelProperty(value = "")
+
+  private String topic;
+
+  @ApiModelProperty(required = true, value = "")
+
+  private DeliveryMode deliveryMode;
+
+  @ApiModelProperty(required = true, value = "")
+
+  private String currentStatus;
+
+  @ApiModelProperty(required = true, value = "")
+
+  private Long occurredAt;
+
+  @ApiModelProperty(value = "")
+
+  private Long nextRetryAt;
+
+  @ApiModelProperty(value = "")
+
+  private String completionStatus;
+
+  @ApiModelProperty(value = "")
+
+  private String completionEvidence;
+
+  @ApiModelProperty(required = true, value = "")
+
+  private List<DeliveryAttempt> history;
+ /**
+   * Get deliveryId
+   * @return deliveryId
+  **/
+  @JsonProperty("deliveryId")
+  public String getDeliveryId() {
+    return deliveryId;
+  }
+
+  public void setDeliveryId(String deliveryId) {
+    this.deliveryId = deliveryId;
+  }
+
+  public DeliveryHistory deliveryId(String deliveryId) {
+    this.deliveryId = deliveryId;
+    return this;
+  }
+
+ /**
+   * Get eventId
+   * @return eventId
+  **/
+  @JsonProperty("eventId")
+  public String getEventId() {
+    return eventId;
+  }
+
+  public void setEventId(String eventId) {
+    this.eventId = eventId;
+  }
+
+  public DeliveryHistory eventId(String eventId) {
+    this.eventId = eventId;
+    return this;
+  }
+
+ /**
+   * Get topic
+   * @return topic
+  **/
+  @JsonProperty("topic")
+  public String getTopic() {
+    return topic;
+  }
+
+  public void setTopic(String topic) {
+    this.topic = topic;
+  }
+
+  public DeliveryHistory topic(String topic) {
+    this.topic = topic;
+    return this;
+  }
+
+ /**
+   * Get deliveryMode
+   * @return deliveryMode
+  **/
+  @JsonProperty("deliveryMode")
+  public DeliveryMode getDeliveryMode() {
+    return deliveryMode;
+  }
+
+  public void setDeliveryMode(DeliveryMode deliveryMode) {
+    this.deliveryMode = deliveryMode;
+  }
+
+  public DeliveryHistory deliveryMode(DeliveryMode deliveryMode) {
+    this.deliveryMode = deliveryMode;
+    return this;
+  }
+
+ /**
+   * Get currentStatus
+   * @return currentStatus
+  **/
+  @JsonProperty("currentStatus")
+  public String getCurrentStatus() {
+    return currentStatus;
+  }
+
+  public void setCurrentStatus(String currentStatus) {
+    this.currentStatus = currentStatus;
+  }
+
+  public DeliveryHistory currentStatus(String currentStatus) {
+    this.currentStatus = currentStatus;
+    return this;
+  }
+
+ /**
+   * Get occurredAt
+   * @return occurredAt
+  **/
+  @JsonProperty("occurredAt")
+  public Long getOccurredAt() {
+    return occurredAt;
+  }
+
+  public void setOccurredAt(Long occurredAt) {
+    this.occurredAt = occurredAt;
+  }
+
+  public DeliveryHistory occurredAt(Long occurredAt) {
+    this.occurredAt = occurredAt;
+    return this;
+  }
+
+ /**
+   * Get nextRetryAt
+   * @return nextRetryAt
+  **/
+  @JsonProperty("nextRetryAt")
+  public Long getNextRetryAt() {
+    return nextRetryAt;
+  }
+
+  public void setNextRetryAt(Long nextRetryAt) {
+    this.nextRetryAt = nextRetryAt;
+  }
+
+  public DeliveryHistory nextRetryAt(Long nextRetryAt) {
+    this.nextRetryAt = nextRetryAt;
+    return this;
+  }
+
+ /**
+   * Get completionStatus
+   * @return completionStatus
+  **/
+  @JsonProperty("completionStatus")
+  public String getCompletionStatus() {
+    return completionStatus;
+  }
+
+  public void setCompletionStatus(String completionStatus) {
+    this.completionStatus = completionStatus;
+  }
+
+  public DeliveryHistory completionStatus(String completionStatus) {
+    this.completionStatus = completionStatus;
+    return this;
+  }
+
+ /**
+   * Get completionEvidence
+   * @return completionEvidence
+  **/
+  @JsonProperty("completionEvidence")
+  public String getCompletionEvidence() {
+    return completionEvidence;
+  }
+
+  public void setCompletionEvidence(String completionEvidence) {
+    this.completionEvidence = completionEvidence;
+  }
+
+  public DeliveryHistory completionEvidence(String completionEvidence) {
+    this.completionEvidence = completionEvidence;
+    return this;
+  }
+
+ /**
+   * Get history
+   * @return history
+  **/
+  @JsonProperty("history")
+  public List<DeliveryAttempt> getHistory() {
+    return history;
+  }
+
+  public void setHistory(List<DeliveryAttempt> history) {
+    this.history = history;
+  }
+
+  public DeliveryHistory history(List<DeliveryAttempt> history) {
+    this.history = history;
+    return this;
+  }
+
+  public DeliveryHistory addHistoryItem(DeliveryAttempt historyItem) {
+    this.history.add(historyItem);
+    return this;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    DeliveryHistory deliveryHistory = (DeliveryHistory) o;
+    return Objects.equals(this.deliveryId, deliveryHistory.deliveryId) &&
+        Objects.equals(this.eventId, deliveryHistory.eventId) &&
+        Objects.equals(this.topic, deliveryHistory.topic) &&
+        Objects.equals(this.deliveryMode, deliveryHistory.deliveryMode) &&
+        Objects.equals(this.currentStatus, deliveryHistory.currentStatus) &&
+        Objects.equals(this.occurredAt, deliveryHistory.occurredAt) &&
+        Objects.equals(this.nextRetryAt, deliveryHistory.nextRetryAt) &&
+        Objects.equals(this.completionStatus, deliveryHistory.completionStatus) &&
+        Objects.equals(this.completionEvidence, deliveryHistory.completionEvidence) &&
+        Objects.equals(this.history, deliveryHistory.history);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(deliveryId, eventId, topic, deliveryMode, currentStatus, occurredAt, nextRetryAt, completionStatus, completionEvidence, history);
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("class DeliveryHistory {\n");
+    
+    sb.append("    deliveryId: ").append(toIndentedString(deliveryId)).append("\n");
+    sb.append("    eventId: ").append(toIndentedString(eventId)).append("\n");
+    sb.append("    topic: ").append(toIndentedString(topic)).append("\n");
+    sb.append("    deliveryMode: ").append(toIndentedString(deliveryMode)).append("\n");
+    sb.append("    currentStatus: ").append(toIndentedString(currentStatus)).append("\n");
+    sb.append("    occurredAt: ").append(toIndentedString(occurredAt)).append("\n");
+    sb.append("    nextRetryAt: ").append(toIndentedString(nextRetryAt)).append("\n");
+    sb.append("    completionStatus: ").append(toIndentedString(completionStatus)).append("\n");
+    sb.append("    completionEvidence: ").append(toIndentedString(completionEvidence)).append("\n");
+    sb.append("    history: ").append(toIndentedString(history)).append("\n");
+    sb.append("}");
+    return sb.toString();
+  }
+
+  /**
+   * Convert the given object to string with each line indented by 4 spaces
+   * (except the first line).
+   */
+  private static String toIndentedString(Object o) {
+    return o == null ? "null" : o.toString().replace("\n", "\n    ");
+  }
+}
+

--- a/dpdp-accelerator/internal-webapps/org.wso2.dpdp.accelerator.event.notifications.endpoint/src/gen/java/org/wso2/dpdp/accelerator/event/notifications/endpoint/dto/DeliveryMode.java
+++ b/dpdp-accelerator/internal-webapps/org.wso2.dpdp.accelerator.event.notifications.endpoint/src/gen/java/org/wso2/dpdp/accelerator/event/notifications/endpoint/dto/DeliveryMode.java
@@ -1,0 +1,40 @@
+package org.wso2.dpdp.accelerator.event.notifications.endpoint.dto;
+
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+/**
+ * Gets or Sets DeliveryMode
+ */
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(using = org.wso2.dpdp.accelerator.event.notifications.endpoint.util.RequestEnumDeserializers.Delivery.class)
+public enum DeliveryMode {
+  
+  WEBHOOK("webhook"),
+  
+  POLL("poll");
+
+  private String value;
+
+  DeliveryMode(String value) {
+    this.value = value;
+  }
+
+  @Override
+  @JsonValue
+  public String toString() {
+    return String.valueOf(value);
+  }
+
+  @JsonCreator
+  public static DeliveryMode fromValue(String value) {
+    for (DeliveryMode b : DeliveryMode.values()) {
+      if (b.value.equals(value)) {
+        return b;
+      }
+    }
+    throw new IllegalArgumentException("Unexpected value '" + value + "'");
+  }
+
+}
+

--- a/dpdp-accelerator/internal-webapps/org.wso2.dpdp.accelerator.event.notifications.endpoint/src/gen/java/org/wso2/dpdp/accelerator/event/notifications/endpoint/dto/DeliveryPage.java
+++ b/dpdp-accelerator/internal-webapps/org.wso2.dpdp.accelerator.event.notifications.endpoint/src/gen/java/org/wso2/dpdp/accelerator/event/notifications/endpoint/dto/DeliveryPage.java
@@ -1,0 +1,100 @@
+package org.wso2.dpdp.accelerator.event.notifications.endpoint.dto;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.wso2.dpdp.accelerator.event.notifications.endpoint.dto.Delivery;
+
+import io.swagger.annotations.ApiModelProperty;
+import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+
+public class DeliveryPage  {
+  
+  @ApiModelProperty(required = true, value = "")
+
+  private List<Delivery> items;
+
+  @ApiModelProperty(required = true, value = "")
+
+  private Integer total;
+ /**
+   * Get items
+   * @return items
+  **/
+  @JsonProperty("items")
+  public List<Delivery> getItems() {
+    return items;
+  }
+
+  public void setItems(List<Delivery> items) {
+    this.items = items;
+  }
+
+  public DeliveryPage items(List<Delivery> items) {
+    this.items = items;
+    return this;
+  }
+
+  public DeliveryPage addItemsItem(Delivery itemsItem) {
+    this.items.add(itemsItem);
+    return this;
+  }
+
+ /**
+   * Get total
+   * @return total
+  **/
+  @JsonProperty("total")
+  public Integer getTotal() {
+    return total;
+  }
+
+  public void setTotal(Integer total) {
+    this.total = total;
+  }
+
+  public DeliveryPage total(Integer total) {
+    this.total = total;
+    return this;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    DeliveryPage deliveryPage = (DeliveryPage) o;
+    return Objects.equals(this.items, deliveryPage.items) &&
+        Objects.equals(this.total, deliveryPage.total);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(items, total);
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("class DeliveryPage {\n");
+    
+    sb.append("    items: ").append(toIndentedString(items)).append("\n");
+    sb.append("    total: ").append(toIndentedString(total)).append("\n");
+    sb.append("}");
+    return sb.toString();
+  }
+
+  /**
+   * Convert the given object to string with each line indented by 4 spaces
+   * (except the first line).
+   */
+  private static String toIndentedString(Object o) {
+    return o == null ? "null" : o.toString().replace("\n", "\n    ");
+  }
+}
+

--- a/dpdp-accelerator/internal-webapps/org.wso2.dpdp.accelerator.event.notifications.endpoint/src/gen/java/org/wso2/dpdp/accelerator/event/notifications/endpoint/dto/Error.java
+++ b/dpdp-accelerator/internal-webapps/org.wso2.dpdp.accelerator.event.notifications.endpoint/src/gen/java/org/wso2/dpdp/accelerator/event/notifications/endpoint/dto/Error.java
@@ -1,0 +1,116 @@
+package org.wso2.dpdp.accelerator.event.notifications.endpoint.dto;
+
+
+import io.swagger.annotations.ApiModelProperty;
+import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+
+@com.fasterxml.jackson.annotation.JsonInclude(com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL)
+public class Error  {
+  
+  @ApiModelProperty(required = true, value = "")
+
+  private String code;
+
+  @ApiModelProperty(required = true, value = "")
+
+  private String message;
+
+  @ApiModelProperty(value = "")
+
+  private String description;
+ /**
+   * Get code
+   * @return code
+  **/
+  @JsonProperty("code")
+  public String getCode() {
+    return code;
+  }
+
+  public void setCode(String code) {
+    this.code = code;
+  }
+
+  public Error code(String code) {
+    this.code = code;
+    return this;
+  }
+
+ /**
+   * Get message
+   * @return message
+  **/
+  @JsonProperty("message")
+  public String getMessage() {
+    return message;
+  }
+
+  public void setMessage(String message) {
+    this.message = message;
+  }
+
+  public Error message(String message) {
+    this.message = message;
+    return this;
+  }
+
+ /**
+   * Get description
+   * @return description
+  **/
+  @JsonProperty("description")
+  public String getDescription() {
+    return description;
+  }
+
+  public void setDescription(String description) {
+    this.description = description;
+  }
+
+  public Error description(String description) {
+    this.description = description;
+    return this;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    Error error = (Error) o;
+    return Objects.equals(this.code, error.code) &&
+        Objects.equals(this.message, error.message) &&
+        Objects.equals(this.description, error.description);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(code, message, description);
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("class Error {\n");
+    
+    sb.append("    code: ").append(toIndentedString(code)).append("\n");
+    sb.append("    message: ").append(toIndentedString(message)).append("\n");
+    sb.append("    description: ").append(toIndentedString(description)).append("\n");
+    sb.append("}");
+    return sb.toString();
+  }
+
+  /**
+   * Convert the given object to string with each line indented by 4 spaces
+   * (except the first line).
+   */
+  private static String toIndentedString(Object o) {
+    return o == null ? "null" : o.toString().replace("\n", "\n    ");
+  }
+}
+

--- a/dpdp-accelerator/internal-webapps/org.wso2.dpdp.accelerator.event.notifications.endpoint/src/gen/java/org/wso2/dpdp/accelerator/event/notifications/endpoint/dto/Event.java
+++ b/dpdp-accelerator/internal-webapps/org.wso2.dpdp.accelerator.event.notifications.endpoint/src/gen/java/org/wso2/dpdp/accelerator/event/notifications/endpoint/dto/Event.java
@@ -1,0 +1,294 @@
+package org.wso2.dpdp.accelerator.event.notifications.endpoint.dto;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import io.swagger.annotations.ApiModelProperty;
+import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+
+public class Event  {
+  
+  @ApiModelProperty(required = true, value = "")
+
+  private String eventId;
+
+  @ApiModelProperty(required = true, value = "")
+
+  private String orgId;
+
+  @ApiModelProperty(required = true, value = "")
+
+  private String groupId;
+
+  @ApiModelProperty(required = true, value = "")
+
+  private String topicId;
+
+  @ApiModelProperty(value = "")
+
+  private String topic;
+
+ /**
+  * Persisted event JSON serialized as a JSON string.
+  */
+  @ApiModelProperty(required = true, value = "Persisted event JSON serialized as a JSON string.")
+
+  private String payload;
+
+  @ApiModelProperty(value = "")
+
+  private List<String> purposes;
+
+  @ApiModelProperty(value = "")
+
+  private Long occurredAt;
+
+  @ApiModelProperty(value = "")
+
+  private Long createdAt;
+
+  @ApiModelProperty(required = true, value = "")
+
+  private Integer deliveriesCount;
+ /**
+   * Get eventId
+   * @return eventId
+  **/
+  @JsonProperty("eventId")
+  public String getEventId() {
+    return eventId;
+  }
+
+  public void setEventId(String eventId) {
+    this.eventId = eventId;
+  }
+
+  public Event eventId(String eventId) {
+    this.eventId = eventId;
+    return this;
+  }
+
+ /**
+   * Get orgId
+   * @return orgId
+  **/
+  @JsonProperty("orgId")
+  public String getOrgId() {
+    return orgId;
+  }
+
+  public void setOrgId(String orgId) {
+    this.orgId = orgId;
+  }
+
+  public Event orgId(String orgId) {
+    this.orgId = orgId;
+    return this;
+  }
+
+ /**
+   * Get groupId
+   * @return groupId
+  **/
+  @JsonProperty("groupId")
+  public String getGroupId() {
+    return groupId;
+  }
+
+  public void setGroupId(String groupId) {
+    this.groupId = groupId;
+  }
+
+  public Event groupId(String groupId) {
+    this.groupId = groupId;
+    return this;
+  }
+
+ /**
+   * Get topicId
+   * @return topicId
+  **/
+  @JsonProperty("topicId")
+  public String getTopicId() {
+    return topicId;
+  }
+
+  public void setTopicId(String topicId) {
+    this.topicId = topicId;
+  }
+
+  public Event topicId(String topicId) {
+    this.topicId = topicId;
+    return this;
+  }
+
+ /**
+   * Get topic
+   * @return topic
+  **/
+  @JsonProperty("topic")
+  public String getTopic() {
+    return topic;
+  }
+
+  public void setTopic(String topic) {
+    this.topic = topic;
+  }
+
+  public Event topic(String topic) {
+    this.topic = topic;
+    return this;
+  }
+
+ /**
+   * Persisted event JSON serialized as a JSON string.
+   * @return payload
+  **/
+  @JsonProperty("payload")
+  public String getPayload() {
+    return payload;
+  }
+
+  public void setPayload(String payload) {
+    this.payload = payload;
+  }
+
+  public Event payload(String payload) {
+    this.payload = payload;
+    return this;
+  }
+
+ /**
+   * Get purposes
+   * @return purposes
+  **/
+  @JsonProperty("purposes")
+  public List<String> getPurposes() {
+    return purposes;
+  }
+
+  public void setPurposes(List<String> purposes) {
+    this.purposes = purposes;
+  }
+
+  public Event purposes(List<String> purposes) {
+    this.purposes = purposes;
+    return this;
+  }
+
+  public Event addPurposesItem(String purposesItem) {
+    this.purposes.add(purposesItem);
+    return this;
+  }
+
+ /**
+   * Get occurredAt
+   * @return occurredAt
+  **/
+  @JsonProperty("occurredAt")
+  public Long getOccurredAt() {
+    return occurredAt;
+  }
+
+  public void setOccurredAt(Long occurredAt) {
+    this.occurredAt = occurredAt;
+  }
+
+  public Event occurredAt(Long occurredAt) {
+    this.occurredAt = occurredAt;
+    return this;
+  }
+
+ /**
+   * Get createdAt
+   * @return createdAt
+  **/
+  @JsonProperty("createdAt")
+  public Long getCreatedAt() {
+    return createdAt;
+  }
+
+  public void setCreatedAt(Long createdAt) {
+    this.createdAt = createdAt;
+  }
+
+  public Event createdAt(Long createdAt) {
+    this.createdAt = createdAt;
+    return this;
+  }
+
+ /**
+   * Get deliveriesCount
+   * @return deliveriesCount
+  **/
+  @JsonProperty("deliveriesCount")
+  public Integer getDeliveriesCount() {
+    return deliveriesCount;
+  }
+
+  public void setDeliveriesCount(Integer deliveriesCount) {
+    this.deliveriesCount = deliveriesCount;
+  }
+
+  public Event deliveriesCount(Integer deliveriesCount) {
+    this.deliveriesCount = deliveriesCount;
+    return this;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    Event event = (Event) o;
+    return Objects.equals(this.eventId, event.eventId) &&
+        Objects.equals(this.orgId, event.orgId) &&
+        Objects.equals(this.groupId, event.groupId) &&
+        Objects.equals(this.topicId, event.topicId) &&
+        Objects.equals(this.topic, event.topic) &&
+        Objects.equals(this.payload, event.payload) &&
+        Objects.equals(this.purposes, event.purposes) &&
+        Objects.equals(this.occurredAt, event.occurredAt) &&
+        Objects.equals(this.createdAt, event.createdAt) &&
+        Objects.equals(this.deliveriesCount, event.deliveriesCount);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(eventId, orgId, groupId, topicId, topic, payload, purposes, occurredAt, createdAt, deliveriesCount);
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("class Event {\n");
+    
+    sb.append("    eventId: ").append(toIndentedString(eventId)).append("\n");
+    sb.append("    orgId: ").append(toIndentedString(orgId)).append("\n");
+    sb.append("    groupId: ").append(toIndentedString(groupId)).append("\n");
+    sb.append("    topicId: ").append(toIndentedString(topicId)).append("\n");
+    sb.append("    topic: ").append(toIndentedString(topic)).append("\n");
+    sb.append("    payload: ").append(toIndentedString(payload)).append("\n");
+    sb.append("    purposes: ").append(toIndentedString(purposes)).append("\n");
+    sb.append("    occurredAt: ").append(toIndentedString(occurredAt)).append("\n");
+    sb.append("    createdAt: ").append(toIndentedString(createdAt)).append("\n");
+    sb.append("    deliveriesCount: ").append(toIndentedString(deliveriesCount)).append("\n");
+    sb.append("}");
+    return sb.toString();
+  }
+
+  /**
+   * Convert the given object to string with each line indented by 4 spaces
+   * (except the first line).
+   */
+  private static String toIndentedString(Object o) {
+    return o == null ? "null" : o.toString().replace("\n", "\n    ");
+  }
+}
+

--- a/dpdp-accelerator/internal-webapps/org.wso2.dpdp.accelerator.event.notifications.endpoint/src/gen/java/org/wso2/dpdp/accelerator/event/notifications/endpoint/dto/EventCreateRequest.java
+++ b/dpdp-accelerator/internal-webapps/org.wso2.dpdp.accelerator.event.notifications.endpoint/src/gen/java/org/wso2/dpdp/accelerator/event/notifications/endpoint/dto/EventCreateRequest.java
@@ -1,0 +1,130 @@
+package org.wso2.dpdp.accelerator.event.notifications.endpoint.dto;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import io.swagger.annotations.ApiModelProperty;
+import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+
+public class EventCreateRequest  {
+  
+  @ApiModelProperty(required = true, value = "")
+
+  private String topic;
+
+  @ApiModelProperty(value = "")
+
+  private List<String> purposes;
+
+  @ApiModelProperty(required = true, value = "")
+
+  private Map<String, Object> payload;
+ /**
+   * Get topic
+   * @return topic
+  **/
+  @JsonProperty("topic")
+  public String getTopic() {
+    return topic;
+  }
+
+  public void setTopic(String topic) {
+    this.topic = topic;
+  }
+
+  public EventCreateRequest topic(String topic) {
+    this.topic = topic;
+    return this;
+  }
+
+ /**
+   * Get purposes
+   * @return purposes
+  **/
+  @JsonProperty("purposes")
+  public List<String> getPurposes() {
+    return purposes;
+  }
+
+  public void setPurposes(List<String> purposes) {
+    this.purposes = purposes;
+  }
+
+  public EventCreateRequest purposes(List<String> purposes) {
+    this.purposes = purposes;
+    return this;
+  }
+
+  public EventCreateRequest addPurposesItem(String purposesItem) {
+    this.purposes.add(purposesItem);
+    return this;
+  }
+
+ /**
+   * Get payload
+   * @return payload
+  **/
+  @JsonProperty("payload")
+  public Map<String, Object> getPayload() {
+    return payload;
+  }
+
+  public void setPayload(Map<String, Object> payload) {
+    this.payload = payload;
+  }
+
+  public EventCreateRequest payload(Map<String, Object> payload) {
+    this.payload = payload;
+    return this;
+  }
+
+  public EventCreateRequest putPayloadItem(String key, Object payloadItem) {
+    this.payload.put(key, payloadItem);
+    return this;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    EventCreateRequest eventCreateRequest = (EventCreateRequest) o;
+    return Objects.equals(this.topic, eventCreateRequest.topic) &&
+        Objects.equals(this.purposes, eventCreateRequest.purposes) &&
+        Objects.equals(this.payload, eventCreateRequest.payload);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(topic, purposes, payload);
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("class EventCreateRequest {\n");
+    
+    sb.append("    topic: ").append(toIndentedString(topic)).append("\n");
+    sb.append("    purposes: ").append(toIndentedString(purposes)).append("\n");
+    sb.append("    payload: ").append(toIndentedString(payload)).append("\n");
+    sb.append("}");
+    return sb.toString();
+  }
+
+  /**
+   * Convert the given object to string with each line indented by 4 spaces
+   * (except the first line).
+   */
+  private static String toIndentedString(Object o) {
+    return o == null ? "null" : o.toString().replace("\n", "\n    ");
+  }
+}
+

--- a/dpdp-accelerator/internal-webapps/org.wso2.dpdp.accelerator.event.notifications.endpoint/src/gen/java/org/wso2/dpdp/accelerator/event/notifications/endpoint/dto/EventPage.java
+++ b/dpdp-accelerator/internal-webapps/org.wso2.dpdp.accelerator.event.notifications.endpoint/src/gen/java/org/wso2/dpdp/accelerator/event/notifications/endpoint/dto/EventPage.java
@@ -1,0 +1,100 @@
+package org.wso2.dpdp.accelerator.event.notifications.endpoint.dto;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.wso2.dpdp.accelerator.event.notifications.endpoint.dto.Event;
+
+import io.swagger.annotations.ApiModelProperty;
+import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+
+public class EventPage  {
+  
+  @ApiModelProperty(required = true, value = "")
+
+  private List<Event> items;
+
+  @ApiModelProperty(required = true, value = "")
+
+  private Integer total;
+ /**
+   * Get items
+   * @return items
+  **/
+  @JsonProperty("items")
+  public List<Event> getItems() {
+    return items;
+  }
+
+  public void setItems(List<Event> items) {
+    this.items = items;
+  }
+
+  public EventPage items(List<Event> items) {
+    this.items = items;
+    return this;
+  }
+
+  public EventPage addItemsItem(Event itemsItem) {
+    this.items.add(itemsItem);
+    return this;
+  }
+
+ /**
+   * Get total
+   * @return total
+  **/
+  @JsonProperty("total")
+  public Integer getTotal() {
+    return total;
+  }
+
+  public void setTotal(Integer total) {
+    this.total = total;
+  }
+
+  public EventPage total(Integer total) {
+    this.total = total;
+    return this;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    EventPage eventPage = (EventPage) o;
+    return Objects.equals(this.items, eventPage.items) &&
+        Objects.equals(this.total, eventPage.total);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(items, total);
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("class EventPage {\n");
+    
+    sb.append("    items: ").append(toIndentedString(items)).append("\n");
+    sb.append("    total: ").append(toIndentedString(total)).append("\n");
+    sb.append("}");
+    return sb.toString();
+  }
+
+  /**
+   * Convert the given object to string with each line indented by 4 spaces
+   * (except the first line).
+   */
+  private static String toIndentedString(Object o) {
+    return o == null ? "null" : o.toString().replace("\n", "\n    ");
+  }
+}
+

--- a/dpdp-accelerator/internal-webapps/org.wso2.dpdp.accelerator.event.notifications.endpoint/src/gen/java/org/wso2/dpdp/accelerator/event/notifications/endpoint/dto/Filter.java
+++ b/dpdp-accelerator/internal-webapps/org.wso2.dpdp.accelerator.event.notifications.endpoint/src/gen/java/org/wso2/dpdp/accelerator/event/notifications/endpoint/dto/Filter.java
@@ -1,0 +1,102 @@
+package org.wso2.dpdp.accelerator.event.notifications.endpoint.dto;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.wso2.dpdp.accelerator.event.notifications.endpoint.dto.PurposeFilterMode;
+
+import io.swagger.annotations.ApiModelProperty;
+import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+
+public class Filter  {
+  
+  @ApiModelProperty(required = true, value = "")
+
+  private PurposeFilterMode type;
+
+  @ApiModelProperty(value = "")
+
+  private List<String> purposes;
+ /**
+   * Get type
+   * @return type
+  **/
+  @JsonProperty("type")
+  public PurposeFilterMode getType() {
+    return type;
+  }
+
+  public void setType(PurposeFilterMode type) {
+    this.type = type;
+  }
+
+  public Filter type(PurposeFilterMode type) {
+    this.type = type;
+    return this;
+  }
+
+ /**
+   * Get purposes
+   * @return purposes
+  **/
+  @JsonProperty("purposes")
+  public List<String> getPurposes() {
+    return purposes;
+  }
+
+  public void setPurposes(List<String> purposes) {
+    this.purposes = purposes;
+  }
+
+  public Filter purposes(List<String> purposes) {
+    this.purposes = purposes;
+    return this;
+  }
+
+  public Filter addPurposesItem(String purposesItem) {
+    this.purposes.add(purposesItem);
+    return this;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    Filter filter = (Filter) o;
+    return Objects.equals(this.type, filter.type) &&
+        Objects.equals(this.purposes, filter.purposes);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(type, purposes);
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("class Filter {\n");
+    
+    sb.append("    type: ").append(toIndentedString(type)).append("\n");
+    sb.append("    purposes: ").append(toIndentedString(purposes)).append("\n");
+    sb.append("}");
+    return sb.toString();
+  }
+
+  /**
+   * Convert the given object to string with each line indented by 4 spaces
+   * (except the first line).
+   */
+  private static String toIndentedString(Object o) {
+    return o == null ? "null" : o.toString().replace("\n", "\n    ");
+  }
+}
+

--- a/dpdp-accelerator/internal-webapps/org.wso2.dpdp.accelerator.event.notifications.endpoint/src/gen/java/org/wso2/dpdp/accelerator/event/notifications/endpoint/dto/JwsClaims.java
+++ b/dpdp-accelerator/internal-webapps/org.wso2.dpdp.accelerator.event.notifications.endpoint/src/gen/java/org/wso2/dpdp/accelerator/event/notifications/endpoint/dto/JwsClaims.java
@@ -1,0 +1,241 @@
+package org.wso2.dpdp.accelerator.event.notifications.endpoint.dto;
+
+import org.wso2.dpdp.accelerator.event.notifications.endpoint.dto.SignedEventEnvelope;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Decoded JWS claims. The iss value is the issuer configured by Identity Server for the tenant. The protected header also contains alg=RS256, typ=JWT, kid, and x5t#S256. The kid is resolved through the configured Identity Server KeyIDProvider and must match an entry from the trusted tenant JWKS endpoint.
+ */
+@ApiModel(description="Decoded JWS claims. The iss value is the issuer configured by Identity Server for the tenant. The protected header also contains alg=RS256, typ=JWT, kid, and x5t#S256. The kid is resolved through the configured Identity Server KeyIDProvider and must match an entry from the trusted tenant JWKS endpoint.")
+
+public class JwsClaims  {
+  
+  @ApiModelProperty(example = "https://is.example.com:9443/t/example.com/oauth2/token", required = true, value = "")
+
+  private String iss;
+
+  @ApiModelProperty(example = "processor-1", required = true, value = "")
+
+  private String sub;
+
+  @ApiModelProperty(example = "dpdp-event-notifications", required = true, value = "")
+
+  private String aud;
+
+  @ApiModelProperty(required = true, value = "")
+
+  private Long iat;
+
+  @ApiModelProperty(required = true, value = "")
+
+  private String jti;
+
+  @ApiModelProperty(required = true, value = "")
+
+  private String txn;
+
+  @ApiModelProperty(required = true, value = "")
+
+  private String payloadHash;
+
+  @ApiModelProperty(required = true, value = "")
+
+  private SignedEventEnvelope payload;
+ /**
+   * Get iss
+   * @return iss
+  **/
+  @JsonProperty("iss")
+  public String getIss() {
+    return iss;
+  }
+
+  public void setIss(String iss) {
+    this.iss = iss;
+  }
+
+  public JwsClaims iss(String iss) {
+    this.iss = iss;
+    return this;
+  }
+
+ /**
+   * Get sub
+   * @return sub
+  **/
+  @JsonProperty("sub")
+  public String getSub() {
+    return sub;
+  }
+
+  public void setSub(String sub) {
+    this.sub = sub;
+  }
+
+  public JwsClaims sub(String sub) {
+    this.sub = sub;
+    return this;
+  }
+
+ /**
+   * Get aud
+   * @return aud
+  **/
+  @JsonProperty("aud")
+  public String getAud() {
+    return aud;
+  }
+
+  public void setAud(String aud) {
+    this.aud = aud;
+  }
+
+  public JwsClaims aud(String aud) {
+    this.aud = aud;
+    return this;
+  }
+
+ /**
+   * Get iat
+   * @return iat
+  **/
+  @JsonProperty("iat")
+  public Long getIat() {
+    return iat;
+  }
+
+  public void setIat(Long iat) {
+    this.iat = iat;
+  }
+
+  public JwsClaims iat(Long iat) {
+    this.iat = iat;
+    return this;
+  }
+
+ /**
+   * Get jti
+   * @return jti
+  **/
+  @JsonProperty("jti")
+  public String getJti() {
+    return jti;
+  }
+
+  public void setJti(String jti) {
+    this.jti = jti;
+  }
+
+  public JwsClaims jti(String jti) {
+    this.jti = jti;
+    return this;
+  }
+
+ /**
+   * Get txn
+   * @return txn
+  **/
+  @JsonProperty("txn")
+  public String getTxn() {
+    return txn;
+  }
+
+  public void setTxn(String txn) {
+    this.txn = txn;
+  }
+
+  public JwsClaims txn(String txn) {
+    this.txn = txn;
+    return this;
+  }
+
+ /**
+   * Get payloadHash
+   * @return payloadHash
+  **/
+  @JsonProperty("payloadHash")
+  public String getPayloadHash() {
+    return payloadHash;
+  }
+
+  public void setPayloadHash(String payloadHash) {
+    this.payloadHash = payloadHash;
+  }
+
+  public JwsClaims payloadHash(String payloadHash) {
+    this.payloadHash = payloadHash;
+    return this;
+  }
+
+ /**
+   * Get payload
+   * @return payload
+  **/
+  @JsonProperty("payload")
+  public SignedEventEnvelope getPayload() {
+    return payload;
+  }
+
+  public void setPayload(SignedEventEnvelope payload) {
+    this.payload = payload;
+  }
+
+  public JwsClaims payload(SignedEventEnvelope payload) {
+    this.payload = payload;
+    return this;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    JwsClaims jwsClaims = (JwsClaims) o;
+    return Objects.equals(this.iss, jwsClaims.iss) &&
+        Objects.equals(this.sub, jwsClaims.sub) &&
+        Objects.equals(this.aud, jwsClaims.aud) &&
+        Objects.equals(this.iat, jwsClaims.iat) &&
+        Objects.equals(this.jti, jwsClaims.jti) &&
+        Objects.equals(this.txn, jwsClaims.txn) &&
+        Objects.equals(this.payloadHash, jwsClaims.payloadHash) &&
+        Objects.equals(this.payload, jwsClaims.payload);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(iss, sub, aud, iat, jti, txn, payloadHash, payload);
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("class JwsClaims {\n");
+    
+    sb.append("    iss: ").append(toIndentedString(iss)).append("\n");
+    sb.append("    sub: ").append(toIndentedString(sub)).append("\n");
+    sb.append("    aud: ").append(toIndentedString(aud)).append("\n");
+    sb.append("    iat: ").append(toIndentedString(iat)).append("\n");
+    sb.append("    jti: ").append(toIndentedString(jti)).append("\n");
+    sb.append("    txn: ").append(toIndentedString(txn)).append("\n");
+    sb.append("    payloadHash: ").append(toIndentedString(payloadHash)).append("\n");
+    sb.append("    payload: ").append(toIndentedString(payload)).append("\n");
+    sb.append("}");
+    return sb.toString();
+  }
+
+  /**
+   * Convert the given object to string with each line indented by 4 spaces
+   * (except the first line).
+   */
+  private static String toIndentedString(Object o) {
+    return o == null ? "null" : o.toString().replace("\n", "\n    ");
+  }
+}
+

--- a/dpdp-accelerator/internal-webapps/org.wso2.dpdp.accelerator.event.notifications.endpoint/src/gen/java/org/wso2/dpdp/accelerator/event/notifications/endpoint/dto/PollRequest.java
+++ b/dpdp-accelerator/internal-webapps/org.wso2.dpdp.accelerator.event.notifications.endpoint/src/gen/java/org/wso2/dpdp/accelerator/event/notifications/endpoint/dto/PollRequest.java
@@ -1,0 +1,191 @@
+package org.wso2.dpdp.accelerator.event.notifications.endpoint.dto;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
+import org.wso2.dpdp.accelerator.event.notifications.endpoint.dto.PollSetError;
+
+import io.swagger.annotations.ApiModelProperty;
+import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+
+public class PollRequest  {
+  
+ /**
+  * Optional compatibility field; when present it must equal the URL tenant.
+  */
+  @ApiModelProperty(value = "Optional compatibility field; when present it must equal the URL tenant.")
+
+  private String orgId;
+
+  @ApiModelProperty(value = "")
+
+  private Set<String> ack;
+
+  @ApiModelProperty(value = "")
+
+  private Map<String, PollSetError> setErrs;
+
+ /**
+  * Uses the configured default when omitted; the configured maximum defaults to 100.
+  */
+  @ApiModelProperty(value = "Uses the configured default when omitted; the configured maximum defaults to 100.")
+
+  private Integer maxEvents;
+
+ /**
+  * Uses the configured default when omitted; false is unsupported.
+  */
+  @ApiModelProperty(value = "Uses the configured default when omitted; false is unsupported.")
+
+  private Boolean returnImmediately;
+ /**
+   * Optional compatibility field; when present it must equal the URL tenant.
+   * @return orgId
+  **/
+  @JsonProperty("orgId")
+  public String getOrgId() {
+    return orgId;
+  }
+
+  public void setOrgId(String orgId) {
+    this.orgId = orgId;
+  }
+
+  public PollRequest orgId(String orgId) {
+    this.orgId = orgId;
+    return this;
+  }
+
+ /**
+   * Get ack
+   * @return ack
+  **/
+  @JsonProperty("ack")
+  public Set<String> getAck() {
+    return ack;
+  }
+
+  @JsonDeserialize(as = LinkedHashSet.class)
+  public void setAck(Set<String> ack) {
+    this.ack = ack;
+  }
+
+  public PollRequest ack(Set<String> ack) {
+    this.ack = ack;
+    return this;
+  }
+
+  public PollRequest addAckItem(String ackItem) {
+    this.ack.add(ackItem);
+    return this;
+  }
+
+ /**
+   * Get setErrs
+   * @return setErrs
+  **/
+  @JsonProperty("setErrs")
+  public Map<String, PollSetError> getSetErrs() {
+    return setErrs;
+  }
+
+  public void setSetErrs(Map<String, PollSetError> setErrs) {
+    this.setErrs = setErrs;
+  }
+
+  public PollRequest setErrs(Map<String, PollSetError> setErrs) {
+    this.setErrs = setErrs;
+    return this;
+  }
+
+  public PollRequest putSetErrsItem(String key, PollSetError setErrsItem) {
+    this.setErrs.put(key, setErrsItem);
+    return this;
+  }
+
+ /**
+   * Uses the configured default when omitted; the configured maximum defaults to 100.
+   * minimum: 0
+   * @return maxEvents
+  **/
+  @JsonProperty("maxEvents")
+  public Integer getMaxEvents() {
+    return maxEvents;
+  }
+
+  public void setMaxEvents(Integer maxEvents) {
+    this.maxEvents = maxEvents;
+  }
+
+  public PollRequest maxEvents(Integer maxEvents) {
+    this.maxEvents = maxEvents;
+    return this;
+  }
+
+ /**
+   * Uses the configured default when omitted; false is unsupported.
+   * @return returnImmediately
+  **/
+  @JsonProperty("returnImmediately")
+  public Boolean getReturnImmediately() {
+    return returnImmediately;
+  }
+
+  public void setReturnImmediately(Boolean returnImmediately) {
+    this.returnImmediately = returnImmediately;
+  }
+
+  public PollRequest returnImmediately(Boolean returnImmediately) {
+    this.returnImmediately = returnImmediately;
+    return this;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    PollRequest pollRequest = (PollRequest) o;
+    return Objects.equals(this.orgId, pollRequest.orgId) &&
+        Objects.equals(this.ack, pollRequest.ack) &&
+        Objects.equals(this.setErrs, pollRequest.setErrs) &&
+        Objects.equals(this.maxEvents, pollRequest.maxEvents) &&
+        Objects.equals(this.returnImmediately, pollRequest.returnImmediately);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(orgId, ack, setErrs, maxEvents, returnImmediately);
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("class PollRequest {\n");
+    
+    sb.append("    orgId: ").append(toIndentedString(orgId)).append("\n");
+    sb.append("    ack: ").append(toIndentedString(ack)).append("\n");
+    sb.append("    setErrs: ").append(toIndentedString(setErrs)).append("\n");
+    sb.append("    maxEvents: ").append(toIndentedString(maxEvents)).append("\n");
+    sb.append("    returnImmediately: ").append(toIndentedString(returnImmediately)).append("\n");
+    sb.append("}");
+    return sb.toString();
+  }
+
+  /**
+   * Convert the given object to string with each line indented by 4 spaces
+   * (except the first line).
+   */
+  private static String toIndentedString(Object o) {
+    return o == null ? "null" : o.toString().replace("\n", "\n    ");
+  }
+}
+

--- a/dpdp-accelerator/internal-webapps/org.wso2.dpdp.accelerator.event.notifications.endpoint/src/gen/java/org/wso2/dpdp/accelerator/event/notifications/endpoint/dto/PollResponse.java
+++ b/dpdp-accelerator/internal-webapps/org.wso2.dpdp.accelerator.event.notifications.endpoint/src/gen/java/org/wso2/dpdp/accelerator/event/notifications/endpoint/dto/PollResponse.java
@@ -1,0 +1,101 @@
+package org.wso2.dpdp.accelerator.event.notifications.endpoint.dto;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import io.swagger.annotations.ApiModelProperty;
+import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+
+public class PollResponse  {
+  
+  @ApiModelProperty(required = true, value = "")
+
+  private Boolean moreAvailable;
+
+ /**
+  * Map of deliveryId to compact RS256 JWS.
+  */
+  @ApiModelProperty(required = true, value = "Map of deliveryId to compact RS256 JWS.")
+
+  private Map<String, String> sets;
+ /**
+   * Get moreAvailable
+   * @return moreAvailable
+  **/
+  @JsonProperty("moreAvailable")
+  public Boolean getMoreAvailable() {
+    return moreAvailable;
+  }
+
+  public void setMoreAvailable(Boolean moreAvailable) {
+    this.moreAvailable = moreAvailable;
+  }
+
+  public PollResponse moreAvailable(Boolean moreAvailable) {
+    this.moreAvailable = moreAvailable;
+    return this;
+  }
+
+ /**
+   * Map of deliveryId to compact RS256 JWS.
+   * @return sets
+  **/
+  @JsonProperty("sets")
+  public Map<String, String> getSets() {
+    return sets;
+  }
+
+  public void setSets(Map<String, String> sets) {
+    this.sets = sets;
+  }
+
+  public PollResponse sets(Map<String, String> sets) {
+    this.sets = sets;
+    return this;
+  }
+
+  public PollResponse putSetsItem(String key, String setsItem) {
+    this.sets.put(key, setsItem);
+    return this;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    PollResponse pollResponse = (PollResponse) o;
+    return Objects.equals(this.moreAvailable, pollResponse.moreAvailable) &&
+        Objects.equals(this.sets, pollResponse.sets);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(moreAvailable, sets);
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("class PollResponse {\n");
+    
+    sb.append("    moreAvailable: ").append(toIndentedString(moreAvailable)).append("\n");
+    sb.append("    sets: ").append(toIndentedString(sets)).append("\n");
+    sb.append("}");
+    return sb.toString();
+  }
+
+  /**
+   * Convert the given object to string with each line indented by 4 spaces
+   * (except the first line).
+   */
+  private static String toIndentedString(Object o) {
+    return o == null ? "null" : o.toString().replace("\n", "\n    ");
+  }
+}
+

--- a/dpdp-accelerator/internal-webapps/org.wso2.dpdp.accelerator.event.notifications.endpoint/src/gen/java/org/wso2/dpdp/accelerator/event/notifications/endpoint/dto/PollSetError.java
+++ b/dpdp-accelerator/internal-webapps/org.wso2.dpdp.accelerator.event.notifications.endpoint/src/gen/java/org/wso2/dpdp/accelerator/event/notifications/endpoint/dto/PollSetError.java
@@ -1,0 +1,91 @@
+package org.wso2.dpdp.accelerator.event.notifications.endpoint.dto;
+
+
+import io.swagger.annotations.ApiModelProperty;
+import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+
+public class PollSetError  {
+  
+  @ApiModelProperty(required = true, value = "")
+
+  private String err;
+
+  @ApiModelProperty(required = true, value = "")
+
+  private String description;
+ /**
+   * Get err
+   * @return err
+  **/
+  @JsonProperty("err")
+  public String getErr() {
+    return err;
+  }
+
+  public void setErr(String err) {
+    this.err = err;
+  }
+
+  public PollSetError err(String err) {
+    this.err = err;
+    return this;
+  }
+
+ /**
+   * Get description
+   * @return description
+  **/
+  @JsonProperty("description")
+  public String getDescription() {
+    return description;
+  }
+
+  public void setDescription(String description) {
+    this.description = description;
+  }
+
+  public PollSetError description(String description) {
+    this.description = description;
+    return this;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    PollSetError pollSetError = (PollSetError) o;
+    return Objects.equals(this.err, pollSetError.err) &&
+        Objects.equals(this.description, pollSetError.description);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(err, description);
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("class PollSetError {\n");
+    
+    sb.append("    err: ").append(toIndentedString(err)).append("\n");
+    sb.append("    description: ").append(toIndentedString(description)).append("\n");
+    sb.append("}");
+    return sb.toString();
+  }
+
+  /**
+   * Convert the given object to string with each line indented by 4 spaces
+   * (except the first line).
+   */
+  private static String toIndentedString(Object o) {
+    return o == null ? "null" : o.toString().replace("\n", "\n    ");
+  }
+}
+

--- a/dpdp-accelerator/internal-webapps/org.wso2.dpdp.accelerator.event.notifications.endpoint/src/gen/java/org/wso2/dpdp/accelerator/event/notifications/endpoint/dto/PurposeFilterMode.java
+++ b/dpdp-accelerator/internal-webapps/org.wso2.dpdp.accelerator.event.notifications.endpoint/src/gen/java/org/wso2/dpdp/accelerator/event/notifications/endpoint/dto/PurposeFilterMode.java
@@ -1,0 +1,42 @@
+package org.wso2.dpdp.accelerator.event.notifications.endpoint.dto;
+
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+/**
+ * Gets or Sets PurposeFilterMode
+ */
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(using = org.wso2.dpdp.accelerator.event.notifications.endpoint.util.RequestEnumDeserializers.FilterMode.class)
+public enum PurposeFilterMode {
+  
+  ALL("all"),
+  
+  ALL_EXCEPT("all_except"),
+  
+  SPECIFIC("specific");
+
+  private String value;
+
+  PurposeFilterMode(String value) {
+    this.value = value;
+  }
+
+  @Override
+  @JsonValue
+  public String toString() {
+    return String.valueOf(value);
+  }
+
+  @JsonCreator
+  public static PurposeFilterMode fromValue(String value) {
+    for (PurposeFilterMode b : PurposeFilterMode.values()) {
+      if (b.value.equals(value)) {
+        return b;
+      }
+    }
+    throw new IllegalArgumentException("Unexpected value '" + value + "'");
+  }
+
+}
+

--- a/dpdp-accelerator/internal-webapps/org.wso2.dpdp.accelerator.event.notifications.endpoint/src/gen/java/org/wso2/dpdp/accelerator/event/notifications/endpoint/dto/SignedEventEnvelope.java
+++ b/dpdp-accelerator/internal-webapps/org.wso2.dpdp.accelerator.event.notifications.endpoint/src/gen/java/org/wso2/dpdp/accelerator/event/notifications/endpoint/dto/SignedEventEnvelope.java
@@ -1,0 +1,223 @@
+package org.wso2.dpdp.accelerator.event.notifications.endpoint.dto;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Object carried in the JWS payload claim for webhook and poll delivery.
+ */
+@ApiModel(description="Object carried in the JWS payload claim for webhook and poll delivery.")
+
+public class SignedEventEnvelope  {
+  
+  @ApiModelProperty(required = true, value = "")
+
+  private String deliveryId;
+
+  @ApiModelProperty(required = true, value = "")
+
+  private String eventId;
+
+  @ApiModelProperty(required = true, value = "")
+
+  private String subscriptionId;
+
+  @ApiModelProperty(required = true, value = "")
+
+  private String orgId;
+
+  @ApiModelProperty(required = true, value = "")
+
+  private String groupId;
+
+  @ApiModelProperty(required = true, value = "")
+
+  private String topic;
+
+  @ApiModelProperty(required = true, value = "")
+
+  private Map<String, Object> eventPayload;
+ /**
+   * Get deliveryId
+   * @return deliveryId
+  **/
+  @JsonProperty("deliveryId")
+  public String getDeliveryId() {
+    return deliveryId;
+  }
+
+  public void setDeliveryId(String deliveryId) {
+    this.deliveryId = deliveryId;
+  }
+
+  public SignedEventEnvelope deliveryId(String deliveryId) {
+    this.deliveryId = deliveryId;
+    return this;
+  }
+
+ /**
+   * Get eventId
+   * @return eventId
+  **/
+  @JsonProperty("eventId")
+  public String getEventId() {
+    return eventId;
+  }
+
+  public void setEventId(String eventId) {
+    this.eventId = eventId;
+  }
+
+  public SignedEventEnvelope eventId(String eventId) {
+    this.eventId = eventId;
+    return this;
+  }
+
+ /**
+   * Get subscriptionId
+   * @return subscriptionId
+  **/
+  @JsonProperty("subscriptionId")
+  public String getSubscriptionId() {
+    return subscriptionId;
+  }
+
+  public void setSubscriptionId(String subscriptionId) {
+    this.subscriptionId = subscriptionId;
+  }
+
+  public SignedEventEnvelope subscriptionId(String subscriptionId) {
+    this.subscriptionId = subscriptionId;
+    return this;
+  }
+
+ /**
+   * Get orgId
+   * @return orgId
+  **/
+  @JsonProperty("orgId")
+  public String getOrgId() {
+    return orgId;
+  }
+
+  public void setOrgId(String orgId) {
+    this.orgId = orgId;
+  }
+
+  public SignedEventEnvelope orgId(String orgId) {
+    this.orgId = orgId;
+    return this;
+  }
+
+ /**
+   * Get groupId
+   * @return groupId
+  **/
+  @JsonProperty("groupId")
+  public String getGroupId() {
+    return groupId;
+  }
+
+  public void setGroupId(String groupId) {
+    this.groupId = groupId;
+  }
+
+  public SignedEventEnvelope groupId(String groupId) {
+    this.groupId = groupId;
+    return this;
+  }
+
+ /**
+   * Get topic
+   * @return topic
+  **/
+  @JsonProperty("topic")
+  public String getTopic() {
+    return topic;
+  }
+
+  public void setTopic(String topic) {
+    this.topic = topic;
+  }
+
+  public SignedEventEnvelope topic(String topic) {
+    this.topic = topic;
+    return this;
+  }
+
+ /**
+   * Get eventPayload
+   * @return eventPayload
+  **/
+  @JsonProperty("eventPayload")
+  public Map<String, Object> getEventPayload() {
+    return eventPayload;
+  }
+
+  public void setEventPayload(Map<String, Object> eventPayload) {
+    this.eventPayload = eventPayload;
+  }
+
+  public SignedEventEnvelope eventPayload(Map<String, Object> eventPayload) {
+    this.eventPayload = eventPayload;
+    return this;
+  }
+
+  public SignedEventEnvelope putEventPayloadItem(String key, Object eventPayloadItem) {
+    this.eventPayload.put(key, eventPayloadItem);
+    return this;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    SignedEventEnvelope signedEventEnvelope = (SignedEventEnvelope) o;
+    return Objects.equals(this.deliveryId, signedEventEnvelope.deliveryId) &&
+        Objects.equals(this.eventId, signedEventEnvelope.eventId) &&
+        Objects.equals(this.subscriptionId, signedEventEnvelope.subscriptionId) &&
+        Objects.equals(this.orgId, signedEventEnvelope.orgId) &&
+        Objects.equals(this.groupId, signedEventEnvelope.groupId) &&
+        Objects.equals(this.topic, signedEventEnvelope.topic) &&
+        Objects.equals(this.eventPayload, signedEventEnvelope.eventPayload);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(deliveryId, eventId, subscriptionId, orgId, groupId, topic, eventPayload);
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("class SignedEventEnvelope {\n");
+    
+    sb.append("    deliveryId: ").append(toIndentedString(deliveryId)).append("\n");
+    sb.append("    eventId: ").append(toIndentedString(eventId)).append("\n");
+    sb.append("    subscriptionId: ").append(toIndentedString(subscriptionId)).append("\n");
+    sb.append("    orgId: ").append(toIndentedString(orgId)).append("\n");
+    sb.append("    groupId: ").append(toIndentedString(groupId)).append("\n");
+    sb.append("    topic: ").append(toIndentedString(topic)).append("\n");
+    sb.append("    eventPayload: ").append(toIndentedString(eventPayload)).append("\n");
+    sb.append("}");
+    return sb.toString();
+  }
+
+  /**
+   * Convert the given object to string with each line indented by 4 spaces
+   * (except the first line).
+   */
+  private static String toIndentedString(Object o) {
+    return o == null ? "null" : o.toString().replace("\n", "\n    ");
+  }
+}
+

--- a/dpdp-accelerator/internal-webapps/org.wso2.dpdp.accelerator.event.notifications.endpoint/src/gen/java/org/wso2/dpdp/accelerator/event/notifications/endpoint/dto/Subscription.java
+++ b/dpdp-accelerator/internal-webapps/org.wso2.dpdp.accelerator.event.notifications.endpoint/src/gen/java/org/wso2/dpdp/accelerator/event/notifications/endpoint/dto/Subscription.java
@@ -1,0 +1,312 @@
+package org.wso2.dpdp.accelerator.event.notifications.endpoint.dto;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import org.wso2.dpdp.accelerator.event.notifications.endpoint.dto.DeliveryConfig;
+import org.wso2.dpdp.accelerator.event.notifications.endpoint.dto.Filter;
+import org.wso2.dpdp.accelerator.event.notifications.endpoint.dto.SubscriptionStatus;
+
+import io.swagger.annotations.ApiModelProperty;
+import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+
+public class Subscription  {
+  
+  @ApiModelProperty(required = true, value = "")
+
+  private String subscriptionId;
+
+  @ApiModelProperty(required = true, value = "")
+
+  private String orgId;
+
+  @ApiModelProperty(required = true, value = "")
+
+  private String groupId;
+
+  @ApiModelProperty(required = true, value = "")
+
+  private String topic;
+
+  @ApiModelProperty(required = true, value = "")
+
+  private Filter filter;
+
+  @ApiModelProperty(required = true, value = "")
+
+  private DeliveryConfig delivery;
+
+  @ApiModelProperty(required = true, value = "")
+
+  private SubscriptionStatus status;
+
+  @ApiModelProperty(value = "")
+
+  private Long createdAt;
+
+  @ApiModelProperty(value = "")
+
+  private Long updatedAt;
+
+  @ApiModelProperty(value = "")
+
+  private Boolean alreadyExists;
+
+  @ApiModelProperty(value = "")
+
+  private String message;
+ /**
+   * Get subscriptionId
+   * @return subscriptionId
+  **/
+  @JsonProperty("subscriptionId")
+  public String getSubscriptionId() {
+    return subscriptionId;
+  }
+
+  public void setSubscriptionId(String subscriptionId) {
+    this.subscriptionId = subscriptionId;
+  }
+
+  public Subscription subscriptionId(String subscriptionId) {
+    this.subscriptionId = subscriptionId;
+    return this;
+  }
+
+ /**
+   * Get orgId
+   * @return orgId
+  **/
+  @JsonProperty("orgId")
+  public String getOrgId() {
+    return orgId;
+  }
+
+  public void setOrgId(String orgId) {
+    this.orgId = orgId;
+  }
+
+  public Subscription orgId(String orgId) {
+    this.orgId = orgId;
+    return this;
+  }
+
+ /**
+   * Get groupId
+   * @return groupId
+  **/
+  @JsonProperty("groupId")
+  public String getGroupId() {
+    return groupId;
+  }
+
+  public void setGroupId(String groupId) {
+    this.groupId = groupId;
+  }
+
+  public Subscription groupId(String groupId) {
+    this.groupId = groupId;
+    return this;
+  }
+
+ /**
+   * Get topic
+   * @return topic
+  **/
+  @JsonProperty("topic")
+  public String getTopic() {
+    return topic;
+  }
+
+  public void setTopic(String topic) {
+    this.topic = topic;
+  }
+
+  public Subscription topic(String topic) {
+    this.topic = topic;
+    return this;
+  }
+
+ /**
+   * Get filter
+   * @return filter
+  **/
+  @JsonProperty("filter")
+  public Filter getFilter() {
+    return filter;
+  }
+
+  public void setFilter(Filter filter) {
+    this.filter = filter;
+  }
+
+  public Subscription filter(Filter filter) {
+    this.filter = filter;
+    return this;
+  }
+
+ /**
+   * Get delivery
+   * @return delivery
+  **/
+  @JsonProperty("delivery")
+  public DeliveryConfig getDelivery() {
+    return delivery;
+  }
+
+  public void setDelivery(DeliveryConfig delivery) {
+    this.delivery = delivery;
+  }
+
+  public Subscription delivery(DeliveryConfig delivery) {
+    this.delivery = delivery;
+    return this;
+  }
+
+ /**
+   * Get status
+   * @return status
+  **/
+  @JsonProperty("status")
+  public SubscriptionStatus getStatus() {
+    return status;
+  }
+
+  public void setStatus(SubscriptionStatus status) {
+    this.status = status;
+  }
+
+  public Subscription status(SubscriptionStatus status) {
+    this.status = status;
+    return this;
+  }
+
+ /**
+   * Get createdAt
+   * @return createdAt
+  **/
+  @JsonProperty("createdAt")
+  public Long getCreatedAt() {
+    return createdAt;
+  }
+
+  public void setCreatedAt(Long createdAt) {
+    this.createdAt = createdAt;
+  }
+
+  public Subscription createdAt(Long createdAt) {
+    this.createdAt = createdAt;
+    return this;
+  }
+
+ /**
+   * Get updatedAt
+   * @return updatedAt
+  **/
+  @JsonProperty("updatedAt")
+  public Long getUpdatedAt() {
+    return updatedAt;
+  }
+
+  public void setUpdatedAt(Long updatedAt) {
+    this.updatedAt = updatedAt;
+  }
+
+  public Subscription updatedAt(Long updatedAt) {
+    this.updatedAt = updatedAt;
+    return this;
+  }
+
+ /**
+   * Get alreadyExists
+   * @return alreadyExists
+  **/
+  @JsonProperty("alreadyExists")
+  public Boolean getAlreadyExists() {
+    return alreadyExists;
+  }
+
+  public void setAlreadyExists(Boolean alreadyExists) {
+    this.alreadyExists = alreadyExists;
+  }
+
+  public Subscription alreadyExists(Boolean alreadyExists) {
+    this.alreadyExists = alreadyExists;
+    return this;
+  }
+
+ /**
+   * Get message
+   * @return message
+  **/
+  @JsonProperty("message")
+  public String getMessage() {
+    return message;
+  }
+
+  public void setMessage(String message) {
+    this.message = message;
+  }
+
+  public Subscription message(String message) {
+    this.message = message;
+    return this;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    Subscription subscription = (Subscription) o;
+    return Objects.equals(this.subscriptionId, subscription.subscriptionId) &&
+        Objects.equals(this.orgId, subscription.orgId) &&
+        Objects.equals(this.groupId, subscription.groupId) &&
+        Objects.equals(this.topic, subscription.topic) &&
+        Objects.equals(this.filter, subscription.filter) &&
+        Objects.equals(this.delivery, subscription.delivery) &&
+        Objects.equals(this.status, subscription.status) &&
+        Objects.equals(this.createdAt, subscription.createdAt) &&
+        Objects.equals(this.updatedAt, subscription.updatedAt) &&
+        Objects.equals(this.alreadyExists, subscription.alreadyExists) &&
+        Objects.equals(this.message, subscription.message);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(subscriptionId, orgId, groupId, topic, filter, delivery, status, createdAt, updatedAt, alreadyExists, message);
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("class Subscription {\n");
+    
+    sb.append("    subscriptionId: ").append(toIndentedString(subscriptionId)).append("\n");
+    sb.append("    orgId: ").append(toIndentedString(orgId)).append("\n");
+    sb.append("    groupId: ").append(toIndentedString(groupId)).append("\n");
+    sb.append("    topic: ").append(toIndentedString(topic)).append("\n");
+    sb.append("    filter: ").append(toIndentedString(filter)).append("\n");
+    sb.append("    delivery: ").append(toIndentedString(delivery)).append("\n");
+    sb.append("    status: ").append(toIndentedString(status)).append("\n");
+    sb.append("    createdAt: ").append(toIndentedString(createdAt)).append("\n");
+    sb.append("    updatedAt: ").append(toIndentedString(updatedAt)).append("\n");
+    sb.append("    alreadyExists: ").append(toIndentedString(alreadyExists)).append("\n");
+    sb.append("    message: ").append(toIndentedString(message)).append("\n");
+    sb.append("}");
+    return sb.toString();
+  }
+
+  /**
+   * Convert the given object to string with each line indented by 4 spaces
+   * (except the first line).
+   */
+  private static String toIndentedString(Object o) {
+    return o == null ? "null" : o.toString().replace("\n", "\n    ");
+  }
+}
+

--- a/dpdp-accelerator/internal-webapps/org.wso2.dpdp.accelerator.event.notifications.endpoint/src/gen/java/org/wso2/dpdp/accelerator/event/notifications/endpoint/dto/SubscriptionCreateRequest.java
+++ b/dpdp-accelerator/internal-webapps/org.wso2.dpdp.accelerator.event.notifications.endpoint/src/gen/java/org/wso2/dpdp/accelerator/event/notifications/endpoint/dto/SubscriptionCreateRequest.java
@@ -1,0 +1,333 @@
+package org.wso2.dpdp.accelerator.event.notifications.endpoint.dto;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import org.wso2.dpdp.accelerator.event.notifications.endpoint.dto.DeliveryConfigRequest;
+import org.wso2.dpdp.accelerator.event.notifications.endpoint.dto.Filter;
+import org.wso2.dpdp.accelerator.event.notifications.endpoint.dto.SubscriptionStatus;
+
+import io.swagger.annotations.ApiModelProperty;
+import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+
+public class SubscriptionCreateRequest  {
+  
+ /**
+  * Accepted for compatibility; ignored on creation.
+  */
+  @ApiModelProperty(value = "Accepted for compatibility; ignored on creation.")
+
+  private String subscriptionId;
+
+ /**
+  * Accepted for compatibility; tenant context determines the organization.
+  */
+  @ApiModelProperty(value = "Accepted for compatibility; tenant context determines the organization.")
+
+  private String orgId;
+
+ /**
+  * Accepted for compatibility; the handler derives the group from tenant context.
+  */
+  @ApiModelProperty(value = "Accepted for compatibility; the handler derives the group from tenant context.")
+
+  private String groupId;
+
+  @ApiModelProperty(value = "")
+
+  private SubscriptionStatus status;
+
+ /**
+  * Accepted for compatibility; ignored on creation.
+  */
+  @ApiModelProperty(value = "Accepted for compatibility; ignored on creation.")
+
+  private Long createdAt;
+
+ /**
+  * Accepted for compatibility; ignored on creation.
+  */
+  @ApiModelProperty(value = "Accepted for compatibility; ignored on creation.")
+
+  private Long updatedAt;
+
+ /**
+  * Accepted for compatibility; ignored on creation.
+  */
+  @ApiModelProperty(value = "Accepted for compatibility; ignored on creation.")
+
+  private Boolean alreadyExists;
+
+ /**
+  * Accepted for compatibility; ignored on creation.
+  */
+  @ApiModelProperty(value = "Accepted for compatibility; ignored on creation.")
+
+  private String message;
+
+  @ApiModelProperty(required = true, value = "")
+
+  private String topic;
+
+  @ApiModelProperty(value = "")
+
+  private Filter filter;
+
+  @ApiModelProperty(required = true, value = "")
+
+  private DeliveryConfigRequest delivery;
+ /**
+   * Accepted for compatibility; ignored on creation.
+   * @return subscriptionId
+  **/
+  @JsonProperty("subscriptionId")
+  public String getSubscriptionId() {
+    return subscriptionId;
+  }
+
+  public void setSubscriptionId(String subscriptionId) {
+    this.subscriptionId = subscriptionId;
+  }
+
+  public SubscriptionCreateRequest subscriptionId(String subscriptionId) {
+    this.subscriptionId = subscriptionId;
+    return this;
+  }
+
+ /**
+   * Accepted for compatibility; tenant context determines the organization.
+   * @return orgId
+  **/
+  @JsonProperty("orgId")
+  public String getOrgId() {
+    return orgId;
+  }
+
+  public void setOrgId(String orgId) {
+    this.orgId = orgId;
+  }
+
+  public SubscriptionCreateRequest orgId(String orgId) {
+    this.orgId = orgId;
+    return this;
+  }
+
+ /**
+   * Accepted for compatibility; the handler derives the group from tenant context.
+   * @return groupId
+  **/
+  @JsonProperty("groupId")
+  public String getGroupId() {
+    return groupId;
+  }
+
+  public void setGroupId(String groupId) {
+    this.groupId = groupId;
+  }
+
+  public SubscriptionCreateRequest groupId(String groupId) {
+    this.groupId = groupId;
+    return this;
+  }
+
+ /**
+   * Get status
+   * @return status
+  **/
+  @JsonProperty("status")
+  public SubscriptionStatus getStatus() {
+    return status;
+  }
+
+  public void setStatus(SubscriptionStatus status) {
+    this.status = status;
+  }
+
+  public SubscriptionCreateRequest status(SubscriptionStatus status) {
+    this.status = status;
+    return this;
+  }
+
+ /**
+   * Accepted for compatibility; ignored on creation.
+   * @return createdAt
+  **/
+  @JsonProperty("createdAt")
+  public Long getCreatedAt() {
+    return createdAt;
+  }
+
+  public void setCreatedAt(Long createdAt) {
+    this.createdAt = createdAt;
+  }
+
+  public SubscriptionCreateRequest createdAt(Long createdAt) {
+    this.createdAt = createdAt;
+    return this;
+  }
+
+ /**
+   * Accepted for compatibility; ignored on creation.
+   * @return updatedAt
+  **/
+  @JsonProperty("updatedAt")
+  public Long getUpdatedAt() {
+    return updatedAt;
+  }
+
+  public void setUpdatedAt(Long updatedAt) {
+    this.updatedAt = updatedAt;
+  }
+
+  public SubscriptionCreateRequest updatedAt(Long updatedAt) {
+    this.updatedAt = updatedAt;
+    return this;
+  }
+
+ /**
+   * Accepted for compatibility; ignored on creation.
+   * @return alreadyExists
+  **/
+  @JsonProperty("alreadyExists")
+  public Boolean getAlreadyExists() {
+    return alreadyExists;
+  }
+
+  public void setAlreadyExists(Boolean alreadyExists) {
+    this.alreadyExists = alreadyExists;
+  }
+
+  public SubscriptionCreateRequest alreadyExists(Boolean alreadyExists) {
+    this.alreadyExists = alreadyExists;
+    return this;
+  }
+
+ /**
+   * Accepted for compatibility; ignored on creation.
+   * @return message
+  **/
+  @JsonProperty("message")
+  public String getMessage() {
+    return message;
+  }
+
+  public void setMessage(String message) {
+    this.message = message;
+  }
+
+  public SubscriptionCreateRequest message(String message) {
+    this.message = message;
+    return this;
+  }
+
+ /**
+   * Get topic
+   * @return topic
+  **/
+  @JsonProperty("topic")
+  public String getTopic() {
+    return topic;
+  }
+
+  public void setTopic(String topic) {
+    this.topic = topic;
+  }
+
+  public SubscriptionCreateRequest topic(String topic) {
+    this.topic = topic;
+    return this;
+  }
+
+ /**
+   * Get filter
+   * @return filter
+  **/
+  @JsonProperty("filter")
+  public Filter getFilter() {
+    return filter;
+  }
+
+  public void setFilter(Filter filter) {
+    this.filter = filter;
+  }
+
+  public SubscriptionCreateRequest filter(Filter filter) {
+    this.filter = filter;
+    return this;
+  }
+
+ /**
+   * Get delivery
+   * @return delivery
+  **/
+  @JsonProperty("delivery")
+  public DeliveryConfigRequest getDelivery() {
+    return delivery;
+  }
+
+  public void setDelivery(DeliveryConfigRequest delivery) {
+    this.delivery = delivery;
+  }
+
+  public SubscriptionCreateRequest delivery(DeliveryConfigRequest delivery) {
+    this.delivery = delivery;
+    return this;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    SubscriptionCreateRequest subscriptionCreateRequest = (SubscriptionCreateRequest) o;
+    return Objects.equals(this.subscriptionId, subscriptionCreateRequest.subscriptionId) &&
+        Objects.equals(this.orgId, subscriptionCreateRequest.orgId) &&
+        Objects.equals(this.groupId, subscriptionCreateRequest.groupId) &&
+        Objects.equals(this.status, subscriptionCreateRequest.status) &&
+        Objects.equals(this.createdAt, subscriptionCreateRequest.createdAt) &&
+        Objects.equals(this.updatedAt, subscriptionCreateRequest.updatedAt) &&
+        Objects.equals(this.alreadyExists, subscriptionCreateRequest.alreadyExists) &&
+        Objects.equals(this.message, subscriptionCreateRequest.message) &&
+        Objects.equals(this.topic, subscriptionCreateRequest.topic) &&
+        Objects.equals(this.filter, subscriptionCreateRequest.filter) &&
+        Objects.equals(this.delivery, subscriptionCreateRequest.delivery);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(subscriptionId, orgId, groupId, status, createdAt, updatedAt, alreadyExists, message, topic, filter, delivery);
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("class SubscriptionCreateRequest {\n");
+    
+    sb.append("    subscriptionId: ").append(toIndentedString(subscriptionId)).append("\n");
+    sb.append("    orgId: ").append(toIndentedString(orgId)).append("\n");
+    sb.append("    groupId: ").append(toIndentedString(groupId)).append("\n");
+    sb.append("    status: ").append(toIndentedString(status)).append("\n");
+    sb.append("    createdAt: ").append(toIndentedString(createdAt)).append("\n");
+    sb.append("    updatedAt: ").append(toIndentedString(updatedAt)).append("\n");
+    sb.append("    alreadyExists: ").append(toIndentedString(alreadyExists)).append("\n");
+    sb.append("    message: ").append(toIndentedString(message)).append("\n");
+    sb.append("    topic: ").append(toIndentedString(topic)).append("\n");
+    sb.append("    filter: ").append(toIndentedString(filter)).append("\n");
+    sb.append("    delivery: ").append(toIndentedString(delivery)).append("\n");
+    sb.append("}");
+    return sb.toString();
+  }
+
+  /**
+   * Convert the given object to string with each line indented by 4 spaces
+   * (except the first line).
+   */
+  private static String toIndentedString(Object o) {
+    return o == null ? "null" : o.toString().replace("\n", "\n    ");
+  }
+}
+

--- a/dpdp-accelerator/internal-webapps/org.wso2.dpdp.accelerator.event.notifications.endpoint/src/gen/java/org/wso2/dpdp/accelerator/event/notifications/endpoint/dto/SubscriptionPage.java
+++ b/dpdp-accelerator/internal-webapps/org.wso2.dpdp.accelerator.event.notifications.endpoint/src/gen/java/org/wso2/dpdp/accelerator/event/notifications/endpoint/dto/SubscriptionPage.java
@@ -1,0 +1,100 @@
+package org.wso2.dpdp.accelerator.event.notifications.endpoint.dto;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.wso2.dpdp.accelerator.event.notifications.endpoint.dto.Subscription;
+
+import io.swagger.annotations.ApiModelProperty;
+import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+
+public class SubscriptionPage  {
+  
+  @ApiModelProperty(required = true, value = "")
+
+  private List<Subscription> items;
+
+  @ApiModelProperty(required = true, value = "")
+
+  private Integer total;
+ /**
+   * Get items
+   * @return items
+  **/
+  @JsonProperty("items")
+  public List<Subscription> getItems() {
+    return items;
+  }
+
+  public void setItems(List<Subscription> items) {
+    this.items = items;
+  }
+
+  public SubscriptionPage items(List<Subscription> items) {
+    this.items = items;
+    return this;
+  }
+
+  public SubscriptionPage addItemsItem(Subscription itemsItem) {
+    this.items.add(itemsItem);
+    return this;
+  }
+
+ /**
+   * Get total
+   * @return total
+  **/
+  @JsonProperty("total")
+  public Integer getTotal() {
+    return total;
+  }
+
+  public void setTotal(Integer total) {
+    this.total = total;
+  }
+
+  public SubscriptionPage total(Integer total) {
+    this.total = total;
+    return this;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    SubscriptionPage subscriptionPage = (SubscriptionPage) o;
+    return Objects.equals(this.items, subscriptionPage.items) &&
+        Objects.equals(this.total, subscriptionPage.total);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(items, total);
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("class SubscriptionPage {\n");
+    
+    sb.append("    items: ").append(toIndentedString(items)).append("\n");
+    sb.append("    total: ").append(toIndentedString(total)).append("\n");
+    sb.append("}");
+    return sb.toString();
+  }
+
+  /**
+   * Convert the given object to string with each line indented by 4 spaces
+   * (except the first line).
+   */
+  private static String toIndentedString(Object o) {
+    return o == null ? "null" : o.toString().replace("\n", "\n    ");
+  }
+}
+

--- a/dpdp-accelerator/internal-webapps/org.wso2.dpdp.accelerator.event.notifications.endpoint/src/gen/java/org/wso2/dpdp/accelerator/event/notifications/endpoint/dto/SubscriptionStatus.java
+++ b/dpdp-accelerator/internal-webapps/org.wso2.dpdp.accelerator.event.notifications.endpoint/src/gen/java/org/wso2/dpdp/accelerator/event/notifications/endpoint/dto/SubscriptionStatus.java
@@ -1,0 +1,44 @@
+package org.wso2.dpdp.accelerator.event.notifications.endpoint.dto;
+
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+/**
+ * Gets or Sets SubscriptionStatus
+ */
+@com.fasterxml.jackson.databind.annotation.JsonDeserialize(using = org.wso2.dpdp.accelerator.event.notifications.endpoint.util.RequestEnumDeserializers.Status.class)
+public enum SubscriptionStatus {
+  
+  ACTIVE("active"),
+  
+  PENDING("pending"),
+  
+  STALE("stale"),
+  
+  DELETED("deleted");
+
+  private String value;
+
+  SubscriptionStatus(String value) {
+    this.value = value;
+  }
+
+  @Override
+  @JsonValue
+  public String toString() {
+    return String.valueOf(value);
+  }
+
+  @JsonCreator
+  public static SubscriptionStatus fromValue(String value) {
+    for (SubscriptionStatus b : SubscriptionStatus.values()) {
+      if (b.value.equals(value)) {
+        return b;
+      }
+    }
+    throw new IllegalArgumentException("Unexpected value '" + value + "'");
+  }
+
+}
+

--- a/dpdp-accelerator/internal-webapps/org.wso2.dpdp.accelerator.event.notifications.endpoint/src/gen/java/org/wso2/dpdp/accelerator/event/notifications/endpoint/dto/Topic.java
+++ b/dpdp-accelerator/internal-webapps/org.wso2.dpdp.accelerator.event.notifications.endpoint/src/gen/java/org/wso2/dpdp/accelerator/event/notifications/endpoint/dto/Topic.java
@@ -1,0 +1,201 @@
+package org.wso2.dpdp.accelerator.event.notifications.endpoint.dto;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import org.wso2.dpdp.accelerator.event.notifications.endpoint.dto.TopicStatus;
+
+import io.swagger.annotations.ApiModelProperty;
+import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+
+public class Topic  {
+  
+  @ApiModelProperty(required = true, value = "")
+
+  private String name;
+
+  @ApiModelProperty(value = "")
+
+  private String description;
+
+  @ApiModelProperty(required = true, value = "")
+
+  private String topicId;
+
+  @ApiModelProperty(required = true, value = "")
+
+  private TopicStatus status;
+
+public enum InitiatedByEnum {
+
+SYSTEM(String.valueOf("system")), USER(String.valueOf("user"));
+
+
+    private String value;
+
+    InitiatedByEnum (String v) {
+        value = v;
+    }
+
+    public String value() {
+        return value;
+    }
+
+    @Override
+    @JsonValue
+    public String toString() {
+        return String.valueOf(value);
+    }
+
+    @JsonCreator
+    public static InitiatedByEnum fromValue(String value) {
+        for (InitiatedByEnum b : InitiatedByEnum.values()) {
+            if (b.value.equals(value)) {
+                return b;
+            }
+        }
+        throw new IllegalArgumentException("Unexpected value '" + value + "'");
+    }
+}
+
+  @ApiModelProperty(required = true, value = "")
+
+  private InitiatedByEnum initiatedBy;
+ /**
+   * Get name
+   * @return name
+  **/
+  @JsonProperty("name")
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  public Topic name(String name) {
+    this.name = name;
+    return this;
+  }
+
+ /**
+   * Get description
+   * @return description
+  **/
+  @JsonProperty("description")
+  public String getDescription() {
+    return description;
+  }
+
+  public void setDescription(String description) {
+    this.description = description;
+  }
+
+  public Topic description(String description) {
+    this.description = description;
+    return this;
+  }
+
+ /**
+   * Get topicId
+   * @return topicId
+  **/
+  @JsonProperty("topicId")
+  public String getTopicId() {
+    return topicId;
+  }
+
+  public void setTopicId(String topicId) {
+    this.topicId = topicId;
+  }
+
+  public Topic topicId(String topicId) {
+    this.topicId = topicId;
+    return this;
+  }
+
+ /**
+   * Get status
+   * @return status
+  **/
+  @JsonProperty("status")
+  public TopicStatus getStatus() {
+    return status;
+  }
+
+  public void setStatus(TopicStatus status) {
+    this.status = status;
+  }
+
+  public Topic status(TopicStatus status) {
+    this.status = status;
+    return this;
+  }
+
+ /**
+   * Get initiatedBy
+   * @return initiatedBy
+  **/
+  @JsonProperty("initiatedBy")
+  public String getInitiatedBy() {
+    if (initiatedBy == null) {
+      return null;
+    }
+    return initiatedBy.value();
+  }
+
+  public void setInitiatedBy(InitiatedByEnum initiatedBy) {
+    this.initiatedBy = initiatedBy;
+  }
+
+  public Topic initiatedBy(InitiatedByEnum initiatedBy) {
+    this.initiatedBy = initiatedBy;
+    return this;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    Topic topic = (Topic) o;
+    return Objects.equals(this.name, topic.name) &&
+        Objects.equals(this.description, topic.description) &&
+        Objects.equals(this.topicId, topic.topicId) &&
+        Objects.equals(this.status, topic.status) &&
+        Objects.equals(this.initiatedBy, topic.initiatedBy);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(name, description, topicId, status, initiatedBy);
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("class Topic {\n");
+    
+    sb.append("    name: ").append(toIndentedString(name)).append("\n");
+    sb.append("    description: ").append(toIndentedString(description)).append("\n");
+    sb.append("    topicId: ").append(toIndentedString(topicId)).append("\n");
+    sb.append("    status: ").append(toIndentedString(status)).append("\n");
+    sb.append("    initiatedBy: ").append(toIndentedString(initiatedBy)).append("\n");
+    sb.append("}");
+    return sb.toString();
+  }
+
+  /**
+   * Convert the given object to string with each line indented by 4 spaces
+   * (except the first line).
+   */
+  private static String toIndentedString(Object o) {
+    return o == null ? "null" : o.toString().replace("\n", "\n    ");
+  }
+}
+

--- a/dpdp-accelerator/internal-webapps/org.wso2.dpdp.accelerator.event.notifications.endpoint/src/gen/java/org/wso2/dpdp/accelerator/event/notifications/endpoint/dto/TopicCreateRequest.java
+++ b/dpdp-accelerator/internal-webapps/org.wso2.dpdp.accelerator.event.notifications.endpoint/src/gen/java/org/wso2/dpdp/accelerator/event/notifications/endpoint/dto/TopicCreateRequest.java
@@ -1,0 +1,172 @@
+package org.wso2.dpdp.accelerator.event.notifications.endpoint.dto;
+
+
+import io.swagger.annotations.ApiModelProperty;
+import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+
+public class TopicCreateRequest  {
+  
+ /**
+  * Accepted for compatibility; ignored on creation.
+  */
+  @ApiModelProperty(value = "Accepted for compatibility; ignored on creation.")
+
+  private String topicId;
+
+ /**
+  * Accepted for compatibility; ignored on creation.
+  */
+  @ApiModelProperty(value = "Accepted for compatibility; ignored on creation.")
+
+  private String status;
+
+ /**
+  * Accepted for compatibility; ignored on creation.
+  */
+  @ApiModelProperty(value = "Accepted for compatibility; ignored on creation.")
+
+  private String initiatedBy;
+
+  @ApiModelProperty(required = true, value = "")
+
+  private String name;
+
+  @ApiModelProperty(value = "")
+
+  private String description;
+ /**
+   * Accepted for compatibility; ignored on creation.
+   * @return topicId
+  **/
+  @JsonProperty("topicId")
+  public String getTopicId() {
+    return topicId;
+  }
+
+  public void setTopicId(String topicId) {
+    this.topicId = topicId;
+  }
+
+  public TopicCreateRequest topicId(String topicId) {
+    this.topicId = topicId;
+    return this;
+  }
+
+ /**
+   * Accepted for compatibility; ignored on creation.
+   * @return status
+  **/
+  @JsonProperty("status")
+  public String getStatus() {
+    return status;
+  }
+
+  public void setStatus(String status) {
+    this.status = status;
+  }
+
+  public TopicCreateRequest status(String status) {
+    this.status = status;
+    return this;
+  }
+
+ /**
+   * Accepted for compatibility; ignored on creation.
+   * @return initiatedBy
+  **/
+  @JsonProperty("initiatedBy")
+  public String getInitiatedBy() {
+    return initiatedBy;
+  }
+
+  public void setInitiatedBy(String initiatedBy) {
+    this.initiatedBy = initiatedBy;
+  }
+
+  public TopicCreateRequest initiatedBy(String initiatedBy) {
+    this.initiatedBy = initiatedBy;
+    return this;
+  }
+
+ /**
+   * Get name
+   * @return name
+  **/
+  @JsonProperty("name")
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  public TopicCreateRequest name(String name) {
+    this.name = name;
+    return this;
+  }
+
+ /**
+   * Get description
+   * @return description
+  **/
+  @JsonProperty("description")
+  public String getDescription() {
+    return description;
+  }
+
+  public void setDescription(String description) {
+    this.description = description;
+  }
+
+  public TopicCreateRequest description(String description) {
+    this.description = description;
+    return this;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    TopicCreateRequest topicCreateRequest = (TopicCreateRequest) o;
+    return Objects.equals(this.topicId, topicCreateRequest.topicId) &&
+        Objects.equals(this.status, topicCreateRequest.status) &&
+        Objects.equals(this.initiatedBy, topicCreateRequest.initiatedBy) &&
+        Objects.equals(this.name, topicCreateRequest.name) &&
+        Objects.equals(this.description, topicCreateRequest.description);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(topicId, status, initiatedBy, name, description);
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("class TopicCreateRequest {\n");
+    
+    sb.append("    topicId: ").append(toIndentedString(topicId)).append("\n");
+    sb.append("    status: ").append(toIndentedString(status)).append("\n");
+    sb.append("    initiatedBy: ").append(toIndentedString(initiatedBy)).append("\n");
+    sb.append("    name: ").append(toIndentedString(name)).append("\n");
+    sb.append("    description: ").append(toIndentedString(description)).append("\n");
+    sb.append("}");
+    return sb.toString();
+  }
+
+  /**
+   * Convert the given object to string with each line indented by 4 spaces
+   * (except the first line).
+   */
+  private static String toIndentedString(Object o) {
+    return o == null ? "null" : o.toString().replace("\n", "\n    ");
+  }
+}
+

--- a/dpdp-accelerator/internal-webapps/org.wso2.dpdp.accelerator.event.notifications.endpoint/src/gen/java/org/wso2/dpdp/accelerator/event/notifications/endpoint/dto/TopicPage.java
+++ b/dpdp-accelerator/internal-webapps/org.wso2.dpdp.accelerator.event.notifications.endpoint/src/gen/java/org/wso2/dpdp/accelerator/event/notifications/endpoint/dto/TopicPage.java
@@ -1,0 +1,100 @@
+package org.wso2.dpdp.accelerator.event.notifications.endpoint.dto;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.wso2.dpdp.accelerator.event.notifications.endpoint.dto.Topic;
+
+import io.swagger.annotations.ApiModelProperty;
+import java.util.Objects;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+
+public class TopicPage  {
+  
+  @ApiModelProperty(required = true, value = "")
+
+  private List<Topic> items;
+
+  @ApiModelProperty(required = true, value = "")
+
+  private Integer total;
+ /**
+   * Get items
+   * @return items
+  **/
+  @JsonProperty("items")
+  public List<Topic> getItems() {
+    return items;
+  }
+
+  public void setItems(List<Topic> items) {
+    this.items = items;
+  }
+
+  public TopicPage items(List<Topic> items) {
+    this.items = items;
+    return this;
+  }
+
+  public TopicPage addItemsItem(Topic itemsItem) {
+    this.items.add(itemsItem);
+    return this;
+  }
+
+ /**
+   * Get total
+   * @return total
+  **/
+  @JsonProperty("total")
+  public Integer getTotal() {
+    return total;
+  }
+
+  public void setTotal(Integer total) {
+    this.total = total;
+  }
+
+  public TopicPage total(Integer total) {
+    this.total = total;
+    return this;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    TopicPage topicPage = (TopicPage) o;
+    return Objects.equals(this.items, topicPage.items) &&
+        Objects.equals(this.total, topicPage.total);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(items, total);
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("class TopicPage {\n");
+    
+    sb.append("    items: ").append(toIndentedString(items)).append("\n");
+    sb.append("    total: ").append(toIndentedString(total)).append("\n");
+    sb.append("}");
+    return sb.toString();
+  }
+
+  /**
+   * Convert the given object to string with each line indented by 4 spaces
+   * (except the first line).
+   */
+  private static String toIndentedString(Object o) {
+    return o == null ? "null" : o.toString().replace("\n", "\n    ");
+  }
+}
+

--- a/dpdp-accelerator/internal-webapps/org.wso2.dpdp.accelerator.event.notifications.endpoint/src/gen/java/org/wso2/dpdp/accelerator/event/notifications/endpoint/dto/TopicStatus.java
+++ b/dpdp-accelerator/internal-webapps/org.wso2.dpdp.accelerator.event.notifications.endpoint/src/gen/java/org/wso2/dpdp/accelerator/event/notifications/endpoint/dto/TopicStatus.java
@@ -1,0 +1,39 @@
+package org.wso2.dpdp.accelerator.event.notifications.endpoint.dto;
+
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+/**
+ * Gets or Sets TopicStatus
+ */
+public enum TopicStatus {
+  
+  ACTIVE("active"),
+  
+  DEREGISTERED("deregistered");
+
+  private String value;
+
+  TopicStatus(String value) {
+    this.value = value;
+  }
+
+  @Override
+  @JsonValue
+  public String toString() {
+    return String.valueOf(value);
+  }
+
+  @JsonCreator
+  public static TopicStatus fromValue(String value) {
+    for (TopicStatus b : TopicStatus.values()) {
+      if (b.value.equals(value)) {
+        return b;
+      }
+    }
+    throw new IllegalArgumentException("Unexpected value '" + value + "'");
+  }
+
+}
+

--- a/dpdp-accelerator/internal-webapps/org.wso2.dpdp.accelerator.event.notifications.endpoint/src/main/java/org/wso2/dpdp/accelerator/event/notifications/endpoint/api/EventEndpoint.java
+++ b/dpdp-accelerator/internal-webapps/org.wso2.dpdp.accelerator.event.notifications.endpoint/src/main/java/org/wso2/dpdp/accelerator/event/notifications/endpoint/api/EventEndpoint.java
@@ -18,9 +18,11 @@
 
 package org.wso2.dpdp.accelerator.event.notifications.endpoint.api;
 
+import org.wso2.dpdp.accelerator.event.notifications.endpoint.dto.EventCreateRequest;
+import org.wso2.dpdp.accelerator.event.notifications.endpoint.util.EventNotificationDtoMapper;
+
 import org.wso2.dpdp.accelerator.event.notifications.endpoint.handler.EventHandler;
 import org.wso2.dpdp.accelerator.event.notifications.endpoint.constants.EventNotificationEndpointConstants;
-import org.wso2.dpdp.accelerator.event.notifications.service.dto.EventCreateDTO;
 import org.wso2.dpdp.accelerator.event.notifications.service.dto.EventDTO;
 import org.wso2.dpdp.accelerator.event.notifications.service.dto.EventPollingResponseDTO;
 import org.wso2.dpdp.accelerator.event.notifications.service.dto.SubscriptionDeliveryDTO;
@@ -69,9 +71,9 @@ public class EventEndpoint {
     @POST
     public Response publishEvent(
             @HeaderParam(EventNotificationEndpointConstants.GROUP_ID_HEADER) String groupId,
-            EventCreateDTO request) {
-        EventDTO dto = eventHandler.publishEvent(organizationIdResolver.get(), groupId, request);
-        return Response.status(Response.Status.CREATED).entity(dto).build();
+            EventCreateRequest request) {
+        EventDTO dto = eventHandler.publishEvent(organizationIdResolver.get(), groupId, EventNotificationDtoMapper.toService(request));
+        return Response.status(Response.Status.CREATED).entity(EventNotificationDtoMapper.toApi(dto)).build();
     }
 
     @POST
@@ -83,7 +85,7 @@ public class EventEndpoint {
             String requestBody) {
         EventPollingResponseDTO response = eventHandler.pollEvents(organizationIdResolver.get(), groupId,
                 subscriptionId, requestBody, signature);
-        return Response.ok(response).build();
+        return Response.ok(EventNotificationDtoMapper.toApi(response)).build();
     }
 
     @GET
@@ -100,7 +102,7 @@ public class EventEndpoint {
                 ? eventHandler.searchEvents(orgId, topic, status, orgId, purposes, search, limit, offset)
                 : eventHandler.searchEvents(orgId, topic, status, orgId, subscriptionId,
                         purposes, search, limit, offset);
-        return Response.ok(result).build();
+        return Response.ok(EventNotificationDtoMapper.events(result)).build();
     }
 
     @GET
@@ -108,7 +110,7 @@ public class EventEndpoint {
     public Response getDeliveryHistory(
             @PathParam("deliveryId") String deliveryId) {
         SubscriptionEventHistoryDTO dto = eventHandler.getDeliveryHistory(organizationIdResolver.get(), deliveryId);
-        return Response.ok(dto).build();
+        return Response.ok(EventNotificationDtoMapper.toApi(dto)).build();
     }
 
     @GET
@@ -116,7 +118,7 @@ public class EventEndpoint {
     public Response getEvent(
             @PathParam("eventId") String eventId) {
         EventDTO dto = eventHandler.getEventById(organizationIdResolver.get(), eventId);
-        return Response.ok(dto).build();
+        return Response.ok(EventNotificationDtoMapper.toApi(dto)).build();
     }
 
     @GET
@@ -127,6 +129,6 @@ public class EventEndpoint {
             @QueryParam("offset") @DefaultValue(EventNotificationEndpointConstants.DEFAULT_OFFSET_STR) int offset) {
         PaginatedResult<SubscriptionDeliveryDTO> result = eventHandler.getEventDeliveries(
                 organizationIdResolver.get(), eventId, limit, offset);
-        return Response.ok(result).build();
+        return Response.ok(EventNotificationDtoMapper.deliveries(result)).build();
     }
 }

--- a/dpdp-accelerator/internal-webapps/org.wso2.dpdp.accelerator.event.notifications.endpoint/src/main/java/org/wso2/dpdp/accelerator/event/notifications/endpoint/api/SubscriptionEndpoint.java
+++ b/dpdp-accelerator/internal-webapps/org.wso2.dpdp.accelerator.event.notifications.endpoint/src/main/java/org/wso2/dpdp/accelerator/event/notifications/endpoint/api/SubscriptionEndpoint.java
@@ -18,6 +18,9 @@
 
 package org.wso2.dpdp.accelerator.event.notifications.endpoint.api;
 
+import org.wso2.dpdp.accelerator.event.notifications.endpoint.dto.SubscriptionCreateRequest;
+import org.wso2.dpdp.accelerator.event.notifications.endpoint.util.EventNotificationDtoMapper;
+
 import org.wso2.dpdp.accelerator.event.notifications.endpoint.handler.SubscriptionHandler;
 import org.wso2.dpdp.accelerator.event.notifications.endpoint.constants.EventNotificationEndpointConstants;
 import org.wso2.dpdp.accelerator.event.notifications.service.dto.SubscriptionDTO;
@@ -63,10 +66,10 @@ public class SubscriptionEndpoint {
     }
 
     @POST
-    public Response createSubscription(SubscriptionDTO request) {
+    public Response createSubscription(SubscriptionCreateRequest request) {
         String orgId = organizationIdSupplier.get();
-        SubscriptionDTO dto = subscriptionHandler.createSubscription(orgId, request);
-        return Response.status(Response.Status.CREATED).entity(dto).build();
+        SubscriptionDTO dto = subscriptionHandler.createSubscription(orgId, EventNotificationDtoMapper.toService(request));
+        return Response.status(Response.Status.CREATED).entity(EventNotificationDtoMapper.toApi(dto)).build();
     }
 
     @GET
@@ -79,7 +82,7 @@ public class SubscriptionEndpoint {
             @QueryParam("sort") String sort) {
         PaginatedResult<SubscriptionDTO> result = subscriptionHandler.listSubscriptions(
                 organizationIdSupplier.get(), status, purposes, search, limit, offset, sort);
-        return Response.ok(result).build();
+        return Response.ok(EventNotificationDtoMapper.subscriptions(result)).build();
     }
 
     @GET
@@ -87,7 +90,7 @@ public class SubscriptionEndpoint {
     public Response getSubscription(
             @PathParam("subscriptionId") String subscriptionId) {
         SubscriptionDTO dto = subscriptionHandler.getSubscription(organizationIdSupplier.get(), subscriptionId);
-        return Response.ok(dto).build();
+        return Response.ok(EventNotificationDtoMapper.toApi(dto)).build();
     }
 
     @DELETE
@@ -95,7 +98,7 @@ public class SubscriptionEndpoint {
     public Response deleteSubscription(
             @PathParam("subscriptionId") String subscriptionId) {
         SubscriptionDTO dto = subscriptionHandler.deleteSubscription(organizationIdSupplier.get(), subscriptionId);
-        return Response.ok(dto).build();
+        return Response.ok(EventNotificationDtoMapper.toApi(dto)).build();
     }
 
     @POST
@@ -103,7 +106,7 @@ public class SubscriptionEndpoint {
     public Response retryVerification(
             @PathParam("subscriptionId") String subscriptionId) {
         SubscriptionDTO dto = subscriptionHandler.retryVerification(organizationIdSupplier.get(), subscriptionId);
-        return Response.ok(dto).build();
+        return Response.ok(EventNotificationDtoMapper.toApi(dto)).build();
     }
 
     @GET
@@ -114,7 +117,7 @@ public class SubscriptionEndpoint {
             @QueryParam("offset") @DefaultValue(EventNotificationEndpointConstants.DEFAULT_OFFSET_STR) int offset) {
         PaginatedResult<SubscriptionDeliveryDTO> result = subscriptionHandler.listSubscriptionEvents(
                 organizationIdSupplier.get(), subscriptionId, limit, offset);
-        return Response.ok(result).build();
+        return Response.ok(EventNotificationDtoMapper.deliveries(result)).build();
     }
 
     @GET
@@ -124,6 +127,6 @@ public class SubscriptionEndpoint {
             @PathParam("deliveryId") String deliveryId) {
         SubscriptionEventHistoryDTO dto = subscriptionHandler.getSubscriptionEventHistory(
                 organizationIdSupplier.get(), subscriptionId, deliveryId);
-        return Response.ok(dto).build();
+        return Response.ok(EventNotificationDtoMapper.toApi(dto)).build();
     }
 }

--- a/dpdp-accelerator/internal-webapps/org.wso2.dpdp.accelerator.event.notifications.endpoint/src/main/java/org/wso2/dpdp/accelerator/event/notifications/endpoint/api/TopicEndpoint.java
+++ b/dpdp-accelerator/internal-webapps/org.wso2.dpdp.accelerator.event.notifications.endpoint/src/main/java/org/wso2/dpdp/accelerator/event/notifications/endpoint/api/TopicEndpoint.java
@@ -18,6 +18,9 @@
 
 package org.wso2.dpdp.accelerator.event.notifications.endpoint.api;
 
+import org.wso2.dpdp.accelerator.event.notifications.endpoint.dto.TopicCreateRequest;
+import org.wso2.dpdp.accelerator.event.notifications.endpoint.util.EventNotificationDtoMapper;
+
 import org.wso2.dpdp.accelerator.event.notifications.endpoint.handler.TopicHandler;
 import org.wso2.dpdp.accelerator.event.notifications.endpoint.constants.EventNotificationEndpointConstants;
 import org.wso2.dpdp.accelerator.event.notifications.service.dto.TopicDTO;
@@ -61,9 +64,9 @@ public class TopicEndpoint {
     }
 
     @POST
-    public Response createTopic(TopicDTO request) {
-        TopicDTO dto = topicHandler.createTopic(organizationIdSupplier.get(), request);
-        return Response.status(Response.Status.CREATED).entity(dto).build();
+    public Response createTopic(TopicCreateRequest request) {
+        TopicDTO dto = topicHandler.createTopic(organizationIdSupplier.get(), EventNotificationDtoMapper.toService(request));
+        return Response.status(Response.Status.CREATED).entity(EventNotificationDtoMapper.toApi(dto)).build();
     }
 
     @GET
@@ -75,7 +78,7 @@ public class TopicEndpoint {
             @QueryParam("sort") String sort) {
         PaginatedResult<TopicDTO> result = topicHandler.listTopics(organizationIdSupplier.get(), status,
                 search, limit, offset, sort);
-        return Response.ok(result).build();
+        return Response.ok(EventNotificationDtoMapper.topics(result)).build();
     }
 
     @DELETE
@@ -83,6 +86,6 @@ public class TopicEndpoint {
     public Response deleteTopic(
             @PathParam("topicId") String topicId) {
         TopicDTO dto = topicHandler.deleteTopic(organizationIdSupplier.get(), topicId);
-        return Response.ok(dto).build();
+        return Response.ok(EventNotificationDtoMapper.toApi(dto)).build();
     }
 }

--- a/dpdp-accelerator/internal-webapps/org.wso2.dpdp.accelerator.event.notifications.endpoint/src/main/java/org/wso2/dpdp/accelerator/event/notifications/endpoint/exception/EventNotificationExceptionMapper.java
+++ b/dpdp-accelerator/internal-webapps/org.wso2.dpdp.accelerator.event.notifications.endpoint/src/main/java/org/wso2/dpdp/accelerator/event/notifications/endpoint/exception/EventNotificationExceptionMapper.java
@@ -31,9 +31,8 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.ext.ExceptionMapper;
 import javax.ws.rs.ext.Provider;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.IdentityHashMap;
-import java.util.Map;
+import org.wso2.dpdp.accelerator.event.notifications.endpoint.dto.Error;
 import java.util.Set;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -125,12 +124,7 @@ public class EventNotificationExceptionMapper implements ExceptionMapper<Throwab
     }
 
     private Response buildResponse(int status, String code, String message, String description) {
-        Map<String, Object> body = new HashMap<>();
-        body.put("code", code);
-        body.put("message", message);
-        if (description != null) {
-            body.put("description", description);
-        }
+        Error body = new Error().code(code).message(message).description(description);
 
         return Response.status(status > 0 ? status : 500)
                 .type(MediaType.APPLICATION_JSON)

--- a/dpdp-accelerator/internal-webapps/org.wso2.dpdp.accelerator.event.notifications.endpoint/src/main/java/org/wso2/dpdp/accelerator/event/notifications/endpoint/util/EventNotificationDtoMapper.java
+++ b/dpdp-accelerator/internal-webapps/org.wso2.dpdp.accelerator.event.notifications.endpoint/src/main/java/org/wso2/dpdp/accelerator/event/notifications/endpoint/util/EventNotificationDtoMapper.java
@@ -1,0 +1,293 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ * <p>
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.dpdp.accelerator.event.notifications.endpoint.util;
+
+import org.wso2.dpdp.accelerator.event.notifications.endpoint.dto.Delivery;
+import org.wso2.dpdp.accelerator.event.notifications.endpoint.dto.DeliveryAttempt;
+import org.wso2.dpdp.accelerator.event.notifications.endpoint.dto.DeliveryConfig;
+import org.wso2.dpdp.accelerator.event.notifications.endpoint.dto.DeliveryConfigRequest;
+import org.wso2.dpdp.accelerator.event.notifications.endpoint.dto.DeliveryHistory;
+import org.wso2.dpdp.accelerator.event.notifications.endpoint.dto.DeliveryMode;
+import org.wso2.dpdp.accelerator.event.notifications.endpoint.dto.DeliveryPage;
+import org.wso2.dpdp.accelerator.event.notifications.endpoint.dto.Event;
+import org.wso2.dpdp.accelerator.event.notifications.endpoint.dto.EventCreateRequest;
+import org.wso2.dpdp.accelerator.event.notifications.endpoint.dto.EventPage;
+import org.wso2.dpdp.accelerator.event.notifications.endpoint.dto.Filter;
+import org.wso2.dpdp.accelerator.event.notifications.endpoint.dto.PollResponse;
+import org.wso2.dpdp.accelerator.event.notifications.endpoint.dto.PurposeFilterMode;
+import org.wso2.dpdp.accelerator.event.notifications.endpoint.dto.Subscription;
+import org.wso2.dpdp.accelerator.event.notifications.endpoint.dto.SubscriptionCreateRequest;
+import org.wso2.dpdp.accelerator.event.notifications.endpoint.dto.SubscriptionPage;
+import org.wso2.dpdp.accelerator.event.notifications.endpoint.dto.SubscriptionStatus;
+import org.wso2.dpdp.accelerator.event.notifications.endpoint.dto.Topic;
+import org.wso2.dpdp.accelerator.event.notifications.endpoint.dto.TopicCreateRequest;
+import org.wso2.dpdp.accelerator.event.notifications.endpoint.dto.TopicPage;
+import org.wso2.dpdp.accelerator.event.notifications.endpoint.dto.TopicStatus;
+import org.wso2.dpdp.accelerator.event.notifications.service.dto.DeliveryConfigDTO;
+import org.wso2.dpdp.accelerator.event.notifications.service.dto.EventCreateDTO;
+import org.wso2.dpdp.accelerator.event.notifications.service.dto.EventDTO;
+import org.wso2.dpdp.accelerator.event.notifications.service.dto.EventPollingResponseDTO;
+import org.wso2.dpdp.accelerator.event.notifications.service.dto.FilterDTO;
+import org.wso2.dpdp.accelerator.event.notifications.service.dto.SubscriptionDTO;
+import org.wso2.dpdp.accelerator.event.notifications.service.dto.SubscriptionDeliveryAttemptDTO;
+import org.wso2.dpdp.accelerator.event.notifications.service.dto.SubscriptionDeliveryDTO;
+import org.wso2.dpdp.accelerator.event.notifications.service.dto.SubscriptionEventHistoryDTO;
+import org.wso2.dpdp.accelerator.event.notifications.service.dto.TopicDTO;
+import org.wso2.dpdp.accelerator.event.notifications.service.model.PaginatedResult;
+import java.sql.Timestamp;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Function;
+
+/** Explicit conversion between the REST contract and service contracts. */
+public final class EventNotificationDtoMapper {
+    private EventNotificationDtoMapper() {
+    }
+
+    public static TopicDTO toService(TopicCreateRequest source) {
+        if (source == null) {
+            return null;
+        }
+        TopicDTO target = new TopicDTO();
+        target.setTopicId(source.getTopicId());
+        target.setStatus(source.getStatus());
+        target.setInitiatedBy(source.getInitiatedBy());
+        target.setName(source.getName());
+        target.setDescription(source.getDescription());
+        return target;
+    }
+
+    public static EventCreateDTO toService(EventCreateRequest source) {
+        return source == null ? null : new EventCreateDTO(source.getTopic(),
+                copy(source.getPurposes()), source.getPayload());
+    }
+
+    public static SubscriptionDTO toService(SubscriptionCreateRequest source) {
+        if (source == null) {
+            return null;
+        }
+        SubscriptionDTO target = new SubscriptionDTO();
+        target.setSubscriptionId(source.getSubscriptionId());
+        target.setOrgId(source.getOrgId());
+        target.setGroupId(source.getGroupId());
+        target.setStatus(source.getStatus() == null ? null :
+                org.wso2.dpdp.accelerator.event.notifications.common.enums.SubscriptionStatus
+                        .fromValue(source.getStatus().toString()));
+        target.setCreatedAt(source.getCreatedAt());
+        target.setUpdatedAt(source.getUpdatedAt());
+        target.setAlreadyExists(source.getAlreadyExists());
+        target.setMessage(source.getMessage());
+        target.setTopic(source.getTopic());
+        if (source.getFilter() != null) {
+            Filter filter = source.getFilter();
+            target.setFilter(new FilterDTO(filter.getType() == null ? null :
+                    org.wso2.dpdp.accelerator.event.notifications.common.enums.PurposeFilterMode
+                            .fromValue(filter.getType().toString()), copy(filter.getPurposes())));
+        }
+        if (source.getDelivery() != null) {
+            DeliveryConfigRequest delivery = source.getDelivery();
+            target.setDelivery(new DeliveryConfigDTO(delivery.getMode() == null ? null :
+                    org.wso2.dpdp.accelerator.event.notifications.common.enums.DeliveryMode
+                            .fromValue(delivery.getMode().toString()),
+                    delivery.getCallbackUrl(), delivery.getSharedSecret()));
+        }
+        return target;
+    }
+
+    public static Topic toApi(TopicDTO source) {
+        if (source == null) {
+            return null;
+        }
+        Topic target = new Topic();
+        target.setTopicId(source.getTopicId());
+        target.setName(source.getName());
+        target.setDescription(source.getDescription());
+        target.setStatus(source.getStatus() == null ? null : TopicStatus.fromValue(source.getStatus()));
+        target.setInitiatedBy(source.getInitiatedBy() == null ? null :
+                Topic.InitiatedByEnum.fromValue(source.getInitiatedBy()));
+        return target;
+    }
+
+    public static Subscription toApi(SubscriptionDTO source) {
+        if (source == null) {
+            return null;
+        }
+        Subscription target = new Subscription();
+        target.setSubscriptionId(source.getSubscriptionId());
+        target.setOrgId(source.getOrgId());
+        target.setGroupId(source.getGroupId());
+        target.setTopic(source.getTopic());
+        target.setStatus(source.getStatus() == null ? null :
+                SubscriptionStatus.fromValue(source.getStatus().getValue()));
+        target.setCreatedAt(source.getCreatedAt());
+        target.setUpdatedAt(source.getUpdatedAt());
+        target.setAlreadyExists(source.getAlreadyExists());
+        target.setMessage(source.getMessage());
+        if (source.getFilter() != null) {
+            Filter filter = new Filter();
+            filter.setType(source.getFilter().getType() == null ? null :
+                    PurposeFilterMode.fromValue(source.getFilter().getType().getValue()));
+            filter.setPurposes(copy(source.getFilter().getPurposes()));
+            target.setFilter(filter);
+        }
+        if (source.getDelivery() != null) {
+            DeliveryConfig delivery = new DeliveryConfig();
+            delivery.setMode(source.getDelivery().getMode() == null ? null :
+                    DeliveryMode.fromValue(source.getDelivery().getMode().getValue()));
+            delivery.setCallbackUrl(source.getDelivery().getCallbackUrl());
+            // The public response never exposes the subscription shared secret.
+            target.setDelivery(delivery);
+        }
+        return target;
+    }
+
+    public static Event toApi(EventDTO source) {
+        if (source == null) {
+            return null;
+        }
+        Event target = new Event();
+        target.setEventId(source.getEventId());
+        target.setOrgId(source.getOrgId());
+        target.setGroupId(source.getGroupId());
+        target.setTopicId(source.getTopicId());
+        target.setTopic(source.getTopic());
+        target.setPayload(source.getPayload());
+        target.setDeliveriesCount(source.getDeliveriesCount());
+        target.setPurposes(copy(source.getPurposes()));
+        target.setOccurredAt(epoch(source.getOccurredAt()));
+        target.setCreatedAt(epoch(source.getCreatedAt()));
+        return target;
+    }
+
+    public static Delivery toApi(SubscriptionDeliveryDTO source) {
+        if (source == null) {
+            return null;
+        }
+        Delivery target = new Delivery();
+        target.setDeliveryId(source.getDeliveryId());
+        target.setEventId(source.getEventId());
+        target.setSubscriptionId(source.getSubscriptionId());
+        target.setGroupId(source.getGroupId());
+        target.setTopic(source.getTopic());
+        target.setCurrentStatus(source.getCurrentStatus());
+        target.setOccurredAt(source.getOccurredAt());
+        target.setDeliveryMode(source.getDeliveryMode() == null ? null : DeliveryMode.fromValue(source.getDeliveryMode()));
+        return target;
+    }
+
+    public static DeliveryAttempt toApi(SubscriptionDeliveryAttemptDTO source) {
+        if (source == null) {
+            return null;
+        }
+        DeliveryAttempt target = new DeliveryAttempt();
+        target.setAttempt(source.getAttempt());
+        target.setStatus(source.getStatus());
+        target.setTimestamp(source.getTimestamp());
+        target.setHttpStatus(source.getHttpStatus());
+        target.setError(source.getError());
+        return target;
+    }
+
+    public static DeliveryHistory toApi(SubscriptionEventHistoryDTO source) {
+        if (source == null) {
+            return null;
+        }
+        DeliveryHistory target = new DeliveryHistory();
+        target.setDeliveryId(source.getDeliveryId());
+        target.setEventId(source.getEventId());
+        target.setTopic(source.getTopic());
+        target.setCurrentStatus(source.getCurrentStatus());
+        target.setOccurredAt(source.getOccurredAt());
+        target.setNextRetryAt(source.getNextRetryAt());
+        target.setCompletionStatus(source.getCompletionStatus());
+        target.setCompletionEvidence(source.getCompletionEvidence());
+        target.setDeliveryMode(source.getDeliveryMode() == null ? null : DeliveryMode.fromValue(source.getDeliveryMode()));
+        target.setHistory(map(source.getHistory(), EventNotificationDtoMapper::toApi));
+        return target;
+    }
+
+    public static PollResponse toApi(EventPollingResponseDTO source) {
+        if (source == null) {
+            return null;
+        }
+        PollResponse target = new PollResponse();
+        target.setMoreAvailable(source.isMoreAvailable());
+        target.setSets(source.getSets());
+        return target;
+    }
+
+    public static TopicPage topics(PaginatedResult<TopicDTO> source) {
+        if (source == null) {
+            return null;
+        }
+        TopicPage target = new TopicPage();
+        target.setItems(map(source.getItems(), EventNotificationDtoMapper::toApi));
+        target.setTotal(source.getTotal());
+        return target;
+    }
+
+    public static SubscriptionPage subscriptions(PaginatedResult<SubscriptionDTO> source) {
+        if (source == null) {
+            return null;
+        }
+        SubscriptionPage target = new SubscriptionPage();
+        target.setItems(map(source.getItems(), EventNotificationDtoMapper::toApi));
+        target.setTotal(source.getTotal());
+        return target;
+    }
+
+    public static EventPage events(PaginatedResult<EventDTO> source) {
+        if (source == null) {
+            return null;
+        }
+        EventPage target = new EventPage();
+        target.setItems(map(source.getItems(), EventNotificationDtoMapper::toApi));
+        target.setTotal(source.getTotal());
+        return target;
+    }
+
+    public static DeliveryPage deliveries(PaginatedResult<SubscriptionDeliveryDTO> source) {
+        if (source == null) {
+            return null;
+        }
+        DeliveryPage target = new DeliveryPage();
+        target.setItems(map(source.getItems(), EventNotificationDtoMapper::toApi));
+        target.setTotal(source.getTotal());
+        return target;
+    }
+
+    private static Long epoch(Timestamp value) {
+        return value == null ? null : value.getTime();
+    }
+
+    private static <T> List<T> copy(List<T> values) {
+        return values == null ? null : new ArrayList<>(values);
+    }
+
+    private static <S, T> List<T> map(List<S> source, Function<S, T> mapper) {
+        if (source == null) {
+            return null;
+        }
+        List<T> target = new ArrayList<>(source.size());
+        for (S item : source) {
+            target.add(mapper.apply(item));
+        }
+        return target;
+    }
+}

--- a/dpdp-accelerator/internal-webapps/org.wso2.dpdp.accelerator.event.notifications.endpoint/src/main/java/org/wso2/dpdp/accelerator/event/notifications/endpoint/util/RequestEnumDeserializers.java
+++ b/dpdp-accelerator/internal-webapps/org.wso2.dpdp.accelerator.event.notifications.endpoint/src/main/java/org/wso2/dpdp/accelerator/event/notifications/endpoint/util/RequestEnumDeserializers.java
@@ -1,0 +1,77 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ * <p>
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.dpdp.accelerator.event.notifications.endpoint.util;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import org.wso2.dpdp.accelerator.event.notifications.endpoint.dto.DeliveryMode;
+import org.wso2.dpdp.accelerator.event.notifications.endpoint.dto.PurposeFilterMode;
+import java.io.IOException;
+
+/** Preserves the service's existing enum aliases and malformed-JSON error handling. */
+public final class RequestEnumDeserializers {
+    private RequestEnumDeserializers() {
+    }
+
+    public static final class Status extends JsonDeserializer<
+            org.wso2.dpdp.accelerator.event.notifications.endpoint.dto.SubscriptionStatus> {
+        @Override
+        public org.wso2.dpdp.accelerator.event.notifications.endpoint.dto.SubscriptionStatus deserialize(
+                JsonParser parser, DeserializationContext context) throws IOException {
+            if (!parser.currentToken().isScalarValue()) {
+                return (org.wso2.dpdp.accelerator.event.notifications.endpoint.dto.SubscriptionStatus)
+                        context.handleUnexpectedToken(
+                                org.wso2.dpdp.accelerator.event.notifications.endpoint.dto.SubscriptionStatus.class, parser);
+            }
+            org.wso2.dpdp.accelerator.event.notifications.common.enums.SubscriptionStatus status =
+                    org.wso2.dpdp.accelerator.event.notifications.common.enums.SubscriptionStatus
+                            .fromValue(parser.getValueAsString());
+            return status == null ? null :
+                    org.wso2.dpdp.accelerator.event.notifications.endpoint.dto.SubscriptionStatus
+                            .fromValue(status.getValue());
+        }
+    }
+
+    public static final class Delivery extends JsonDeserializer<DeliveryMode> {
+        @Override
+        public DeliveryMode deserialize(JsonParser parser, DeserializationContext context) throws IOException {
+            if (!parser.currentToken().isScalarValue()) {
+                return (DeliveryMode) context.handleUnexpectedToken(DeliveryMode.class, parser);
+            }
+            String value = parser.getValueAsString();
+            org.wso2.dpdp.accelerator.event.notifications.common.enums.DeliveryMode mode =
+                    org.wso2.dpdp.accelerator.event.notifications.common.enums.DeliveryMode.fromValue(value);
+            return mode == null ? null : DeliveryMode.fromValue(mode.getValue());
+        }
+    }
+
+    public static final class FilterMode extends JsonDeserializer<PurposeFilterMode> {
+        @Override
+        public PurposeFilterMode deserialize(JsonParser parser, DeserializationContext context) throws IOException {
+            if (!parser.currentToken().isScalarValue()) {
+                return (PurposeFilterMode) context.handleUnexpectedToken(PurposeFilterMode.class, parser);
+            }
+            String value = parser.getValueAsString();
+            org.wso2.dpdp.accelerator.event.notifications.common.enums.PurposeFilterMode mode =
+                    org.wso2.dpdp.accelerator.event.notifications.common.enums.PurposeFilterMode.fromValue(value);
+            return mode == null ? null : PurposeFilterMode.fromValue(mode.getValue());
+        }
+    }
+}

--- a/dpdp-accelerator/internal-webapps/org.wso2.dpdp.accelerator.event.notifications.endpoint/src/main/openapi-templates/enumOuterClass.mustache
+++ b/dpdp-accelerator/internal-webapps/org.wso2.dpdp.accelerator.event.notifications.endpoint/src/main/openapi-templates/enumOuterClass.mustache
@@ -1,0 +1,51 @@
+{{#jackson}}
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+{{/jackson}}
+
+/**
+ * {{description}}{{^description}}Gets or Sets {{{name}}}{{/description}}
+ */
+{{#vendorExtensions.x-class-extra-annotation}}
+{{{.}}}
+{{/vendorExtensions.x-class-extra-annotation}}
+{{>additionalEnumTypeAnnotations}}public enum {{{datatypeWithEnum}}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}} {
+  {{#gson}}
+  {{#allowableValues}}{{#enumVars}}
+  @SerializedName({{#isInteger}}"{{/isInteger}}{{#isDouble}}"{{/isDouble}}{{#isLong}}"{{/isLong}}{{#isFloat}}"{{/isFloat}}{{{value}}}{{#isInteger}}"{{/isInteger}}{{#isDouble}}"{{/isDouble}}{{#isLong}}"{{/isLong}}{{#isFloat}}"{{/isFloat}})
+  {{{name}}}({{{value}}}){{^-last}},
+  {{/-last}}{{#-last}};{{/-last}}{{/enumVars}}{{/allowableValues}}
+  {{/gson}}
+  {{^gson}}
+  {{#allowableValues}}{{#enumVars}}
+  {{{name}}}({{{value}}}){{^-last}},
+  {{/-last}}{{#-last}};{{/-last}}{{/enumVars}}{{/allowableValues}}
+  {{/gson}}
+
+  private {{{dataType}}} value;
+
+  {{{datatypeWithEnum}}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}}({{{dataType}}} value) {
+    this.value = value;
+  }
+
+  @Override
+{{#jackson}}
+  @JsonValue
+{{/jackson}}
+  public String toString() {
+    return String.valueOf(value);
+  }
+
+{{#jackson}}
+  @JsonCreator
+{{/jackson}}
+  public static {{{datatypeWithEnum}}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}} fromValue({{{dataType}}} value) {
+    for ({{{datatypeWithEnum}}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}} b : {{{datatypeWithEnum}}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}}.values()) {
+      if (b.value.equals{{#isString}}{{#useEnumCaseInsensitive}}IgnoreCase{{/useEnumCaseInsensitive}}{{/isString}}(value)) {
+        return b;
+      }
+    }
+    {{#isNullable}}return null;{{/isNullable}}{{^isNullable}}throw new IllegalArgumentException("Unexpected value '" + value + "'");{{/isNullable}}
+  }
+
+}

--- a/dpdp-accelerator/internal-webapps/org.wso2.dpdp.accelerator.event.notifications.endpoint/src/main/resources/event-notifications.yaml
+++ b/dpdp-accelerator/internal-webapps/org.wso2.dpdp.accelerator.event.notifications.endpoint/src/main/resources/event-notifications.yaml
@@ -1201,6 +1201,7 @@ components:
   schemas:
     Error:
       type: object
+      x-class-extra-annotation: '@com.fasterxml.jackson.annotation.JsonInclude(com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL)'
       required: [code, message]
       properties:
         code:
@@ -1217,6 +1218,18 @@ components:
       type: object
       required: [name]
       properties:
+        topicId:
+          type: string
+          deprecated: true
+          description: Accepted for compatibility; ignored on creation.
+        status:
+          type: string
+          deprecated: true
+          description: Accepted for compatibility; ignored on creation.
+        initiatedBy:
+          type: string
+          deprecated: true
+          description: Accepted for compatibility; ignored on creation.
         name:
           type: string
           maxLength: 225
@@ -1224,20 +1237,23 @@ components:
           type: string
           maxLength: 255
     Topic:
-      allOf:
-        - $ref: "#/components/schemas/TopicCreateRequest"
-        - type: object
-          required: [topicId, status, initiatedBy]
-          properties:
-            topicId:
-              type: string
-            status:
-              $ref: "#/components/schemas/TopicStatus"
-            initiatedBy:
-              type: string
-              enum: [system, user]
+      type: object
+      required: [name, topicId, status, initiatedBy]
+      properties:
+        name:
+          type: string
+        description:
+          type: string
+        topicId:
+          type: string
+        status:
+          $ref: "#/components/schemas/TopicStatus"
+        initiatedBy:
+          type: string
+          enum: [system, user]
     PurposeFilterMode:
       type: string
+      x-class-extra-annotation: '@com.fasterxml.jackson.databind.annotation.JsonDeserialize(using = org.wso2.dpdp.accelerator.event.notifications.endpoint.util.RequestEnumDeserializers.FilterMode.class)'
       enum: [all, all_except, specific]
     Filter:
       type: object
@@ -1251,6 +1267,7 @@ components:
             type: string
     DeliveryMode:
       type: string
+      x-class-extra-annotation: '@com.fasterxml.jackson.databind.annotation.JsonDeserialize(using = org.wso2.dpdp.accelerator.event.notifications.endpoint.util.RequestEnumDeserializers.Delivery.class)'
       enum: [webhook, poll]
     DeliveryConfigRequest:
       type: object
@@ -1281,11 +1298,44 @@ components:
           description: Always null in service responses.
     SubscriptionStatus:
       type: string
+      x-class-extra-annotation: '@com.fasterxml.jackson.databind.annotation.JsonDeserialize(using = org.wso2.dpdp.accelerator.event.notifications.endpoint.util.RequestEnumDeserializers.Status.class)'
       enum: [active, pending, stale, deleted]
     SubscriptionCreateRequest:
       type: object
       required: [topic, delivery]
       properties:
+        subscriptionId:
+          type: string
+          deprecated: true
+          description: Accepted for compatibility; ignored on creation.
+        orgId:
+          type: string
+          deprecated: true
+          description: Accepted for compatibility; tenant context determines the organization.
+        groupId:
+          type: string
+          deprecated: true
+          description: Accepted for compatibility; the handler derives the group from tenant context.
+        status:
+          $ref: "#/components/schemas/SubscriptionStatus"
+        createdAt:
+          type: integer
+          format: int64
+          deprecated: true
+          description: Accepted for compatibility; ignored on creation.
+        updatedAt:
+          type: integer
+          format: int64
+          deprecated: true
+          description: Accepted for compatibility; ignored on creation.
+        alreadyExists:
+          type: boolean
+          deprecated: true
+          description: Accepted for compatibility; ignored on creation.
+        message:
+          type: string
+          deprecated: true
+          description: Accepted for compatibility; ignored on creation.
         topic:
           type: string
         filter:

--- a/dpdp-accelerator/internal-webapps/org.wso2.dpdp.accelerator.event.notifications.endpoint/src/test/java/org/wso2/dpdp/accelerator/event/notifications/endpoint/api/DeliveryEndpointTest.java
+++ b/dpdp-accelerator/internal-webapps/org.wso2.dpdp.accelerator.event.notifications.endpoint/src/test/java/org/wso2/dpdp/accelerator/event/notifications/endpoint/api/DeliveryEndpointTest.java
@@ -42,9 +42,12 @@ public class DeliveryEndpointTest {
 
     @Test
     public void completeDeliveryDelegatesAndReturnsNoContent() {
-        Response response = endpoint.completeDelivery("delivery-1", "group-1", "sha256=signature", "{}");
+        String body = "{\n  \"completionEvidence\": \"https://example.com/receipt\","
+                + "\n  \"completionStatus\": \"completed\"\n}";
+        Response response = endpoint.completeDelivery("delivery-1", "group-1", "sha256=signature", body);
 
         assertEquals(response.getStatus(), Response.Status.NO_CONTENT.getStatusCode());
-        verify(eventHandler).completeDelivery("org1", "group-1", "delivery-1", "{}", "sha256=signature");
+        org.testng.Assert.assertNull(response.getEntity());
+        verify(eventHandler).completeDelivery("org1", "group-1", "delivery-1", body, "sha256=signature");
     }
 }

--- a/dpdp-accelerator/internal-webapps/org.wso2.dpdp.accelerator.event.notifications.endpoint/src/test/java/org/wso2/dpdp/accelerator/event/notifications/endpoint/api/DtoContractTest.java
+++ b/dpdp-accelerator/internal-webapps/org.wso2.dpdp.accelerator.event.notifications.endpoint/src/test/java/org/wso2/dpdp/accelerator/event/notifications/endpoint/api/DtoContractTest.java
@@ -1,0 +1,186 @@
+/**
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+ * <p>
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.dpdp.accelerator.event.notifications.endpoint.api;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.testng.annotations.Test;
+import org.wso2.dpdp.accelerator.event.notifications.endpoint.dto.EventCreateRequest;
+import org.wso2.dpdp.accelerator.event.notifications.endpoint.dto.Subscription;
+import org.wso2.dpdp.accelerator.event.notifications.endpoint.dto.SubscriptionCreateRequest;
+import org.wso2.dpdp.accelerator.event.notifications.endpoint.dto.SubscriptionStatus;
+import org.wso2.dpdp.accelerator.event.notifications.endpoint.dto.TopicCreateRequest;
+import org.wso2.dpdp.accelerator.event.notifications.endpoint.exception.EventNotificationExceptionMapper;
+import org.wso2.dpdp.accelerator.event.notifications.endpoint.util.EventNotificationDtoMapper;
+import org.wso2.dpdp.accelerator.event.notifications.service.dto.EventCreateDTO;
+import org.wso2.dpdp.accelerator.event.notifications.service.dto.EventDTO;
+import org.wso2.dpdp.accelerator.event.notifications.service.dto.EventPollingResponseDTO;
+import org.wso2.dpdp.accelerator.event.notifications.service.dto.SubscriptionDTO;
+import org.wso2.dpdp.accelerator.event.notifications.service.dto.SubscriptionDeliveryAttemptDTO;
+import org.wso2.dpdp.accelerator.event.notifications.service.dto.SubscriptionDeliveryDTO;
+import org.wso2.dpdp.accelerator.event.notifications.service.dto.SubscriptionEventHistoryDTO;
+import org.wso2.dpdp.accelerator.event.notifications.service.dto.TopicDTO;
+import org.wso2.dpdp.accelerator.event.notifications.service.model.PaginatedResult;
+import java.sql.Timestamp;
+import java.util.Arrays;
+import java.util.Collections;
+import static org.testng.Assert.*;
+
+/** Compares the public JSON with the previous service DTO wire representation. */
+public class DtoContractTest {
+    private final ObjectMapper json = new ObjectMapper();
+
+    private void equivalent(Object service, Object api) {
+        assertEquals((Object) json.valueToTree(api), (Object) json.valueToTree(service));
+    }
+
+    @Test
+    public void eventPayloadAndEpochDatesRemainUnchanged() {
+        EventDTO source = new EventDTO("event", "org", "group", "topic-id", "{\"nested\":true}",
+                Arrays.asList("a", "b"), new Timestamp(1712345678901L), new Timestamp(1712345678902L));
+        source.setTopic("topic");
+        source.setDeliveriesCount(3);
+        equivalent(source, EventNotificationDtoMapper.toApi(source));
+        equivalent(new PaginatedResult<>(Collections.singletonList(source), 9),
+                EventNotificationDtoMapper.events(new PaginatedResult<>(Collections.singletonList(source), 9)));
+        equivalent(new EventDTO(), EventNotificationDtoMapper.toApi(new EventDTO()));
+    }
+
+    @Test
+    public void subscriptionsPreserveNestedFieldsAndSuppressSecrets() throws Exception {
+        String body = "{\"topic\":\"topic\",\"filter\":{\"type\":\" EXCEPT \",\"purposes\":[\"p\"]},"
+                + "\"delivery\":{\"mode\":\" WEBHOOK \",\"callbackUrl\":\"https://receiver.example/callback\","
+                + "\"sharedSecret\":\"secret\"}}";
+        SubscriptionDTO oldRequest = json.readValue(body, SubscriptionDTO.class);
+        SubscriptionDTO mapped = EventNotificationDtoMapper.toService(
+                json.readValue(body, SubscriptionCreateRequest.class));
+        equivalent(oldRequest, mapped);
+        mapped.setSubscriptionId("subscription");
+        mapped.setOrgId("org");
+        mapped.setGroupId("group");
+        mapped.setStatus(org.wso2.dpdp.accelerator.event.notifications.common.enums.SubscriptionStatus.ACTIVE);
+        mapped.setCreatedAt(100L);
+        mapped.setUpdatedAt(200L);
+        mapped.setAlreadyExists(true);
+        mapped.setMessage("existing");
+        Subscription response = EventNotificationDtoMapper.toApi(mapped);
+        assertNull(response.getDelivery().getSharedSecret());
+        mapped.getDelivery().setSharedSecret(null);
+        equivalent(mapped, response);
+        equivalent(new PaginatedResult<>(Collections.singletonList(mapped), 5),
+                EventNotificationDtoMapper.subscriptions(new PaginatedResult<>(Collections.singletonList(mapped), 5)));
+        equivalent(new SubscriptionDTO(), EventNotificationDtoMapper.toApi(new SubscriptionDTO()));
+    }
+
+    @Test
+    public void topicsAndDeliveryHistoryKeepAllFields() {
+        TopicDTO topic = new TopicDTO("t", "topic", "description", "active", "system");
+        equivalent(topic, EventNotificationDtoMapper.toApi(topic));
+        equivalent(new PaginatedResult<>(Collections.singletonList(topic), 7),
+                EventNotificationDtoMapper.topics(new PaginatedResult<>(Collections.singletonList(topic), 7)));
+        equivalent(new TopicDTO(), EventNotificationDtoMapper.toApi(new TopicDTO()));
+        SubscriptionDeliveryDTO delivery = new SubscriptionDeliveryDTO("d", "e", "topic", "DELIVERED",
+                "webhook", 123L);
+        delivery.setSubscriptionId("s");
+        delivery.setGroupId("g");
+        equivalent(delivery, EventNotificationDtoMapper.toApi(delivery));
+        equivalent(new PaginatedResult<>(Collections.singletonList(delivery), 8),
+                EventNotificationDtoMapper.deliveries(new PaginatedResult<>(Collections.singletonList(delivery), 8)));
+        SubscriptionEventHistoryDTO history = new SubscriptionEventHistoryDTO();
+        history.setDeliveryId("d");
+        history.setEventId("e");
+        history.setTopic("topic");
+        history.setDeliveryMode("webhook");
+        history.setCurrentStatus("DELIVERED");
+        history.setOccurredAt(123L);
+        history.setNextRetryAt(234L);
+        history.setCompletionStatus("completed");
+        history.setCompletionEvidence("https://receiver.example/evidence");
+        history.setHistory(Arrays.asList(new SubscriptionDeliveryAttemptDTO(1, "FAILED", 123L, 503, "unavailable"),
+                new SubscriptionDeliveryAttemptDTO(2, "DELIVERED", 234L, 200, null)));
+        equivalent(history, EventNotificationDtoMapper.toApi(history));
+        equivalent(new SubscriptionEventHistoryDTO(), EventNotificationDtoMapper.toApi(new SubscriptionEventHistoryDTO()));
+        equivalent(new EventPollingResponseDTO(false, Collections.emptyMap()),
+                EventNotificationDtoMapper.toApi(new EventPollingResponseDTO(false, Collections.emptyMap())));
+    }
+
+    @Test
+    public void missingFieldsAndNullRequestsReachServiceValidation() throws Exception {
+        assertNull(EventNotificationDtoMapper.toService((EventCreateRequest) null));
+        assertNull(EventNotificationDtoMapper.toService((TopicCreateRequest) null));
+        assertNull(EventNotificationDtoMapper.toService((SubscriptionCreateRequest) null));
+        equivalent(json.readValue("{}", EventCreateDTO.class),
+                EventNotificationDtoMapper.toService(json.readValue("{}", EventCreateRequest.class)));
+        equivalent(json.readValue("{}", TopicDTO.class),
+                EventNotificationDtoMapper.toService(json.readValue("{}", TopicCreateRequest.class)));
+        equivalent(json.readValue("{}", SubscriptionDTO.class),
+                EventNotificationDtoMapper.toService(json.readValue("{}", SubscriptionCreateRequest.class)));
+        String body = "{\"name\":\"topic\",\"description\":\"description\"}";
+        equivalent(json.readValue(body, TopicDTO.class),
+                EventNotificationDtoMapper.toService(json.readValue(body, TopicCreateRequest.class)));
+        String event = "{\"topic\":\"t\",\"payload\":{\"nested\":[1,true,{\"value\":\"x\"}]}}";
+        equivalent(json.readValue(event, EventCreateDTO.class),
+                EventNotificationDtoMapper.toService(json.readValue(event, EventCreateRequest.class)));
+    }
+
+    @Test
+    public void legacyMetadataAndEnumAliasesStillParse() throws Exception {
+        String topic = "{\"name\":\"t\",\"topicId\":\"ignored\",\"status\":\"ignored\",\"initiatedBy\":\"ignored\"}";
+        equivalent(json.readValue(topic, TopicDTO.class),
+                EventNotificationDtoMapper.toService(json.readValue(topic, TopicCreateRequest.class)));
+        String subscription = "{\"topic\":\"t\",\"subscriptionId\":\"ignored\",\"orgId\":\"ignored\","
+                + "\"groupId\":\"ignored\",\"status\":\" ACTIVE \",\"createdAt\":1,\"updatedAt\":2,"
+                + "\"alreadyExists\":true,\"message\":\"ignored\"}";
+        equivalent(json.readValue(subscription, SubscriptionDTO.class),
+                EventNotificationDtoMapper.toService(json.readValue(subscription, SubscriptionCreateRequest.class)));
+        for (String mode : Arrays.asList("poll", " POLL ", "", " ")) {
+            String body = "{\"delivery\":{\"mode\":\"" + mode + "\"},\"filter\":{\"type\":\" \"}}";
+            equivalent(json.readValue(body, SubscriptionDTO.class),
+                    EventNotificationDtoMapper.toService(json.readValue(body, SubscriptionCreateRequest.class)));
+        }
+    }
+
+    @Test
+    public void malformedRequestsKeepErrorCodes() throws Exception {
+        for (String body : Arrays.asList("{\"unknown\":1}", "{\"delivery\":{\"mode\":\"invalid\"}}",
+                "{\"filter\":{\"type\":\"invalid\"}}", "{\"status\":\"invalid\"}",
+                "{\"delivery\":{\"mode\":[]}}", "{\"filter\":{\"type\":{}}}",
+                "{\"delivery\":{\"mode\":42}}", "{\"filter\":{\"type\":true}}")) {
+            JsonNode previous = error(body, SubscriptionDTO.class);
+            JsonNode current = error(body, SubscriptionCreateRequest.class);
+            assertEquals(current.get("code").asText(), previous.get("code").asText());
+            assertEquals(current.get("message").asText(), previous.get("message").asText());
+        }
+        Object entity = new EventNotificationExceptionMapper().toResponse(
+                new javax.ws.rs.WebApplicationException(404)).getEntity();
+        assertFalse(json.valueToTree(entity).has("description"));
+    }
+
+    private JsonNode error(String body, Class<?> type) throws Exception {
+        try {
+            json.readValue(body, type);
+            fail("Expected malformed JSON for " + type);
+        } catch (com.fasterxml.jackson.core.JsonProcessingException e) {
+            javax.ws.rs.core.Response response = new EventNotificationExceptionMapper().toResponse(e);
+            assertEquals(response.getStatus(), 400);
+            return json.valueToTree(response.getEntity());
+        }
+        throw new AssertionError();
+    }
+}

--- a/dpdp-accelerator/internal-webapps/org.wso2.dpdp.accelerator.event.notifications.endpoint/src/test/java/org/wso2/dpdp/accelerator/event/notifications/endpoint/api/EventEndpointTest.java
+++ b/dpdp-accelerator/internal-webapps/org.wso2.dpdp.accelerator.event.notifications.endpoint/src/test/java/org/wso2/dpdp/accelerator/event/notifications/endpoint/api/EventEndpointTest.java
@@ -24,7 +24,7 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 import org.wso2.dpdp.accelerator.event.notifications.endpoint.constants.EventNotificationEndpointConstants;
 import org.wso2.dpdp.accelerator.event.notifications.endpoint.handler.EventHandler;
-import org.wso2.dpdp.accelerator.event.notifications.service.dto.EventCreateDTO;
+import org.wso2.dpdp.accelerator.event.notifications.endpoint.dto.EventCreateRequest;
 import org.wso2.dpdp.accelerator.event.notifications.service.dto.EventDTO;
 import org.wso2.dpdp.accelerator.event.notifications.service.dto.EventPollingResponseDTO;
 import org.wso2.dpdp.accelerator.event.notifications.service.dto.SubscriptionDeliveryDTO;
@@ -71,8 +71,7 @@ public class EventEndpointTest {
 
     @Test
     public void publishEvent_returns201WithDtoBody() {
-        EventCreateDTO request = new EventCreateDTO("topic-a", Arrays.asList("marketing"),
-                new HashMap<>());
+        EventCreateRequest request = new EventCreateRequest().topic("topic-a").purposes(Arrays.asList("marketing")).payload(new HashMap<>());
         EventDTO published = new EventDTO("evt-1", "org1", "g1", "topic-id-1", "{}",
                 Arrays.asList("marketing"), null, null);
         when(eventHandler.publishEvent(eq("org1"), eq("g1"), any())).thenReturn(published);
@@ -80,13 +79,15 @@ public class EventEndpointTest {
         Response response = eventEndpoint.publishEvent("g1", request);
 
         assertEquals(response.getStatus(), Response.Status.CREATED.getStatusCode());
-        assertEquals(response.getEntity(), published);
-        verify(eventHandler, times(1)).publishEvent("org1", "g1", request);
+        assertJsonEquals(response.getEntity(), published);
+        verify(eventHandler, times(1)).publishEvent(eq("org1"), eq("g1"), org.mockito.ArgumentMatchers.argThat(value ->
+                value.getTopic().equals(request.getTopic()) && value.getPurposes().equals(request.getPurposes())
+                        && value.getPayload().equals(request.getPayload())));
     }
 
     @Test
     public void publishEvent_propagatesHandlerException() {
-        EventCreateDTO request = new EventCreateDTO("topic-a", null, null);
+        EventCreateRequest request = new EventCreateRequest().topic("topic-a");
         when(eventHandler.publishEvent(any(), any(), any()))
                 .thenThrow(new RuntimeException("boom"));
 
@@ -100,7 +101,7 @@ public class EventEndpointTest {
 
     @Test
     public void pollEvents_returns200WithPollingResponse() {
-        String request = "{\"maxEvents\":10,\"returnImmediately\":true}";
+        String request = "{\n  \"returnImmediately\": true, \"maxEvents\": 10\n}";
         EventPollingResponseDTO pollingResponse = new EventPollingResponseDTO(false, Collections.emptyMap());
         when(eventHandler.pollEvents("org1", "g1", "subscription-1", request, "sha256=test"))
                 .thenReturn(pollingResponse);
@@ -108,7 +109,7 @@ public class EventEndpointTest {
         Response response = eventEndpoint.pollEvents("subscription-1", "g1", "sha256=test", request);
 
         assertEquals(response.getStatus(), Response.Status.OK.getStatusCode());
-        assertEquals(response.getEntity(), pollingResponse);
+        assertJsonEquals(response.getEntity(), pollingResponse);
         verify(eventHandler, times(1)).pollEvents("org1", "g1", "subscription-1", request, "sha256=test");
     }
 
@@ -136,7 +137,7 @@ public class EventEndpointTest {
         Response response = eventEndpoint.listEvents("topic-1", "DELIVERED", "sub-1", "marketing", "search", 10, 0);
 
         assertEquals(response.getStatus(), Response.Status.OK.getStatusCode());
-        assertEquals(response.getEntity(), page);
+        assertJsonEquals(response.getEntity(), page);
         verify(eventHandler, times(1)).searchEvents("org1", "topic-1", "DELIVERED", "org1", "sub-1", "marketing", "search", 10, 0);
     }
 
@@ -163,7 +164,7 @@ public class EventEndpointTest {
         Response response = eventEndpoint.getDeliveryHistory("dlv-1");
 
         assertEquals(response.getStatus(), Response.Status.OK.getStatusCode());
-        assertEquals(response.getEntity(), dto);
+        assertJsonEquals(response.getEntity(), dto);
         verify(eventHandler, times(1)).getDeliveryHistory("org1", "dlv-1");
     }
 
@@ -175,7 +176,7 @@ public class EventEndpointTest {
         Response response = eventEndpoint.getEvent("evt-1");
 
         assertEquals(response.getStatus(), Response.Status.OK.getStatusCode());
-        assertEquals(response.getEntity(), dto);
+        assertJsonEquals(response.getEntity(), dto);
         verify(eventHandler, times(1)).getEventById("org1", "evt-1");
     }
 
@@ -190,7 +191,12 @@ public class EventEndpointTest {
         Response response = eventEndpoint.getEventDeliveries("evt-1", 20, 0);
 
         assertEquals(response.getStatus(), Response.Status.OK.getStatusCode());
-        assertEquals(response.getEntity(), page);
+        assertJsonEquals(response.getEntity(), page);
         verify(eventHandler, times(1)).getEventDeliveries("org1", "evt-1", 20, 0);
+    }
+    private static void assertJsonEquals(Object actual, Object expected) {
+        com.fasterxml.jackson.databind.ObjectMapper json = new com.fasterxml.jackson.databind.ObjectMapper();
+        assertEquals((Object) json.valueToTree(actual), (Object) json.valueToTree(expected));
+        org.testng.Assert.assertTrue(actual.getClass().getPackage().getName().endsWith(".endpoint.dto"));
     }
 }

--- a/dpdp-accelerator/internal-webapps/org.wso2.dpdp.accelerator.event.notifications.endpoint/src/test/java/org/wso2/dpdp/accelerator/event/notifications/endpoint/api/TopicAndSubscriptionEndpointTest.java
+++ b/dpdp-accelerator/internal-webapps/org.wso2.dpdp.accelerator.event.notifications.endpoint/src/test/java/org/wso2/dpdp/accelerator/event/notifications/endpoint/api/TopicAndSubscriptionEndpointTest.java
@@ -42,8 +42,8 @@ public class TopicAndSubscriptionEndpointTest {
         when(topicHandler.listTopics("org-1", "active", "search", 20, 0, "name")).thenReturn(page);
         when(topicHandler.deleteTopic("org-1", "topic-1")).thenReturn(topic);
 
-        assertEquals(topicEndpoint.createTopic(topic).getStatus(), 201);
-        assertEquals(topicEndpoint.listTopics("active", "search", 20, 0, "name").getEntity(), page);
+        assertEquals(topicEndpoint.createTopic(new org.wso2.dpdp.accelerator.event.notifications.endpoint.dto.TopicCreateRequest().name(topic.getName())).getStatus(), 201);
+        assertJsonEquals(topicEndpoint.listTopics("active", "search", 20, 0, "name").getEntity(), page);
         assertEquals(topicEndpoint.deleteTopic("topic-1").getStatus(), 200);
         verify(topicHandler).deleteTopic("org-1", "topic-1");
     }
@@ -61,11 +61,16 @@ public class TopicAndSubscriptionEndpointTest {
         when(subscriptionHandler.retryVerification("org-1", "sub-1")).thenReturn(subscription);
         when(subscriptionHandler.getSubscriptionEventHistory("org-1", "sub-1", "delivery-1")).thenReturn(history);
 
-        assertEquals(subscriptionEndpoint.createSubscription(subscription).getStatus(), 201);
-        assertEquals(subscriptionEndpoint.listSubscriptions("active", "marketing", "search", 20, 0, "createdAt").getEntity(), page);
-        assertEquals(subscriptionEndpoint.getSubscription("sub-1").getEntity(), subscription);
-        assertEquals(subscriptionEndpoint.deleteSubscription("sub-1").getEntity(), subscription);
-        assertEquals(subscriptionEndpoint.retryVerification("sub-1").getEntity(), subscription);
-        assertEquals(subscriptionEndpoint.getSubscriptionEventHistory("sub-1", "delivery-1").getEntity(), history);
+        assertEquals(subscriptionEndpoint.createSubscription(new org.wso2.dpdp.accelerator.event.notifications.endpoint.dto.SubscriptionCreateRequest().topic(subscription.getTopic())).getStatus(), 201);
+        assertJsonEquals(subscriptionEndpoint.listSubscriptions("active", "marketing", "search", 20, 0, "createdAt").getEntity(), page);
+        assertJsonEquals(subscriptionEndpoint.getSubscription("sub-1").getEntity(), subscription);
+        assertJsonEquals(subscriptionEndpoint.deleteSubscription("sub-1").getEntity(), subscription);
+        assertJsonEquals(subscriptionEndpoint.retryVerification("sub-1").getEntity(), subscription);
+        assertJsonEquals(subscriptionEndpoint.getSubscriptionEventHistory("sub-1", "delivery-1").getEntity(), history);
+    }
+    private static void assertJsonEquals(Object actual, Object expected) {
+        com.fasterxml.jackson.databind.ObjectMapper json = new com.fasterxml.jackson.databind.ObjectMapper();
+        assertEquals((Object) json.valueToTree(actual), (Object) json.valueToTree(expected));
+        org.testng.Assert.assertTrue(actual.getClass().getPackage().getName().endsWith(".endpoint.dto"));
     }
 }

--- a/dpdp-accelerator/internal-webapps/org.wso2.dpdp.accelerator.event.notifications.endpoint/src/test/java/org/wso2/dpdp/accelerator/event/notifications/endpoint/exception/EventNotificationExceptionMapperTest.java
+++ b/dpdp-accelerator/internal-webapps/org.wso2.dpdp.accelerator.event.notifications.endpoint/src/test/java/org/wso2/dpdp/accelerator/event/notifications/endpoint/exception/EventNotificationExceptionMapperTest.java
@@ -55,7 +55,7 @@ public class EventNotificationExceptionMapperTest {
         assertEquals(response.getMediaType(), MediaType.APPLICATION_JSON_TYPE);
 
         @SuppressWarnings("unchecked")
-        Map<String, Object> entity = (Map<String, Object>) response.getEntity();
+        Map<String, Object> entity = new com.fasterxml.jackson.databind.ObjectMapper().convertValue(response.getEntity(), Map.class);
         assertNotNull(entity);
         assertEquals(entity.get("code"), "EN-4040");
         assertEquals(entity.get("message"), "Resource not found");
@@ -69,7 +69,7 @@ public class EventNotificationExceptionMapperTest {
 
         assertNotNull(response);
         assertEquals(response.getStatus(), 409);
-        assertTrue(response.getEntity() instanceof Map);
+        assertTrue(response.getEntity() instanceof org.wso2.dpdp.accelerator.event.notifications.endpoint.dto.Error);
     }
 
     @Test


### PR DESCRIPTION
## Purpose

  Resolves a layering issue in the Event Notification REST module: public request and response models were service DTOs, so the external API contract was coupled directly to the service layer.

  ## Goals

  - Make event-notifications.yaml the source of truth for the public REST contract.
  - Generate endpoint-local API DTOs under endpoint.dto.
  - Keep service DTOs, handlers, business logic, DAO models, and persistence unchanged.
  - Map between generated API models and service DTOs only at the JAX-RS boundary.
  - Preserve existing JSON behavior, error responses, enum parsing, timestamp representation, secret suppression, and HMAC-signed raw request bodies.

  ## Approach

  The endpoint module now uses OpenAPI Generator (jaxrs-cxf, model-only generation) to generate 28 API models into src/gen/java. Generated sources are committed and compiled as
  endpoint-local models.

  EventNotificationDtoMapper converts:

  - Generated topic, subscription, and event create requests into service DTOs.
  - Service DTOs and paginated results into generated API response models.
  - Delivery history, attempts, polling responses, timestamps, and payload fields while preserving the prior wire representation.

  TopicEndpoint, SubscriptionEndpoint, and EventEndpoint now map requests before calling handlers and map service results before returning HTTP responses.

  Polling and delivery-completion requests continue to use their original raw request bodies. This preserves exact request bytes required for HMAC signature verification.

  Custom generated-enum deserializers preserve the existing case-insensitive, whitespace-tolerant parsing and aliases. The exception mapper now returns the generated Error API model.

  Legacy request metadata remains accepted for compatibility where existing handlers already ignore or derive those values from tenant context. Subscription response delivery
  settings continue to omit the shared secret.

  ## User Stories

  N/A — internal REST-boundary refactor. Existing API behavior and service contracts are preserved.

  ## Release Note

  Internal Event Notification REST API refactor:

  - Public DTOs are generated from the OpenAPI contract and owned by the endpoint module.
  - Service DTOs remain internal to the service layer.
  - No intended API behavior or wire-format changes.

  ## Documentation

  Added endpoint-module documentation covering:

  - OpenAPI regeneration.
  - Generated-source ownership.
  - Runtime mapper responsibilities.
  - Compatibility guarantees.
  - Packaged-WAR verification expectations.

  ## Training

  N/A.

  ## Certification

  N/A 

  ## Marketing

  N/A.

  ## Automation Tests

  Updated and added endpoint tests covering:

  - Request and response JSON compatibility.
  - Nested delivery history and pagination.
  - Epoch-millisecond timestamps and payload strings.
  - Shared-secret suppression.
  - Legacy request metadata.
  - Enum aliases and malformed requests.
  - Error response shape and codes.
  - Exact signed-body forwarding for polling and completion.

  Validation completed:

  - Endpoint Maven verification: 40 tests, 0 failures.
  - OpenAPI regeneration produced identical sources for 28 generated models.
  - Packaged WAR inspection confirmed generated DTOs, mapper, and deserializer classes.
  - git diff --check passed.
  - Live Identity Server deployment testing was not run.

  ## Security Checks

  - Shared secrets remain excluded from subscription response models and are covered by compatibility tests.
  - Polling and completion signatures continue to be verified against the original request body.
  - FindSecurityBugs and a formal secure-engineering review were not run.

This Fixes #39 